### PR TITLE
fix(engagement,compliance): chat stream roomId 400 + rg-monitor scheduler crash

### DIFF
--- a/packages/core/src/compliance/plugin.ts
+++ b/packages/core/src/compliance/plugin.ts
@@ -162,7 +162,7 @@ export default definePlugin({
 
       jobQueueRef = c.get(JOB_QUEUE);
       void jobQueueRef
-        .schedule(RG_MONITOR_QUEUE, 'rg-monitor', {}, { everyMs: 60_000, cron: '* * * * *' })
+        .schedule(RG_MONITOR_QUEUE, 'rg-monitor', {}, { everyMs: 60_000 })
         .catch((err) => logger.error({ err }, 'rg-monitor schedule failed'));
 
       return createComplianceRouter({

--- a/packages/core/src/engagement/chat/contract/index.ts
+++ b/packages/core/src/engagement/chat/contract/index.ts
@@ -84,7 +84,7 @@ export const chatContract = {
 
   streamMessages: oc
     .route({ method: 'GET', path: '/chat/stream' })
-    .input(z.object({ roomId: UuidSchema.nullable() }))
+    .input(z.object({ roomId: UuidSchema.nullable().optional() }))
     .output(eventIterator(ChatMessageSchema)),
 
   listBlockedUsers: oc

--- a/packages/core/src/engagement/chat/router/index.ts
+++ b/packages/core/src/engagement/chat/router/index.ts
@@ -100,7 +100,7 @@ export function createChatRouter(chatService: ChatService, authorizer: RealtimeC
     streamMessages: os.streamMessages.handler(({ input, signal, context }) => {
       const viewerId = resolveViewerId(context);
       return createEventStreamGenerator(
-        (push) => chatService.subscribeMessages(input.roomId, push, viewerId),
+        (push) => chatService.subscribeMessages(input.roomId ?? null, push, viewerId),
         { signal },
       );
     }),


### PR DESCRIPTION
## Summary

Two unrelated bugs found during an e2e QA sweep of the Betfeel consumer app, both traced back to this package.

## Changes

- **engagement/chat**: `streamMessages`'s `roomId` input was `.nullable()` but not `.optional()`. The oRPC GET query serializer drops `null` values entirely, so global chat (`roomId: null`) never reached the server as a key at all - zod saw `undefined`, which `.nullable()` rejects, and the request 400'd on every attempt. Made the input `.nullable().optional()` and normalized `input.roomId ?? null` at the handler.
- **compliance**: the `rg-monitor` repeatable job scheduler was registered with both `everyMs` and a `cron` expression set simultaneously, which BullMQ rejects (`Both .pattern and .every options are defined`) - failing silently on every boot and disabling RG monitoring entirely (0 flags ever computed, regardless of qualifying player data). Dropped the redundant cron expression, kept the equivalent 60s interval.

## Acceptance criteria

- [x] `GET /chat/stream` with no room selected (global chat) succeeds instead of 400ing
- [x] `rg-monitor` job scheduler registers without error on API boot

## Checklist

- [x] `pnpm verify` is green (typecheck + lint + boundaries + module-shape + tests)
- [x] `pnpm verify:drift` is green (catalog / OpenAPI not stale)
- [x] New cross-module talk goes through events / command ports / contracts / the `/schema` subpath (no direct module imports)
- [ ] New data tables carry `tenantId` and are RLS-covered - N/A, no schema changes
- [x] No secrets, real player data, or internal/customer names added
- [ ] Docs / AGENTS.md updated if behavior or extension points changed - N/A, no extension-point changes

## Notes

Both fixes verified live end-to-end against a locally running Betfeel consumer stack (linked via `pnpm link:oss`): chat stream returns 200 with no more retry storm, and the scheduler no longer logs the startup error.

Closes BF-315, BF-214