### PR TITLE
fix(compliance): tolerate legacy rg-flag detail on read so one bad row can't 500 the list

### DIFF
--- a/packages/core/src/compliance/__tests__/rg.contract.test.ts
+++ b/packages/core/src/compliance/__tests__/rg.contract.test.ts
@@ -3,10 +3,36 @@ import {
   ActivateCoolingOffInputSchema,
   ActivateSelfExclusionInputSchema,
   LiftSelfExclusionInputSchema,
+  RgFlagListItemSchema,
   SetPlayerLimitInputSchema,
 } from '../contract/rg.js';
 
 const USER = '11111111-1111-4111-8111-111111111111';
+
+describe('RgFlagListItemSchema.detail resilience', () => {
+  const base = {
+    id: USER,
+    userId: USER,
+    username: null,
+    email: null,
+    flagType: 'session_time' as const,
+    limitType: null,
+    status: 'active' as const,
+    flaggedAt: new Date().toISOString(),
+    clearedAt: null,
+  };
+  it('accepts a legacy/empty detail so one bad row cannot 500 the whole list', () => {
+    expect(RgFlagListItemSchema.safeParse({ ...base, detail: {} }).success).toBe(true);
+  });
+  it('still accepts the known detail shapes', () => {
+    expect(
+      RgFlagListItemSchema.safeParse({
+        ...base,
+        detail: { sessionMinutes: 65, limitMinutes: 60, pct: 108 },
+      }).success,
+    ).toBe(true);
+  });
+});
 
 describe('SetPlayerLimitInputSchema session invariant', () => {
   const money = { userId: USER, amount: '100', minutes: null };

--- a/packages/core/src/compliance/contract/rg.ts
+++ b/packages/core/src/compliance/contract/rg.ts
@@ -118,7 +118,9 @@ export const RgFlagListItemSchema = z.object({
   email: z.string().nullable(),
   flagType: RgFlagTypeSchema,
   limitType: z.string().nullable(),
-  detail: RgFlagDetailSchema,
+  // ponytail: tolerate a legacy/empty ('{}') detail on read so one malformed row can't
+  // 500 the whole RG dashboard. Writes stay strict via RgFlagDetailSchema (raiseFlag).
+  detail: RgFlagDetailSchema.or(z.record(z.string(), z.unknown())),
   status: RgFlagStatusSchema,
   flaggedAt: TimestampSchema,
   clearedAt: TimestampSchema.nullable(),


### PR DESCRIPTION
## Summary

`GET /compliance/rg-flags` validated every row's `detail` against the strict 3-member `RgFlagDetailSchema` union. A single `rg_flag` row whose `detail` does not match a known shape (eg the DB-default `'{}'::jsonb`) fails output validation, so the whole list 500s and the RG Monitoring dashboard renders empty. This makes the read tolerant of a legacy/unknown detail so one malformed row can't take the whole compliance list dark; writes stay strict.

## Changes

- **compliance/contract** - `RgFlagListItemSchema.detail` now falls back to a permissive object shape (`RgFlagDetailSchema.or(z.record(...))`) on read. `RgFlagDetailSchema` is unchanged, so the write path (`raiseFlag`) stays strictly typed.
- **compliance/tests** - added a regression case: an empty/legacy detail and the known shapes all parse.

## Acceptance criteria

- [x] RG flag list does not 500 when a row's `detail` is empty/unknown
- [x] Known detail shapes still validate to their precise type

## Checklist

- [x] `pnpm verify` is green (typecheck + lint + boundaries + module-shape + tests)
- [ ] `pnpm verify:drift` - see Notes (pre-existing, unrelated catalog drift on `dev`)
- [x] New cross-module talk goes through events / command ports / contracts / the `/schema` subpath
- [x] No secrets, real player data, or internal/customer names added

## Notes

- No wire change to OpenAPI; `docs/catalog.json` untouched by this PR.
- `pnpm verify:drift` is red on `dev` independently of this change: `pnpm regen` wants to drop `POST /wallet/deposits/address` and `POST /wallet/webhook` from the catalog (an earlier change skipped regen). Should be fixed in its own PR.
- Consumers pick this up on the next `@openora/core` release.
