### PR TITLE
fix(identity): reset rate-limit on account lockout

### DIFF
--- a/packages/core/src/pam/identity/__tests__/identity.service.test.ts
+++ b/packages/core/src/pam/identity/__tests__/identity.service.test.ts
@@ -5,7 +5,12 @@ import {
   type IdentityServiceDeps,
 } from '../service/identity.service.js';
 import { UnsupportedLanguageError } from '../../shared/language.js';
-import type { EmailTemplateRenderer, SendEmailPort, PlatformConfig } from '@openora/core/contracts';
+import type {
+  EmailTemplateRenderer,
+  SendEmailPort,
+  PlatformConfig,
+  RateLimiterAdapter,
+} from '@openora/core/contracts';
 import { ORPCError } from '@orpc/server';
 import { mock } from '../../../testing/mock.js';
 import type { DrizzleService, EventBus } from '@openora/core/server';
@@ -153,7 +158,11 @@ describe('IdentityService - login lockout', () => {
     });
     const events = makeEvents();
     signInEmailMock.mockResolvedValue(jsonResponse({ message: 'Invalid' }, 401));
-    const svc = withTemplateRenderer({ drizzle: drizzle, events: events });
+    const limiter = mock<RateLimiterAdapter>({
+      consume: vi.fn().mockResolvedValue({ allowed: true, retryAfterMs: 0 }),
+      reset: vi.fn().mockResolvedValue(undefined),
+    });
+    const svc = withTemplateRenderer({ drizzle: drizzle, events: events, limiter });
 
     await expect(
       svc.login({ email: 'A@B.dev', password: 'wrongpass1' }, {}, new Headers()),
@@ -163,6 +172,8 @@ describe('IdentityService - login lockout', () => {
       'identity.user.lockout.triggered',
       expect.objectContaining({ userId: 'u1', email: 'a@b.dev' }),
     );
+
+    expect(limiter.reset).toHaveBeenCalledWith('login:a@b.dev');
   });
 
   it('emits login.failed (not lockout) while still below the threshold', async () => {

--- a/packages/core/src/pam/identity/service/identity.service.ts
+++ b/packages/core/src/pam/identity/service/identity.service.ts
@@ -524,6 +524,8 @@ export class IdentityService {
             .set({ lockoutUntil, lockoutCount: tier, lastLockoutAt: new Date(nowMs) })
             .where(eq(user.id, existingUser.id));
 
+          await this.limiter?.reset(makeLoginRateLimitKey(email));
+
           this.events.emit('identity.user.lockout.triggered', {
             userId: existingUser.id,
             email,


### PR DESCRIPTION
## Summary

Reset the login rate-limiter counter when an account is locked after 5 failed attempts. This prevents testers (and attackers) from hitting the 10/5min throttle while verifying lockout behavior, allowing a clean 15-minute window to check the account-locked flow without interference from rate-limiting.

## Changes

- **pam/identity**: Added `limiter.reset()` call in the lockout branch of `login()`, mirroring the existing reset in `unlockUser()` on admin-initiated unlock.
- **pam/identity tests**: Extended the lockout test to assert that `limiter.reset()` is called with the correct rate-limit key on lockout.

## Acceptance criteria

- [x] Failed login attempts correctly trigger account lockout (5 attempts → `ACCOUNT_LOCKED`, 15 min tiered lockout)
- [x] Rate-limiter counter is reset the moment lockout is triggered
- [x] Subsequent probes during lockout return 401 `ACCOUNT_LOCKED` (not 429) until the throttle naturally expires or the 15 min lockout elapses
- [x] Admin `unlockUser()` still resets the rate-limit counter (pre-existing, unchanged)

## Checklist

- [x] `pnpm verify` is green (typecheck + lint + boundaries + module-shape + tests) — 556/556 tests pass
- [x] `pnpm verify:drift` is green (no OpenAPI/catalog changes needed)
- [x] No new contracts, routes, or breaking changes
- [x] No new tables or tenant/RLS concerns
- [x] No secrets or sensitive data

## Notes

None
