### PR TITLE
chore(release): add missing changeset for password reset OTP

### DIFF
--- a/.changeset/feat-password-reset-otp.md
+++ b/.changeset/feat-password-reset-otp.md
@@ -1,0 +1,5 @@
+---
+'@openora/core': minor
+---
+
+feat(pam): change implementation of password reset to use email OTP


### PR DESCRIPTION
## Summary

Adds a missing changeset for the PAM password reset OTP implementation to trigger a package release for consumers.

## Changes

- **Release**: Added `@openora/core` minor changeset for password reset OTP.

## Acceptance criteria

- [x] Changeset is added.

## Checklist

- [x] `pnpm verify` is green (typecheck + lint + boundaries + module-shape + tests)
- [x] `pnpm verify:drift` is green (catalog / OpenAPI not stale) - run `pnpm regen` if not
- [x] New cross-module talk goes through events / command ports / contracts / the `/schema` subpath (no direct module imports)
- [x] New data tables carry `tenantId` and are RLS-covered (`pnpm regen` runs `gen:rls`)
- [x] No secrets, real player data, or internal/customer names added
- [x] Docs / AGENTS.md updated if behavior or extension points changed
