### PR TITLE
test: update stale wallet e2e assertions after crypto-custody seam

### DIFF
--- a/packages/testing/src/__tests__/wallet-ledger-auto-withdrawal.e2e.test.ts
+++ b/packages/testing/src/__tests__/wallet-ledger-auto-withdrawal.e2e.test.ts
@@ -130,7 +130,7 @@ describe('Auto-withdrawal: single-shot gates (appGated - fiatThreshold 2)', () =
     expect(body.status).toBe('completed');
 
     const balance = (await readJson(await client.get('/wallet/balance'))).balance;
-    expect(balance).toBe('4.50');
+    expect(balance).toBe('4.50000000');
 
     const pending = await pendingWithdrawalIds(admin);
     expect(pending.has(body.transactionId)).toBe(false);
@@ -210,7 +210,11 @@ describe('Auto-withdrawal: single-shot gates (appGated - fiatThreshold 2)', () =
     await verifyKyc(admin, playerId);
 
     await client.post('/wallet/deposit', { amount: '0.1', currency: 'BTC' });
-    const res = await client.post('/wallet/withdraw', { amount: '0.01', currency: 'BTC' });
+    const res = await client.post('/wallet/withdraw', {
+      amount: '0.01',
+      currency: 'BTC',
+      destinationAddress: 'bc1qe2e-crypto-rail-test-address',
+    });
     expect(res.status).toBe(200);
     const body = await readJson(res);
     expect(body.status).toBe('pending');
@@ -262,7 +266,7 @@ describe('Auto-withdrawal: single-shot gates (appGated - fiatThreshold 2)', () =
       );
       const auditBody = await readJson(auditRes);
       expect(auditBody.items[0].after).toMatchObject({
-        threshold: '3.00',
+        threshold: '3.00000000',
         thresholdSource: 'per-player',
       });
     });
@@ -340,11 +344,11 @@ describe('Auto-withdrawal-rule routes: authz + audit', () => {
     });
     expect(setRes.status).toBe(200);
     const rule = await readJson(setRes);
-    expect(rule).toMatchObject({ userId, threshold: '1.50', reason: 'admin round trip' });
+    expect(rule).toMatchObject({ userId, threshold: '1.50000000', reason: 'admin round trip' });
 
     const getRes = await admin.get(`/wallet/auto-withdrawal-rules/${userId}`);
     expect(getRes.status).toBe(200);
-    expect(await readJson(getRes)).toMatchObject({ threshold: '1.50' });
+    expect(await readJson(getRes)).toMatchObject({ threshold: '1.50000000' });
 
     await vi.waitFor(async () => {
       const auditRes = await admin.get(
@@ -353,7 +357,7 @@ describe('Auto-withdrawal-rule routes: authz + audit', () => {
       const auditBody = await readJson(auditRes);
       expect(auditBody.items.length).toBeGreaterThanOrEqual(1);
       expect(auditBody.items[0].after).toMatchObject({
-        threshold: '1.50',
+        threshold: '1.50000000',
         reason: 'admin round trip',
       });
     });
@@ -388,7 +392,7 @@ describe('Manual withdrawal approve/reject regression (appDefault - autoWithdraw
     );
     expect(w1.status).toBe('pending');
     const balanceAfterHold = (await readJson(await client.get('/wallet/balance'))).balance;
-    expect(balanceAfterHold).toBe('2.40');
+    expect(balanceAfterHold).toBe('2.40000000');
 
     const approveRes = await admin.post(`/wallet/withdrawals/${w1.transactionId}/approve`, {
       withdrawalId: w1.transactionId,
@@ -401,7 +405,7 @@ describe('Manual withdrawal approve/reject regression (appDefault - autoWithdraw
     );
     expect(w2.status).toBe('pending');
     const balanceAfterSecondHold = (await readJson(await client.get('/wallet/balance'))).balance;
-    expect(balanceAfterSecondHold).toBe('2.00'); // 2.40 - 0.40
+    expect(balanceAfterSecondHold).toBe('2.00000000');
 
     const rejectRes = await admin.post(`/wallet/withdrawals/${w2.transactionId}/reject`, {
       withdrawalId: w2.transactionId,
@@ -411,7 +415,6 @@ describe('Manual withdrawal approve/reject regression (appDefault - autoWithdraw
     expect((await readJson(rejectRes)).status).toBe('rejected');
 
     const balanceAfterReject = (await readJson(await client.get('/wallet/balance'))).balance;
-    // Held funds are returned on reject.
-    expect(balanceAfterReject).toBe('2.40');
+    expect(balanceAfterReject).toBe('2.40000000');
   });
 });


### PR DESCRIPTION
## Summary

`wallet-ledger-auto-withdrawal.e2e.test.ts` fails 5/10 on `dev` today. All five are stale expectations left behind by the crypto-custody payment seam, not defects - this updates them so the suite is honest again and `dev` goes green.

## Changes

- `packages/testing` - four money assertions now expect the 8 decimal places Postgres actually returns; the crypto-rail test supplies the destination address that rail has required since the same change.

No production code touched.

## Acceptance criteria

Not ticket-driven.

## Checklist

- [x] `pnpm verify` is green (typecheck + lint + boundaries + module-shape + tests)
- [x] `pnpm verify:drift` is green (catalog / OpenAPI not stale) - run `pnpm regen` if not
- [x] New cross-module talk goes through events / command ports / contracts / the `/schema` subpath (no direct module imports)
- [x] New data tables carry `tenantId` and are RLS-covered (`pnpm regen` runs `gen:rls`)
- [x] No secrets, real player data, or internal/customer names added
- [x] Docs / AGENTS.md updated if behavior or extension points changed

Test-only change, so the table/RLS and cross-module items are trivially satisfied. `wallet-ledger-auto-withdrawal.e2e.test.ts` now passes 10/10 against real Postgres (run twice, stable); full core suite 537 passed.

## Notes

Root cause, so the same drift is recognisable next time: the crypto-custody seam moved money columns to `decimal(precision: 18, scale: 8)` for satoshi precision, so `NUMERIC(18,8)` returns `4.50000000` where the assertions still expected `4.50`. `MoneyAmountSchema` permits up to 8 decimals, so the API response was valid throughout - only the expectations were stale. The same change also began requiring a destination address for crypto-rail withdrawals, which the auto-approval test never supplied, so it was failing on an unrelated guard rather than exercising what its name claims.

Deliberately not "fixed" by trimming trailing zeros in serialization - that would break BTC amounts, which need all eight places.

One assertion in the same file was left alone on purpose: the global threshold `'2'` is the raw platform-config string, not a DB round-trip, so it never gained padding.

Worth merging before `feat/kyc-flow-hardening`, which touches the same file and will otherwise inherit a red base. The conflict between the two is small and mechanical.
