### PR TITLE
chore(repo): @openora/create readme + join canary version line

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -67,7 +67,7 @@ jobs:
           NEXT=$(node -e 'const v=process.argv[1].split("-")[0].split(".").map(Number); console.log(v[0]+"."+v[1]+"."+(v[2]+1))' "$LATEST")
           export VERSION="${NEXT}-canary.${RUN}"
           echo "Publishing canary $VERSION"
-          node -e "for (const p of ['packages/core/package.json','packages/mcp/package.json']) { const fs=require('fs'); const j=JSON.parse(fs.readFileSync(p,'utf8')); j.version=process.env.VERSION; fs.writeFileSync(p, JSON.stringify(j,null,2)+'\n'); }"
+          node -e "for (const p of ['packages/core/package.json','packages/mcp/package.json','packages/create-openora/package.json']) { const fs=require('fs'); const j=JSON.parse(fs.readFileSync(p,'utf8')); j.version=process.env.VERSION; fs.writeFileSync(p, JSON.stringify(j,null,2)+'\n'); }"
           pnpm changeset publish --no-git-tag --tag canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/create-openora/README.md
+++ b/packages/create-openora/README.md
@@ -1,0 +1,74 @@
+# @openora/create
+
+[![npm](https://img.shields.io/npm/v/@openora/create)](https://www.npmjs.com/package/@openora/create)
+[![canary](https://img.shields.io/npm/v/@openora/create/canary?label=canary&color=orange)](https://www.npmjs.com/package/@openora/create?activeTab=versions)
+[![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/blurifycom/openora/blob/dev/LICENSE)
+[![GitHub](https://img.shields.io/badge/GitHub-blurifycom%2Fopenora-181717?logo=github)](https://github.com/blurifycom/openora)
+
+> The npm initializer for [Openora](https://github.com/blurifycom/openora) - scaffold a headless iGaming backend in one command. No clone, no fork.
+
+`npm create @openora` writes a ready-to-run consumer app that pulls the platform ([`@openora/core`](https://www.npmjs.com/package/@openora/core)) from npm and wires every built-in module for you. Your branding, adapters, and overlays go on top - core stays an untouched dependency.
+
+> **Status: alpha (pre-1.0).** The scaffold and the packages it installs may change between releases.
+
+## Quick start
+
+```sh
+npm create @openora@latest my-casino
+```
+
+```sh
+cd my-casino
+pnpm install
+cp .env.example .env      # set DATABASE_URL / AUTH_SECRET
+docker compose up -d      # postgres
+pnpm db:migrate
+pnpm dev                  # api on http://localhost:3001
+```
+
+That's a full iGaming backend - accounts, wallet, casino lobby, chat, compliance, CMS, backoffice, audit - running locally, composed from published packages.
+
+Works with any package manager: `pnpm create @openora`, `yarn create @openora`, or `npm create @openora`.
+
+## What it scaffolds
+
+```
+my-casino/
+  apps/api/                    # headless API - createApp() + your extensions
+    src/
+      main.ts                  # composes the module contracts, boots the server
+      extensions.config.ts     # [...corePlugins(), ...your overlays]
+      extensions/              # your plugins live here
+  .mcp.json                    # @openora/mcp preconfigured for AI agents
+  .env.example                 # DATABASE_URL, AUTH_SECRET, ...
+  docker-compose.yml           # local postgres
+```
+
+- **Headless** - the API only. Build your frontend in the same repo and talk to it over HTTP with [`@openora/core/react`](https://www.npmjs.com/package/@openora/core).
+- **Every core module enabled** via `corePlugins()`, resolved from your installed `@openora/core`. Opt one out with `corePlugins().filter((p) => p.id !== 'chat')`.
+- **AI-native** - `.mcp.json` points at [`@openora/mcp`](https://www.npmjs.com/package/@openora/mcp) so an agent can discover routes, schemas, adapter seams, and events in your repo.
+
+## Add your own capability
+
+Inside the scaffolded app, `turbo gen` gives you the same generators the platform uses:
+
+```sh
+pnpm gen plugin    # new overlay plugin (routes / event handlers / jobs)
+pnpm gen adapter   # swap a vendor adapter (payment / KYC / notification)
+```
+
+Overlays load after core, so a later `ctx.provide(TOKEN, ...)` wins - override a vendor seam without editing core.
+
+## Canary channel
+
+Every push to the platform's `dev` branch publishes an immutable canary of the whole `@openora/*` line (including this initializer) under the `canary` dist-tag:
+
+```sh
+npm create @openora@canary my-casino
+```
+
+Use it for pre-release testing, never production.
+
+## License
+
+[AGPL-3.0-only](https://github.com/blurifycom/openora/blob/dev/LICENSE). A commercial license is available - see [LICENSE-COMMERCIAL.md](https://github.com/blurifycom/openora/blob/dev/LICENSE-COMMERCIAL.md).

--- a/packages/create-openora/package.json
+++ b/packages/create-openora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openora/create",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "description": "npm initializer that scaffolds a headless Openora consumer app from the published @openora/* packages - no OSS checkout required",
   "keywords": [
     "ai-native",


### PR DESCRIPTION
Follow-up to #31.

- Adds a README for `@openora/create` (badges, quick start, scaffold layout, `gen plugin/adapter`, canary channel) - the npm page had none.
- Aligns its version to the `@openora/*` fixed group (`0.4.0`) so stable/rc bump together.
- **Canary fix:** the `pipeline.yml` canary step version-stamped only `core` + `mcp`, so `@openora/create` never got a `-canary.NN` build. Adds `packages/create-openora/package.json` to that step - every `dev` push now publishes it under the `canary` dist-tag alongside core and mcp.

After merge, `npm create @openora@canary my-casino` works like the other packages.