### PR TITLE
feat(compliance): widen KYC_ADAPTER seam for hosted-session vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Planned work and progress live on the public board: **[openora roadmap](https://
 - Glossary (operator vs player, KYC, RTP, provably fair, rollover...): [docs/glossary.md](./docs/glossary.md)
 - Pillars & decision tree: [AGENTS.md](./AGENTS.md)
 - ADRs: [docs/adr/](./docs/adr/)
+- Adapter binding guides (KYC, payment, ...): [docs/adapters/](./docs/adapters/)
 
 ## Contributing
 

--- a/docs/adapters/kyc.md
+++ b/docs/adapters/kyc.md
@@ -3,57 +3,109 @@
 ## Interface
 
 ```ts
-// packages/core/src/contracts/adapters/src/kyc.ts
-export interface KycAdapter {
+// packages/core/src/contracts/adapters/kyc.ts
+export type KycAdapter = {
+  // True when the adapter rubber-stamps every submission (the default MockKycAdapter).
+  // A boot guard refuses/warns if withdrawals are KYC-gated while this is bound, so an
+  // operator can't enable the gate yet leave verification a no-op. Real providers omit it.
+  readonly autoApproves?: boolean;
   submit(userId: string, documents: KycDocument[]): Promise<KycResult>;
   getStatus(userId: string): Promise<KycVendorStatus>;
-}
+  // Provider-specific normalization of a raw webhook into a vendor decision, or null when
+  // the body is not a reconcilable decision. Optional - MockKycAdapter omits it.
+  parseWebhook?(
+    rawBody: string,
+    headers: Record<string, string | string[] | undefined>,
+  ): KycResult | null;
+};
 
-export interface KycDocument {
+export type KycDocument = {
   type: 'passport' | 'drivers_license' | 'national_id';
   frontUrl: string;
   backUrl?: string;
-}
+};
 
 export type KycVendorStatus = 'pending' | 'approved' | 'rejected' | 'not_started';
 
-export interface KycResult {
+export type KycResult = {
   referenceId: string;
   status: KycVendorStatus;
-}
+  // Hosted verification URL to redirect the end user to, for vendors whose flow collects
+  // documents on their own hosted page rather than accepting them from our backend.
+  // Omitted by document-forwarding vendors (eg SumSub, MockKycAdapter).
+  verificationUrl?: string;
+};
 
-export const KYC_ADAPTER = Symbol('KYC_ADAPTER');
+export const KYC_ADAPTER: Token<KycAdapter> = createToken('KYC_ADAPTER');
 ```
+
+`KYC_ADAPTER` is a `Token<T>` created via `createToken` (`packages/core/src/contracts/adapters/token.ts`),
+not a bare `Symbol` - the `Container` uses it to type both `provide` and `get` calls.
+
+## Webhook verifier
+
+A second port authenticates the vendor's async webhook before `KycAdapter.parseWebhook`
+ever sees the body:
+
+```ts
+export type KycWebhookVerifier = {
+  verify(rawBody: string, headers: Record<string, string | string[] | undefined>): boolean;
+};
+
+export const KYC_WEBHOOK_VERIFIER: Token<KycWebhookVerifier> = createToken('KYC_WEBHOOK_VERIFIER');
+```
+
+`verify` takes the full headers map, not a single pre-extracted value - the signing header
+name is vendor-specific (SumSub, a hosted-session vendor, and any future provider each name
+it differently), so each implementation extracts whatever header(s) it actually needs.
+
+The default binding is `HmacKycWebhookVerifier` (`compliance/adapters/hmac-kyc-webhook-verifier.ts`):
+recomputes an HMAC-SHA256 of the raw request body keyed by a configured secret and
+constant-time compares it against the `x-kyc-signature` header (case-insensitive lookup;
+a leading `sha256=` prefix is tolerated). Fails closed when the secret is unset, the
+signature is absent, or the raw body was not captured. A vendor overlay rebinds
+`KYC_WEBHOOK_VERIFIER` alongside `KYC_ADAPTER` when the vendor signs differently.
+
+The router (`compliance/router/index.ts`, `kycWebhook` handler) verifies against the
+captured `context.rawBody` before calling `kycAdapter.parseWebhook`, and reconciles via
+`KycVerificationService.reconcile` on a decision. Never trust an unverified webhook body.
 
 ## Default binding
 
-The `identity` module ships `MockKycAdapter` (auto-approves all submissions). It is bound
-at boot via `identity/src/plugin.ts`. This is intentionally permissive for local dev.
+The `identity` module ships `MockKycAdapter` (auto-approves all submissions, `autoApproves: true`).
+It is bound at boot via `pam/identity/plugin.ts`. This is intentionally permissive for local dev.
 
-## Real provider: SumSub
+## Binding recipe 1: document-forwarding vendor (eg SumSub)
 
-The intended production provider is [SumSub](https://sumsub.com). To wire it:
+Your backend forwards documents to the vendor and the vendor decides synchronously or via
+webhook. `submit()` returns no `verificationUrl` - nothing for the consumer to redirect to.
 
-1. Create an overlay plugin (or extend an existing one):
+1. Create an overlay plugin:
 
 ```bash
-/scaffold-plugin sumsub-kyc
+pnpm gen plugin sumsub-kyc
 ```
 
-2. Implement `KycAdapter` against the SumSub REST API:
+2. Implement `KycAdapter` against the vendor's REST API:
 
 ```ts
-// apps/api/src/extensions/sumsub-kyc/src/sumsub-kyc-adapter.ts
+// extensions/sumsub-kyc/src/sumsub-kyc-adapter.ts
 import type { KycAdapter, KycDocument, KycResult, KycVendorStatus } from '@openora/core/contracts';
 
 export class SumsubKycAdapter implements KycAdapter {
   async submit(userId: string, documents: KycDocument[]): Promise<KycResult> {
-    // POST to SumSub applicant API
-    // https://developers.sumsub.com/api-reference/#creating-an-applicant
+    // POST to the vendor's applicant API; no verificationUrl - documents were forwarded directly.
   }
 
   async getStatus(userId: string): Promise<KycVendorStatus> {
-    // GET applicant review status from SumSub
+    // GET applicant review status from the vendor.
+  }
+
+  parseWebhook(
+    rawBody: string,
+    headers: Record<string, string | string[] | undefined>,
+  ): KycResult | null {
+    // normalize the vendor's webhook payload into { referenceId, status }
   }
 }
 ```
@@ -61,7 +113,7 @@ export class SumsubKycAdapter implements KycAdapter {
 3. Bind it in the plugin, AFTER `identity` in `extensions.config.ts` (last registration wins):
 
 ```ts
-// apps/api/src/extensions/sumsub-kyc/plugin.ts
+// extensions/sumsub-kyc/plugin.ts
 import { KYC_ADAPTER } from '@openora/core/contracts';
 import { definePlugin } from '@openora/core/server';
 import { SumsubKycAdapter } from './src/sumsub-kyc-adapter.js';
@@ -77,8 +129,76 @@ export default definePlugin({
 
 4. Register in `extensions.config.ts` **after** the `identity` entry.
 
-## Webhook considerations
+## Binding recipe 2: hosted-session vendor (eg Didit or similar)
 
-SumSub sends async review results via webhook. Handle them in a separate HTTP endpoint
-(add a route to the overlay's router) and update the player's KYC status via the
-`identity` module's service or a dedicated `kyc_status` table in the overlay's schema.
+Your backend calls the vendor to create a verification session; the vendor returns a
+hosted URL, and the vendor's own page collects and reviews documents - not your backend.
+`submit()` returns `verificationUrl`; the consumer's `submitKyc` response carries it
+through so the frontend can redirect the player. The vendor reconciles the outcome later
+via webhook, using its own signing header.
+
+1. Create an overlay plugin:
+
+```bash
+pnpm gen plugin hosted-kyc
+```
+
+2. Implement `KycAdapter.submit` to create a session and return the hosted URL, and
+   `parseWebhook` to normalize the vendor's async decision:
+
+```ts
+// extensions/hosted-kyc/src/hosted-kyc-adapter.ts
+import type { KycAdapter, KycDocument, KycResult, KycVendorStatus } from '@openora/core/contracts';
+
+export class HostedKycAdapter implements KycAdapter {
+  async submit(userId: string, _documents: KycDocument[]): Promise<KycResult> {
+    // POST to the vendor's "create session" API; the vendor collects documents itself.
+    // return { referenceId: session.id, status: 'pending', verificationUrl: session.url };
+  }
+
+  async getStatus(userId: string): Promise<KycVendorStatus> {
+    // GET the session's current decision from the vendor.
+  }
+
+  parseWebhook(
+    rawBody: string,
+    headers: Record<string, string | string[] | undefined>,
+  ): KycResult | null {
+    // normalize the vendor's webhook payload into { referenceId, status }
+  }
+}
+```
+
+3. Implement `KycWebhookVerifier` if the vendor's signing header differs from
+   `x-kyc-signature`, and rebind both tokens together:
+
+```ts
+// extensions/hosted-kyc/plugin.ts
+import { KYC_ADAPTER, KYC_WEBHOOK_VERIFIER } from '@openora/core/contracts';
+import { definePlugin } from '@openora/core/server';
+import { HostedKycAdapter } from './src/hosted-kyc-adapter.js';
+import { HostedKycWebhookVerifier } from './src/hosted-kyc-webhook-verifier.js';
+
+export default definePlugin({
+  id: 'hosted-kyc',
+  dependsOn: ['identity'],
+  register(ctx) {
+    ctx.provide(KYC_ADAPTER, () => new HostedKycAdapter());
+    ctx.provide(
+      KYC_WEBHOOK_VERIFIER,
+      () => new HostedKycWebhookVerifier(process.env.HOSTED_KYC_WEBHOOK_SECRET),
+    );
+  },
+});
+```
+
+4. Register in `extensions.config.ts` **after** the `identity` entry. The consumer's
+   frontend calls `submitKyc`, reads `verificationUrl` off the response, and redirects the
+   player there; the vendor's webhook later reconciles the final status via
+   `POST /compliance/kyc/webhook`.
+
+## Webhook route
+
+`POST /compliance/kyc/webhook` is unauthenticated (M2M, no admin session) and relies
+entirely on `KYC_WEBHOOK_VERIFIER` to reject forged calls. It always verifies against the
+verbatim captured request bytes (`context.rawBody`) - never a re-serialized body.

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1060,6 +1060,10 @@
       "file": "packages/core/src/compliance/contract/index.ts"
     },
     {
+      "name": "SubmitKycOutputSchema",
+      "file": "packages/core/src/compliance/contract/index.ts"
+    },
+    {
       "name": "TagKeySchema",
       "file": "packages/core/src/contracts/schemas/tag.ts"
     },

--- a/packages/core/src/compliance/AGENTS.md
+++ b/packages/core/src/compliance/AGENTS.md
@@ -3,6 +3,40 @@
 Regulatory surface: player limits, KYC verification, geo rules, and Responsible
 Gambling (RG). Headless - the back-office UI lives in the consumer.
 
+## KYC
+
+Player identity verification: submission, vendor/webhook reconciliation, and
+deposit-threshold re-KYC. Vendor-agnostic - real providers (SumSub-style
+document-forwarding, hosted-session vendors) bind against the adapter ports in
+`docs/adapters/kyc.md`; this repo ships only `MockKycAdapter` (auto-approves).
+
+### Layout (KYC pieces)
+
+| Layer    | File                        | Holds                                                                                                                                                                                |
+| -------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| schema   | `schema/index.ts`           | `kyc_verification` table (append-only history: `referenceId`, `status`, `documentTypes`, `triggeredBy`, `decidedAt`).                                                                |
+| contract | `contract/index.ts`         | `getPlayerKyc`, `submitKyc`, `kycWebhook` routes + `KycVerificationSchema`/`SubmitKycOutputSchema` (extends the record with an optional `verificationUrl`).                          |
+| service  | `service/kyc.service.ts`    | `KycVerificationService`: `submit` (calls `KYC_ADAPTER`, inserts a record), `reconcile` (idempotent vendor-decision apply), `getForPlayer`, `handleDeposit` (threshold re-KYC hook). |
+| service  | `service/re-kyc-trigger.ts` | `ReKycTrigger` interface + `CumulativeDepositReKycTrigger` (pure, DB-free threshold-band logic).                                                                                     |
+| router   | `router/index.ts`           | `submitKyc` (player-scoped), `getPlayerKyc` (admin-guarded), `kycWebhook` (unauthenticated M2M, verified via `KYC_WEBHOOK_VERIFIER`).                                                |
+
+### oRPC routes
+
+| Procedure                 | Method | Path                               | Guard                        |
+| ------------------------- | ------ | ---------------------------------- | ---------------------------- |
+| `compliance.submitKyc`    | POST   | `/compliance/kyc`                  | authenticated player         |
+| `compliance.getPlayerKyc` | GET    | `/compliance/players/{userId}/kyc` | `compliance:view`            |
+| `compliance.kycWebhook`   | POST   | `/compliance/kyc/webhook`          | `KYC_WEBHOOK_VERIFIER` (M2M) |
+
+### Adapter ports
+
+`KYC_ADAPTER`, `KYC_STATUS_WRITER`, `KYC_WEBHOOK_VERIFIER` (all in
+`packages/core/src/contracts/adapters/kyc.ts`). `KYC_STATUS_WRITER` is the single writer
+for `player.kycStatus` - pam owns it and binds the only implementation; every status
+change (submit, webhook reconcile, threshold re-KYC, admin override) routes through it so
+the `compliance.kyc.updated` audit emit never gets skipped. Compliance calls the port,
+never writes `player` directly.
+
 ## Responsible Gambling (RG)
 
 A write surface (limits, cooling-off, self-exclusion, lift) plus a read/monitoring surface

--- a/packages/core/src/compliance/__tests__/hmac-kyc-webhook-verifier.test.ts
+++ b/packages/core/src/compliance/__tests__/hmac-kyc-webhook-verifier.test.ts
@@ -12,13 +12,22 @@ function sign(body: string, secret = SECRET) {
 describe('HmacKycWebhookVerifier (fail closed)', () => {
   it('accepts a correct signature (with and without sha256= prefix)', () => {
     const v = new HmacKycWebhookVerifier(SECRET);
-    expect(v.verify(BODY, sign(BODY))).toBe(true);
-    expect(v.verify(BODY, `sha256=${sign(BODY)}`)).toBe(true);
+    expect(v.verify(BODY, { 'x-kyc-signature': sign(BODY) })).toBe(true);
+    expect(v.verify(BODY, { 'x-kyc-signature': `sha256=${sign(BODY)}` })).toBe(true);
+  });
+
+  it('extracts the signature header case-insensitively', () => {
+    const v = new HmacKycWebhookVerifier(SECRET);
+    expect(v.verify(BODY, { 'X-Kyc-Signature': sign(BODY) })).toBe(true);
   });
 
   it('rejects a wrong signature, a missing signature, and an unset secret', () => {
-    expect(new HmacKycWebhookVerifier(SECRET).verify(BODY, sign('tampered'))).toBe(false);
-    expect(new HmacKycWebhookVerifier(SECRET).verify(BODY, null)).toBe(false);
-    expect(new HmacKycWebhookVerifier(undefined).verify(BODY, sign(BODY))).toBe(false);
+    expect(
+      new HmacKycWebhookVerifier(SECRET).verify(BODY, { 'x-kyc-signature': sign('tampered') }),
+    ).toBe(false);
+    expect(new HmacKycWebhookVerifier(SECRET).verify(BODY, {})).toBe(false);
+    expect(
+      new HmacKycWebhookVerifier(undefined).verify(BODY, { 'x-kyc-signature': sign(BODY) }),
+    ).toBe(false);
   });
 });

--- a/packages/core/src/compliance/__tests__/kyc.service.test.ts
+++ b/packages/core/src/compliance/__tests__/kyc.service.test.ts
@@ -101,6 +101,31 @@ describe('KycVerificationService.submit', () => {
     );
     expect(dto.status).toBe('verified');
   });
+
+  it('passes verificationUrl through from a hosted-session adapter result', async () => {
+    const adapter = {
+      submit: vi.fn().mockResolvedValue({
+        referenceId: 'ref-1',
+        status: 'pending',
+        verificationUrl: 'https://vendor.example/session/abc',
+      }),
+      getStatus: vi.fn().mockResolvedValue('pending'),
+    };
+    const svc = newSvc({
+      db: makeDb([], [fullRow({ status: 'pending' })]),
+      adapter,
+    });
+    const dto = await svc.submit('user-1', { documents: [{ type: 'passport', frontUrl: 'u' }] });
+    expect(dto.verificationUrl).toBe('https://vendor.example/session/abc');
+  });
+
+  it('omits verificationUrl when the adapter does not return one', async () => {
+    const svc = newSvc({
+      db: makeDb([], [fullRow({ status: 'verified', decidedAt: new Date() })]),
+    });
+    const dto = await svc.submit('user-1', { documents: [{ type: 'passport', frontUrl: 'u' }] });
+    expect(dto.verificationUrl).toBeUndefined();
+  });
 });
 
 describe('KycVerificationService.reconcile', () => {

--- a/packages/core/src/compliance/adapters/hmac-kyc-webhook-verifier.ts
+++ b/packages/core/src/compliance/adapters/hmac-kyc-webhook-verifier.ts
@@ -1,15 +1,11 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { KycWebhookVerifier } from '@openora/core/contracts';
 
-/**
- * Case-insensitive lookup - the runtime normally lowercases header names (Fetch `Headers`),
- * but a caller passing raw framework headers may not.
- */
 function findHeader(
   headers: Record<string, string | string[] | undefined>,
   name: string,
 ): string | null {
-  const key = Object.keys(headers).find((k) => k.toLowerCase() === name);
+  const key = Object.keys(headers).find((k) => k.toLowerCase() === name.toLowerCase());
   if (!key) {
     return null;
   }

--- a/packages/core/src/compliance/adapters/hmac-kyc-webhook-verifier.ts
+++ b/packages/core/src/compliance/adapters/hmac-kyc-webhook-verifier.ts
@@ -1,16 +1,31 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { KycWebhookVerifier } from '@openora/core/contracts';
 
+// Case-insensitive lookup - the runtime normally lowercases header names (Fetch `Headers`),
+// but a caller passing raw framework headers may not.
+function findHeader(
+  headers: Record<string, string | string[] | undefined>,
+  name: string,
+): string | null {
+  const key = Object.keys(headers).find((k) => k.toLowerCase() === name);
+  if (!key) {
+    return null;
+  }
+  const raw = headers[key];
+  return Array.isArray(raw) ? (raw[0] ?? null) : (raw ?? null);
+}
+
 /**
  * Default KYC-webhook verifier: recomputes an HMAC-SHA256 of the raw request body
  * keyed by the configured secret and constant-time compares the hex digest against
- * the signature header (a leading `sha256=` is tolerated). Fails closed when the
- * secret is unset, the signature is absent, or the body was not captured.
+ * the `x-kyc-signature` header (a leading `sha256=` is tolerated). Fails closed when
+ * the secret is unset, the signature is absent, or the body was not captured.
  */
 export class HmacKycWebhookVerifier implements KycWebhookVerifier {
   constructor(private readonly secret: string | undefined) {}
 
-  verify(rawBody: string, signature: string | null): boolean {
+  verify(rawBody: string, headers: Record<string, string | string[] | undefined>): boolean {
+    const signature = findHeader(headers, 'x-kyc-signature');
     if (!this.secret || !signature) {
       return false;
     }

--- a/packages/core/src/compliance/adapters/hmac-kyc-webhook-verifier.ts
+++ b/packages/core/src/compliance/adapters/hmac-kyc-webhook-verifier.ts
@@ -1,8 +1,10 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { KycWebhookVerifier } from '@openora/core/contracts';
 
-// Case-insensitive lookup - the runtime normally lowercases header names (Fetch `Headers`),
-// but a caller passing raw framework headers may not.
+/**
+ * Case-insensitive lookup - the runtime normally lowercases header names (Fetch `Headers`),
+ * but a caller passing raw framework headers may not.
+ */
 function findHeader(
   headers: Record<string, string | string[] | undefined>,
   name: string,

--- a/packages/core/src/compliance/contract/index.ts
+++ b/packages/core/src/compliance/contract/index.ts
@@ -36,13 +36,21 @@ export const KycVerificationSchema = z.object({
   updatedAt: TimestampSchema,
 });
 
+/**
+ * `documents` is empty for a hosted-session vendor (eg Didit) - there is nothing to
+ * forward, the vendor collects documents on its own hosted page after `submitKyc`
+ * redirects the user there. A document-forwarding vendor (eg SumSub) expects at
+ * least one document; that requirement is the adapter's concern, not this contract's.
+ */
 export const SubmitKycInputSchema = z.object({
-  documents: z.array(KycDocumentSchema).min(1),
+  documents: z.array(KycDocumentSchema),
 });
 export type SubmitKycInput = z.infer<typeof SubmitKycInputSchema>;
 
-// Extends the persisted verification record with a hosted verification URL, present only
-// for vendors whose flow requires redirecting the end user (eg a hosted-session provider).
+/**
+ * Extends the persisted verification record with a hosted verification URL, present only
+ * for vendors whose flow requires redirecting the end user (eg a hosted-session provider).
+ */
 export const SubmitKycOutputSchema = KycVerificationSchema.extend({
   verificationUrl: z.string().optional(),
 });

--- a/packages/core/src/compliance/contract/index.ts
+++ b/packages/core/src/compliance/contract/index.ts
@@ -41,6 +41,13 @@ export const SubmitKycInputSchema = z.object({
 });
 export type SubmitKycInput = z.infer<typeof SubmitKycInputSchema>;
 
+// Extends the persisted verification record with a hosted verification URL, present only
+// for vendors whose flow requires redirecting the end user (eg a hosted-session provider).
+export const SubmitKycOutputSchema = KycVerificationSchema.extend({
+  verificationUrl: z.string().optional(),
+});
+export type SubmitKycOutput = z.infer<typeof SubmitKycOutputSchema>;
+
 export const PlayerKycViewSchema = z.object({
   current: KycVerificationSchema.nullable(),
   history: z.array(KycVerificationSchema),
@@ -99,7 +106,7 @@ export const complianceContract = {
   submitKyc: oc
     .route({ method: 'POST', path: '/compliance/kyc' })
     .input(SubmitKycInputSchema)
-    .output(KycVerificationSchema),
+    .output(SubmitKycOutputSchema),
 
   kycWebhook: oc
     .route({ method: 'POST', path: '/compliance/kyc/webhook' })

--- a/packages/core/src/compliance/contract/index.ts
+++ b/packages/core/src/compliance/contract/index.ts
@@ -36,21 +36,11 @@ export const KycVerificationSchema = z.object({
   updatedAt: TimestampSchema,
 });
 
-/**
- * `documents` is empty for a hosted-session vendor (eg Didit) - there is nothing to
- * forward, the vendor collects documents on its own hosted page after `submitKyc`
- * redirects the user there. A document-forwarding vendor (eg SumSub) expects at
- * least one document; that requirement is the adapter's concern, not this contract's.
- */
 export const SubmitKycInputSchema = z.object({
   documents: z.array(KycDocumentSchema),
 });
 export type SubmitKycInput = z.infer<typeof SubmitKycInputSchema>;
 
-/**
- * Extends the persisted verification record with a hosted verification URL, present only
- * for vendors whose flow requires redirecting the end user (eg a hosted-session provider).
- */
 export const SubmitKycOutputSchema = KycVerificationSchema.extend({
   verificationUrl: z.string().optional(),
 });

--- a/packages/core/src/compliance/router/index.ts
+++ b/packages/core/src/compliance/router/index.ts
@@ -17,14 +17,6 @@ import {
 } from '../service/rg.service.js';
 import { RgMonitoringService } from '../service/rg-monitoring.service.js';
 
-function headerValue(context: OssContext, name: string): string | null {
-  const raw = context.request.headers[name];
-  if (Array.isArray(raw)) {
-    return raw[0] ?? null;
-  }
-  return raw ?? null;
-}
-
 export function createComplianceRouter({
   compliance,
   adminGuard,
@@ -87,10 +79,7 @@ export function createComplianceRouter({
     // signature header or reject (fail closed); never fall back to an empty body.
     kycWebhook: os.kycWebhook.handler(async ({ context }) => {
       const rawBody = context.rawBody;
-      if (
-        rawBody === undefined ||
-        !webhookVerifier.verify(rawBody, headerValue(context, 'x-kyc-signature'))
-      ) {
+      if (rawBody === undefined || !webhookVerifier.verify(rawBody, context.request.headers)) {
         throw new ORPCError('UNAUTHORIZED', { message: 'Invalid KYC webhook signature' });
       }
       const decision = kycAdapter.parseWebhook?.(rawBody, context.request.headers);

--- a/packages/core/src/compliance/service/kyc.service.ts
+++ b/packages/core/src/compliance/service/kyc.service.ts
@@ -112,7 +112,7 @@ export class KycVerificationService {
       provider: this.provider,
     });
     await this.statusWriter.setStatus(userId, status, { actorId: null, source: 'vendor' });
-    return toDto(row);
+    return { ...toDto(row), verificationUrl: result.verificationUrl };
   }
 
   /**

--- a/packages/core/src/contracts/adapters/kyc.ts
+++ b/packages/core/src/contracts/adapters/kyc.ts
@@ -1,8 +1,10 @@
-// KYC/identity-verification seam. Intended real provider: SumSub (https://sumsub.com).
-// The identity module ships MockKycAdapter (auto-approves) as the default binding.
-// Override via overlay: ctx.provide(KYC_ADAPTER, () => new SumsubKycAdapter())
-// Load your overlay AFTER the identity plugin in extensions.config.ts (last registration wins).
-// See docs/adapters/kyc.md for the full binding guide.
+/**
+ * KYC/identity-verification seam. Intended real provider: SumSub (https://sumsub.com).
+ * The identity module ships MockKycAdapter (auto-approves) as the default binding.
+ * Override via overlay: `ctx.provide(KYC_ADAPTER, () => new SumsubKycAdapter())`.
+ * Load your overlay AFTER the identity plugin in extensions.config.ts (last registration wins).
+ * See docs/adapters/kyc.md for the full binding guide.
+ */
 import { createToken, type Token } from './token.js';
 import type { KycStatus, Player } from '../schemas/player.js';
 
@@ -19,22 +21,28 @@ export type KycVendorStatus = 'pending' | 'approved' | 'rejected' | 'not_started
 export type KycResult = {
   referenceId: string;
   status: KycVendorStatus;
-  // Hosted verification URL to redirect the end user to, for vendors whose flow collects
-  // documents on their own hosted page (eg Didit) rather than accepting them from our
-  // backend. Omitted by document-forwarding vendors (eg SumSub, MockKycAdapter).
+  /**
+   * Hosted verification URL to redirect the end user to, for vendors whose flow collects
+   * documents on their own hosted page (eg Didit) rather than accepting them from our
+   * backend. Omitted by document-forwarding vendors (eg SumSub, MockKycAdapter).
+   */
   verificationUrl?: string;
 };
 
 export type KycAdapter = {
-  // True when the adapter rubber-stamps every submission (the default MockKycAdapter).
-  // A boot guard refuses/warns if withdrawals are KYC-gated while this is bound, so an
-  // operator can't enable the gate yet leave verification a no-op. Real providers omit it.
+  /**
+   * True when the adapter rubber-stamps every submission (the default MockKycAdapter).
+   * A boot guard refuses/warns if withdrawals are KYC-gated while this is bound, so an
+   * operator can't enable the gate yet leave verification a no-op. Real providers omit it.
+   */
   readonly autoApproves?: boolean;
   submit(userId: string, documents: KycDocument[]): Promise<KycResult>;
   getStatus(userId: string): Promise<KycVendorStatus>;
-  // Provider-specific normalization of a raw webhook into a vendor decision, or
-  // null when the body is not a reconcilable decision. Optional - MockKycAdapter
-  // omits it; the Didit/SumSub overlay (ABC-293) implements it.
+  /**
+   * Provider-specific normalization of a raw webhook into a vendor decision, or
+   * null when the body is not a reconcilable decision. Optional - MockKycAdapter
+   * omits it; the Didit/SumSub overlay (ABC-293) implements it.
+   */
   parseWebhook?(
     rawBody: string,
     headers: Record<string, string | string[] | undefined>,
@@ -66,13 +74,15 @@ export type KycStatusWriter = {
 
 export const KYC_STATUS_WRITER: Token<KycStatusWriter> = createToken('KYC_STATUS_WRITER');
 
-// Verifies the public KYC provider webhook is genuine. The default impl recomputes
-// an HMAC-SHA256 over the raw request body and constant-time compares it against the
-// `x-kyc-signature` header; a vendor overlay rebinds it. Fails closed when the secret is
-// unset, the signature is absent, or the raw body was not captured. Takes the full
-// headers map (not a pre-extracted value) because the signing header name is
-// vendor-specific - eg SumSub vs a hosted-session vendor each name it differently -
-// so each implementation extracts whatever header(s) it actually needs.
+/**
+ * Verifies the public KYC provider webhook is genuine. The default impl recomputes
+ * an HMAC-SHA256 over the raw request body and constant-time compares it against the
+ * `x-kyc-signature` header; a vendor overlay rebinds it. Fails closed when the secret is
+ * unset, the signature is absent, or the raw body was not captured. Takes the full
+ * headers map (not a pre-extracted value) because the signing header name is
+ * vendor-specific - eg SumSub vs a hosted-session vendor each name it differently -
+ * so each implementation extracts whatever header(s) it actually needs.
+ */
 export type KycWebhookVerifier = {
   verify(rawBody: string, headers: Record<string, string | string[] | undefined>): boolean;
 };

--- a/packages/core/src/contracts/adapters/kyc.ts
+++ b/packages/core/src/contracts/adapters/kyc.ts
@@ -19,6 +19,10 @@ export type KycVendorStatus = 'pending' | 'approved' | 'rejected' | 'not_started
 export type KycResult = {
   referenceId: string;
   status: KycVendorStatus;
+  // Hosted verification URL to redirect the end user to, for vendors whose flow collects
+  // documents on their own hosted page (eg Didit) rather than accepting them from our
+  // backend. Omitted by document-forwarding vendors (eg SumSub, MockKycAdapter).
+  verificationUrl?: string;
 };
 
 export type KycAdapter = {
@@ -64,10 +68,13 @@ export const KYC_STATUS_WRITER: Token<KycStatusWriter> = createToken('KYC_STATUS
 
 // Verifies the public KYC provider webhook is genuine. The default impl recomputes
 // an HMAC-SHA256 over the raw request body and constant-time compares it against the
-// signature header; a vendor overlay rebinds it. Fails closed when the secret is
-// unset, the signature is absent, or the raw body was not captured.
+// `x-kyc-signature` header; a vendor overlay rebinds it. Fails closed when the secret is
+// unset, the signature is absent, or the raw body was not captured. Takes the full
+// headers map (not a pre-extracted value) because the signing header name is
+// vendor-specific - eg SumSub vs a hosted-session vendor each name it differently -
+// so each implementation extracts whatever header(s) it actually needs.
 export type KycWebhookVerifier = {
-  verify(rawBody: string, signature: string | null): boolean;
+  verify(rawBody: string, headers: Record<string, string | string[] | undefined>): boolean;
 };
 
 export const KYC_WEBHOOK_VERIFIER: Token<KycWebhookVerifier> = createToken('KYC_WEBHOOK_VERIFIER');

--- a/packages/core/src/contracts/adapters/kyc.ts
+++ b/packages/core/src/contracts/adapters/kyc.ts
@@ -41,7 +41,7 @@ export type KycAdapter = {
   /**
    * Provider-specific normalization of a raw webhook into a vendor decision, or
    * null when the body is not a reconcilable decision. Optional - MockKycAdapter
-   * omits it; the Didit/SumSub overlay (ABC-293) implements it.
+   * omits it; the Didit/SumSub overlay implements it.
    */
   parseWebhook?(
     rawBody: string,
@@ -80,7 +80,7 @@ export const KYC_STATUS_WRITER: Token<KycStatusWriter> = createToken('KYC_STATUS
  * `x-kyc-signature` header; a vendor overlay rebinds it. Fails closed when the secret is
  * unset, the signature is absent, or the raw body was not captured. Takes the full
  * headers map (not a pre-extracted value) because the signing header name is
- * vendor-specific - eg SumSub vs a hosted-session vendor each name it differently -
+ * vendor-specific - eg SumSub vs a hosted-session vendor each names it differently -
  * so each implementation extracts whatever header(s) it actually needs.
  */
 export type KycWebhookVerifier = {


### PR DESCRIPTION
## Summary
- Adds optional `KycResult.verificationUrl` so a hosted-session KYC vendor (creates a session, redirects the end user to its own hosted page) can plug into the existing `KYC_ADAPTER` seam alongside document-forwarding vendors like SumSub.
- Widens `KycWebhookVerifier.verify(rawBody, headers)` to receive the full headers map instead of one pre-extracted `x-kyc-signature` value, since a vendor's signing header name is vendor-specific.
- Both changes are additive/optional - `MockKycAdapter` and the default `HmacKycWebhookVerifier` are unaffected.
- Threads `verificationUrl` through `submitKyc`'s output contract and the compliance service.
- Rewrites the stale `docs/adapters/kyc.md` against the current port shape and adds a "KYC" section to `compliance/AGENTS.md`.

Prepares the seam for a Didit KYC provider overlay being built in the consumer (betfeel) - BF-293.

## Test plan
- [x] `pnpm verify` green (typecheck, unit tests, lint, module-shape, boundaries)
- [x] Updated `hmac-kyc-webhook-verifier.test.ts` for the new `verify(rawBody, headers)` signature + a case-insensitive header-name test
- [x] Added `kyc.service.test.ts` coverage for `verificationUrl` round-tripping (present/absent)