### PR TITLE
feat(compliance): enforce cooling-off at wager time and allow an early lift

### DIFF
--- a/docs/adr/0032-rg-enforcement-at-wager-time.md
+++ b/docs/adr/0032-rg-enforcement-at-wager-time.md
@@ -1,0 +1,68 @@
+# ADR-0032: Responsible-gambling enforcement at wager time
+
+**Date**: 2026-07-25
+**Status**: Accepted
+
+## Context
+
+Responsible-gambling exclusions (cooling-off, self-exclusion) were enforced at exactly
+one point: login. `LOGIN_ENFORCEMENT.block` sets `user.rgBlocked`/`rgBlockedUntil` and
+revokes every active session, and both login gates (password and phone OTP) refuse a
+blocked player after their credentials verify. `compliance/AGENTS.md` stated the
+enforcement depth explicitly: "block login + revoke all sessions. NO per-transaction
+gating - the login block makes betting impossible transitively."
+
+That transitive argument does not hold end to end:
+
+- **A launched game outlives the session.** `startRound` hands the player a provider
+  `launchUrl` + `token`. That token lives in the vendor's session, not ours. Revoking
+  our sessions does not end a game already open in the player's browser.
+- **Settlement is inbound, not player-driven.** An aggregator calls back to settle a
+  round. `WALLET_COMMANDS.debit` is the seam it debits through, and it applied no
+  eligibility check at all - it validated the amount and the balance, nothing else.
+- **The block is asynchronous with play.** An admin activating a cooling-off while a
+  player is mid-session had no way to stop the wager that was already in flight.
+
+The regulatory requirement (BF-215) is that a cooling-off player "cannot log in or place
+bets". Only the first half was true.
+
+## Decision
+
+Introduce a read port, `PLAY_ELIGIBILITY`
+(`packages/core/src/contracts/adapters/play-eligibility.ts`):
+
+```ts
+export type PlayEligibilityPort = {
+  isRestricted(userId: string): Promise<boolean>;
+};
+```
+
+**Identity owns and binds it.** Identity owns the `user` table, and `rgBlocked` /
+`rgBlockedUntil` is the projection `LOGIN_ENFORCEMENT` already maintains.
+`PlayEligibilityService` reads that one indexed row and reuses the same `isRgBlocked`
+predicate the login gate uses, so a wager and a login can never disagree about whether a
+player is restricted - including the lazy-expiry behaviour, where an elapsed
+`rgBlockedUntil` reads as unrestricted without waiting for the 60-second sweep.
+
+**Two enforcement points, both fail-closed:**
+
+- `GamingService.startRound` throws `RgRestrictedError` before touching the provider, so
+  a restricted player never receives a launch token.
+- `WalletCommandsService.debit` throws `WalletRgRestrictedError` when `type === 'bet'`.
+
+An unknown user reads as restricted. A missing row means the caller cannot be resolved,
+and refusing an unresolvable wager is the safe direction.
+
+## Consequences
+
+- Compliance is unchanged. It drives `LOGIN_ENFORCEMENT` exactly as before; the new port
+  is a read of the projection that write already produces. No new state, no second source
+  of truth, nothing to keep in sync.
+- Gaming and wallet declare `requiresPorts: [PLAY_ELIGIBILITY]`. Neither imports the
+  identity schema, so the extraction story of ADR-0017 is preserved: a remote identity
+  service rebinds the port and the callers are untouched.
+- `startRound` and a `bet` debit each cost one extra primary-key read. `win` and `loss`
+  are deliberately NOT gated - they settle a round that was already staked, and refusing
+  them would strand an in-flight round rather than protect the player.
+- The gate is not a substitute for the login block. It is the second layer that makes the
+  first one's guarantee actually hold at the money boundary.

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -100,6 +100,7 @@
         "compliance.getPlayerKyc",
         "compliance.getRgSection",
         "compliance.kycWebhook",
+        "compliance.liftCoolingOff",
         "compliance.liftSelfExclusion",
         "compliance.listGeoRules",
         "compliance.listRgFlags",
@@ -386,6 +387,7 @@
       "token": "EMAIL_TEMPLATE_RENDERER",
       "status": "wired",
       "boundIn": [
+        "packages/core/src/compliance/plugin.ts",
         "packages/core/src/pam/identity/plugin.ts"
       ]
     },
@@ -492,6 +494,17 @@
       "token": "PAYMENT_ADAPTER",
       "status": "wired",
       "boundIn": [
+        "packages/core/src/wallet/plugin.ts"
+      ]
+    },
+    {
+      "category": "play-eligibility",
+      "interface": "PlayEligibilityPort",
+      "token": "PLAY_ELIGIBILITY",
+      "status": "wired",
+      "boundIn": [
+        "packages/core/src/casino/gaming/plugin.ts",
+        "packages/core/src/pam/identity/plugin.ts",
         "packages/core/src/wallet/plugin.ts"
       ]
     },
@@ -607,6 +620,7 @@
     "identity.user.unlocked",
     "notifications.created",
     "rg.cooling_off.activated",
+    "rg.cooling_off.lifted",
     "rg.exclusion.login_blocked",
     "rg.limit.set",
     "rg.self_exclusion.activated",
@@ -954,6 +968,10 @@
     {
       "name": "LanguageSchema",
       "file": "packages/core/src/contracts/schemas/identity.ts"
+    },
+    {
+      "name": "LiftCoolingOffInputSchema",
+      "file": "packages/core/src/compliance/contract/rg.ts"
     },
     {
       "name": "LiftSelfExclusionInputSchema",
@@ -1487,6 +1505,7 @@
     "POST /compliance/kyc",
     "POST /compliance/kyc/webhook",
     "POST /compliance/players/{userId}/cooling-off",
+    "POST /compliance/players/{userId}/cooling-off/lift",
     "POST /compliance/players/{userId}/self-exclusion",
     "POST /compliance/players/{userId}/self-exclusion/lift",
     "POST /gaming/rounds/start",

--- a/packages/core/src/audit/plugin.ts
+++ b/packages/core/src/audit/plugin.ts
@@ -369,12 +369,13 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
     topic === 'rg.limit.set' ||
     topic === 'rg.cooling_off.activated' ||
     topic === 'rg.self_exclusion.activated' ||
-    topic === 'rg.self_exclusion.lifted'
+    topic === 'rg.self_exclusion.lifted' ||
+    topic === 'rg.cooling_off.lifted'
   ) {
     const before =
       topic === 'rg.limit.set'
         ? { amount: p['previousAmount'] ?? null, minutes: p['previousMinutes'] ?? null }
-        : topic === 'rg.self_exclusion.lifted'
+        : topic === 'rg.self_exclusion.lifted' || topic === 'rg.cooling_off.lifted'
           ? { status: 'active' }
           : null;
     return {
@@ -467,6 +468,7 @@ const SUBSCRIBED_TOPICS: DomainEventName[] = [
   'rg.cooling_off.activated',
   'rg.self_exclusion.activated',
   'rg.self_exclusion.lifted',
+  'rg.cooling_off.lifted',
   'rg.exclusion.login_blocked',
   'compliance.kyc.updated',
   'compliance.kyc.submitted',

--- a/packages/core/src/casino/gaming/__tests__/gaming.service.test.ts
+++ b/packages/core/src/casino/gaming/__tests__/gaming.service.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mock, mockDb } from '../../../testing/mock.js';
 import type { EventBus } from '@openora/core/server';
-import type { GameAdapter } from '@openora/core/contracts';
+import type { GameAdapter, PlayEligibilityPort } from '@openora/core/contracts';
 import {
   GamingService,
   GameNotFoundError,
   GameRoundNotFoundError,
+  RgRestrictedError,
 } from '../service/gaming.service.js';
 
 describe('GamingService domain errors', () => {
@@ -41,6 +42,11 @@ function makeQueryChain(rows: unknown[]) {
 const noopEvents = mock<EventBus>({ emit: vi.fn(), on: vi.fn() });
 const noopAdapter = mock<GameAdapter>({});
 
+const eligibility = (isRestricted: boolean) =>
+  mock<PlayEligibilityPort>({ isRestricted: vi.fn().mockResolvedValue(isRestricted) });
+
+const unrestricted = eligibility(false);
+
 describe('GamingService lobby', () => {
   it('listGames returns the active games', async () => {
     const query = makeQueryChain([
@@ -55,7 +61,7 @@ describe('GamingService lobby', () => {
       },
     ]);
     const drizzle = mockDb(query.chain);
-    const svc = new GamingService(drizzle, noopEvents, noopAdapter);
+    const svc = new GamingService(drizzle, noopEvents, noopAdapter, unrestricted);
 
     const games = await svc.listGames();
 
@@ -63,5 +69,37 @@ describe('GamingService lobby', () => {
     expect(query.chain.select).toHaveBeenCalledOnce();
     expect(query.chain.where).toHaveBeenCalledOnce();
     expect(query.calls.where).toBeDefined();
+  });
+});
+
+describe('GamingService responsible-gambling gate', () => {
+  it('startRound refuses a restricted player before touching the provider', async () => {
+    const launchGame = vi.fn();
+    const svc = new GamingService(
+      mockDb(makeQueryChain([]).chain),
+      noopEvents,
+      mock<GameAdapter>({ launchGame }),
+      eligibility(true),
+    );
+
+    await expect(svc.startRound('user-1', 'game-1', 'EUR')).rejects.toBeInstanceOf(
+      RgRestrictedError,
+    );
+    expect(launchGame).not.toHaveBeenCalled();
+  });
+
+  it('startRound passes the gate for an unrestricted player and fails later on the game lookup', async () => {
+    const launchGame = vi.fn();
+    const svc = new GamingService(
+      mockDb(makeQueryChain([]).chain),
+      noopEvents,
+      mock<GameAdapter>({ launchGame }),
+      unrestricted,
+    );
+
+    await expect(svc.startRound('user-1', 'missing-game', 'EUR')).rejects.toBeInstanceOf(
+      GameNotFoundError,
+    );
+    expect(launchGame).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/casino/gaming/plugin.ts
+++ b/packages/core/src/casino/gaming/plugin.ts
@@ -1,5 +1,5 @@
 import { definePlugin, EVENT_BUS, DRIZZLE } from '@openora/core/server';
-import { GAME_ADAPTER, RNG_ADAPTER } from '@openora/core/contracts';
+import { GAME_ADAPTER, PLAY_ELIGIBILITY, RNG_ADAPTER } from '@openora/core/contracts';
 import { GamingService } from './service/gaming.service.js';
 import { createGamingRouter } from './router/index.js';
 import { MockGameAdapter } from './adapters/mock/mock-game-adapter.js';
@@ -7,11 +7,19 @@ import { MockRngAdapter } from './adapters/mock/mock-rng-adapter.js';
 
 export default definePlugin({
   id: 'gaming',
+  requiresPorts: [PLAY_ELIGIBILITY],
   register(ctx) {
     ctx.provide(GAME_ADAPTER, () => new MockGameAdapter());
     ctx.provide(RNG_ADAPTER, () => new MockRngAdapter());
     ctx.routers.add('gaming', (c) =>
-      createGamingRouter(new GamingService(c.get(DRIZZLE), c.get(EVENT_BUS), c.get(GAME_ADAPTER))),
+      createGamingRouter(
+        new GamingService(
+          c.get(DRIZZLE),
+          c.get(EVENT_BUS),
+          c.get(GAME_ADAPTER),
+          c.get(PLAY_ELIGIBILITY),
+        ),
+      ),
     );
   },
 });

--- a/packages/core/src/casino/gaming/router/index.ts
+++ b/packages/core/src/casino/gaming/router/index.ts
@@ -5,6 +5,7 @@ import {
   GamingService,
   GameNotFoundError,
   GameRoundNotFoundError,
+  RgRestrictedError,
 } from '../service/gaming.service.js';
 
 export function createGamingRouter(gaming: GamingService) {
@@ -18,7 +19,7 @@ export function createGamingRouter(gaming: GamingService) {
     ),
 
     startRound: os.startRound.handler(({ input, context }) =>
-      mapErrors({ NOT_FOUND: GameNotFoundError }, () =>
+      mapErrors({ NOT_FOUND: GameNotFoundError, CONFLICT: RgRestrictedError }, () =>
         gaming.startRound(getUserId(context), input.gameId, input.currency),
       ),
     ),

--- a/packages/core/src/casino/gaming/service/gaming.service.ts
+++ b/packages/core/src/casino/gaming/service/gaming.service.ts
@@ -1,17 +1,23 @@
 import {
   type EventBus,
   makeNotFoundError,
+  makeConflictError,
   DrizzleService,
   findOneOrThrow,
   serializeRow,
 } from '@openora/core/server';
 import { eq, and, asc, desc } from 'drizzle-orm';
-import { type GameAdapter, type User } from '@openora/core/contracts';
+import { type GameAdapter, type PlayEligibilityPort, type User } from '@openora/core/contracts';
 import { game, gameRound, type Game, type GameRound } from '../schema/index.js';
 
 export const GameNotFoundError = makeNotFoundError('Game');
 
 export const GameRoundNotFoundError = makeNotFoundError('GameRound');
+
+export const RgRestrictedError = makeConflictError(
+  'RgRestrictedError',
+  'play is restricted by an active responsible-gambling exclusion',
+);
 
 function toGame(record: typeof game.$inferSelect) {
   return {
@@ -34,6 +40,7 @@ export class GamingService {
     private readonly drizzle: DrizzleService,
     private readonly events: EventBus,
     private readonly provider: GameAdapter,
+    private readonly playEligibility: PlayEligibilityPort,
   ) {}
 
   async listGames() {
@@ -54,6 +61,10 @@ export class GamingService {
   }
 
   async startRound(userId: User['id'], gameId: Game['id'], currency: string) {
+    if (await this.playEligibility.isRestricted(userId)) {
+      throw new RgRestrictedError();
+    }
+
     await this.getGame(gameId);
 
     const { launchUrl, token } = await this.provider.launchGame(gameId, userId, currency);

--- a/packages/core/src/compliance/AGENTS.md
+++ b/packages/core/src/compliance/AGENTS.md
@@ -12,9 +12,14 @@ Invariant: `KYC_STATUS_WRITER` is the SINGLE writer for `player.kycStatus` - pam
 
 Write surface (limits incl. a session-time limit, cooling-off 24h-6wk, self-exclusion >=6mo or permanent, server-enforced lift) plus read/monitoring surface (flags, audit-backed history). The session limit reuses `user_limit` polymorphically by `type`: money limits carry `amount` (a `decimal()`), the session-time limit carries `minutes`.
 
-Enforcement depth = block login + revoke all active sessions. NO per-transaction gating - the login block makes betting impossible transitively. Pending withdrawals are untouched (funds are not locked).
+Enforcement depth = block login + revoke all active sessions + refuse the wager itself. The login block alone is NOT sufficient: a launched game's provider token outlives our session and aggregator settlement is inbound, so revoking sessions does not stop a round already in play (ADR-0032). Pending withdrawals are untouched (funds are not locked).
 
-Login enforcement crosses the module boundary through `LOGIN_ENFORCEMENT` (a non-sealed push port in `@openora/core/contracts`, owned + bound by identity): `block` sets `user.rgBlocked`/`rgBlockedUntil` and revokes all sessions, `unblock` clears them. Compliance drives the port only - never the identity schema. Cooling-off auto-expires by the `now >= rgBlockedUntil` compare - there is no unblock job.
+Enforcement crosses the module boundary through two non-sealed ports in `@openora/core/contracts`, both owned + bound by identity. Compliance drives them only - never the identity schema.
+
+- `LOGIN_ENFORCEMENT` (push): `block` sets `user.rgBlocked`/`rgBlockedUntil` and revokes all sessions, `unblock` clears them.
+- `PLAY_ELIGIBILITY` (read): gaming's `startRound` and wallet's `debit` (only `type: 'bet'`) refuse a restricted player, fail-closed, unknown user included. `win`/`loss` stay ungated - they settle an already-staked round rather than opening a new one.
+
+Cooling-off auto-expires by the `now >= rgBlockedUntil` compare - there is no unblock job. An admin can also end one early via `liftCoolingOff` (mandatory reason, NO confirm gate - unlike self-exclusion, a cooling-off is a support action that must stay reversible); `syncEnforcement` then recomputes and keeps the block if a self-exclusion is still active.
 
 Monitoring is queue-based: `wallet.deposit.completed` / `gaming.round.ended` / `rg.exclusion.login_blocked` enqueue per-player `rg-eval` jobs (idempotencyKey + orderingKey:userId) off the hot path; a worker upserts/clears `rg_flag` rows at the 80% band; a recurring `rg-monitor` job (everyMs 60_000 + cron for a durable overlay) raises session-time flags. Pure eval helpers (`periodWindow`/`thresholdPct`/`isAtThreshold`) live in `service/rg-eval.ts`, DB-free. Cross-domain reads go through `/schema` subpaths only (wallet, casino/gaming for spend aggregation, pam/identity `session` for the sweep).
 

--- a/packages/core/src/compliance/__tests__/rg.contract.test.ts
+++ b/packages/core/src/compliance/__tests__/rg.contract.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   ActivateCoolingOffInputSchema,
   ActivateSelfExclusionInputSchema,
+  LiftCoolingOffInputSchema,
   LiftSelfExclusionInputSchema,
   RgFlagListItemSchema,
   SetPlayerLimitInputSchema,
@@ -147,6 +148,16 @@ describe('ActivateSelfExclusionInputSchema', () => {
         confirm: false,
       }).success,
     ).toBe(false);
+  });
+});
+
+describe('LiftCoolingOffInputSchema', () => {
+  it('requires a non-empty reason and takes no confirm flag', () => {
+    expect(LiftCoolingOffInputSchema.safeParse({ userId: USER, reason: 'x' }).success).toBe(true);
+    expect(LiftCoolingOffInputSchema.safeParse({ userId: USER, reason: '' }).success).toBe(false);
+    expect(LiftCoolingOffInputSchema.safeParse({ userId: USER, reason: '   ' }).success).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/core/src/compliance/__tests__/rg.router.test.ts
+++ b/packages/core/src/compliance/__tests__/rg.router.test.ts
@@ -6,7 +6,11 @@ import { mock, adminCaller, testContext } from '../../testing/mock.js';
 import { createComplianceRouter } from '../router/index.js';
 import type { ComplianceService } from '../service/compliance.service.js';
 import type { KycVerificationService } from '../service/kyc.service.js';
-import { RgService, ExclusionPeriodNotElapsedError } from '../service/rg.service.js';
+import {
+  RgService,
+  ExclusionPeriodNotElapsedError,
+  ExclusionNotFoundError,
+} from '../service/rg.service.js';
 import type { RgMonitoringService } from '../service/rg-monitoring.service.js';
 
 const CTX = testContext();
@@ -93,6 +97,51 @@ describe('compliance RG router authz', () => {
       { context: CTX },
     );
     expect(setPlayerLimit).toHaveBeenCalledWith(USER, expect.any(Object), 'admin-1', {
+      ip: null,
+      userAgent: null,
+    });
+  });
+
+  it('liftCoolingOff requires compliance:manage-rg', async () => {
+    const router = build(fakeGuard([]));
+    await expect(
+      call(router.liftCoolingOff, { userId: USER, reason: 'x' }, { context: CTX }),
+    ).rejects.toBeInstanceOf(ORPCError);
+  });
+
+  it('maps a missing cooling-off to a NOT_FOUND error', async () => {
+    const liftCoolingOff = vi.fn().mockRejectedValue(new ExclusionNotFoundError(USER));
+    const router = build(fakeGuard(['compliance:manage-rg']), { liftCoolingOff });
+    await expect(
+      call(router.liftCoolingOff, { userId: USER, reason: 'x' }, { context: CTX }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('passes the caller id to liftCoolingOff when authorized', async () => {
+    const now = new Date().toISOString();
+    const liftCoolingOff = vi.fn().mockResolvedValue({
+      id: '33333333-3333-4333-8333-333333333333',
+      userId: USER,
+      kind: 'cooling_off',
+      status: 'lifted',
+      reason: 'support request',
+      isPermanent: false,
+      startsAt: now,
+      expiresAt: now,
+      liftedAt: now,
+      liftedReason: 'raised in error',
+      liftedBy: '44444444-4444-4444-8444-444444444444',
+      createdBy: '44444444-4444-4444-8444-444444444444',
+      createdAt: now,
+      updatedAt: now,
+    });
+    const router = build(fakeGuard(['compliance:manage-rg']), { liftCoolingOff });
+    await call(
+      router.liftCoolingOff,
+      { userId: USER, reason: 'raised in error' },
+      { context: CTX },
+    );
+    expect(liftCoolingOff).toHaveBeenCalledWith(USER, expect.any(Object), 'admin-1', {
       ip: null,
       userAgent: null,
     });

--- a/packages/core/src/compliance/__tests__/rg.service.test.ts
+++ b/packages/core/src/compliance/__tests__/rg.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { DrizzleService } from '@openora/core/server';
-import type { LoginEnforcementPort } from '@openora/core/contracts';
+import { domainEventSchemas, type LoginEnforcementPort } from '@openora/core/contracts';
 import { mock, mockDb } from '../../testing/mock.js';
 import { userLimit, rgExclusion } from '../schema/index.js';
 import {
@@ -113,6 +113,9 @@ function exclusionRow(overrides: Record<string, unknown> = {}) {
 
 const USER = 'user-1';
 const ADMIN = 'admin-1';
+const USER_UUID = '11111111-1111-4111-8111-111111111111';
+const ADMIN_UUID = '22222222-2222-4222-8222-222222222222';
+const EXCLUSION_UUID = '33333333-3333-4333-8333-333333333333';
 const future = () => new Date(Date.now() + 200 * 24 * 3600_000);
 
 describe('RgService.setPlayerLimit', () => {
@@ -207,8 +210,38 @@ describe('RgService.activateSelfExclusion', () => {
     expect(enforcement.block).toHaveBeenCalledWith(USER, { until: null });
     expect(events.emit).toHaveBeenCalledWith(
       'rg.self_exclusion.activated',
-      expect.objectContaining({ isPermanent: true, expiresAt: null }),
+      expect.objectContaining({ isPermanent: true, durationMonths: null, expiresAt: null }),
     );
+  });
+
+  it('carries the chosen term and a matching expiry for a fixed-term exclusion', async () => {
+    const expiresAt = future();
+    const row = exclusionRow({
+      id: EXCLUSION_UUID,
+      userId: USER_UUID,
+      isPermanent: false,
+      expiresAt,
+    });
+    const db = routingDb({
+      rgExclusion: [[], [{ kind: 'self_exclusion', expiresAt }]],
+      returning: [row],
+    });
+    const { svc, events, enforcement } = newSvc(db);
+    await svc.activateSelfExclusion(
+      USER_UUID,
+      { userId: USER_UUID, isPermanent: false, durationMonths: 6, reason: 'stop', confirm: true },
+      ADMIN_UUID,
+    );
+    expect(enforcement.block).toHaveBeenCalledWith(USER_UUID, { until: null });
+    const [topic, payload] = events.emit.mock.calls[0] ?? [];
+    expect(topic).toBe('rg.self_exclusion.activated');
+    expect(domainEventSchemas['rg.self_exclusion.activated'].parse(payload)).toMatchObject({
+      isPermanent: false,
+      durationMonths: 6,
+      reason: 'stop',
+      actorId: ADMIN_UUID,
+      userId: USER_UUID,
+    });
   });
 });
 

--- a/packages/core/src/compliance/__tests__/rg.service.test.ts
+++ b/packages/core/src/compliance/__tests__/rg.service.test.ts
@@ -267,3 +267,71 @@ describe('RgService.liftSelfExclusion', () => {
     expect(enforcement.unblock).not.toHaveBeenCalled();
   });
 });
+
+describe('RgService.liftCoolingOff', () => {
+  const coolingOffRow = (overrides: Record<string, unknown> = {}) =>
+    exclusionRow({ kind: 'cooling_off', expiresAt: future(), ...overrides });
+
+  it('rejects when the player has no active cooling-off', async () => {
+    const { svc } = newSvc(routingDb({ rgExclusion: [[]] }));
+    await expect(svc.liftCoolingOff(USER, { userId: USER, reason: 'ok' }, ADMIN)).rejects.toThrow(
+      ExclusionNotFoundError,
+    );
+  });
+
+  it('lifts before expiry and unblocks when nothing else is active', async () => {
+    const existing = coolingOffRow();
+    const db = routingDb({
+      rgExclusion: [[existing], []],
+      returning: [{ ...existing, status: 'lifted' }],
+    });
+    const { svc, events, enforcement } = newSvc(db);
+
+    const lifted = await svc.liftCoolingOff(
+      USER,
+      { userId: USER, reason: 'raised in error' },
+      ADMIN,
+    );
+
+    expect(lifted.status).toBe('lifted');
+    expect(enforcement.unblock).toHaveBeenCalledWith(USER);
+    expect(events.emit).toHaveBeenCalledWith(
+      'rg.cooling_off.lifted',
+      expect.objectContaining({ userId: USER, actorId: ADMIN, reason: 'raised in error' }),
+    );
+  });
+
+  it('keeps an indefinite block when the player is also self-excluded', async () => {
+    const existing = coolingOffRow();
+    const db = routingDb({
+      rgExclusion: [[existing], [{ kind: 'self_exclusion', expiresAt: null }]],
+      returning: [{ ...existing, status: 'lifted' }],
+    });
+    const { svc, enforcement } = newSvc(db);
+
+    await svc.liftCoolingOff(USER, { userId: USER, reason: 'ok' }, ADMIN);
+
+    expect(enforcement.block).toHaveBeenCalledWith(USER, { until: null });
+    expect(enforcement.unblock).not.toHaveBeenCalled();
+  });
+
+  it('records the actor and reason on the lifted row', async () => {
+    const existing = coolingOffRow();
+    const db = routingDb({
+      rgExclusion: [[existing], []],
+      returning: [
+        { ...existing, status: 'lifted', liftedBy: ADMIN, liftedReason: 'support ticket 42' },
+      ],
+    });
+    const { svc } = newSvc(db);
+
+    const lifted = await svc.liftCoolingOff(
+      USER,
+      { userId: USER, reason: 'support ticket 42' },
+      ADMIN,
+    );
+
+    expect(lifted.liftedBy).toBe(ADMIN);
+    expect(lifted.liftedReason).toBe('support ticket 42');
+  });
+});

--- a/packages/core/src/compliance/contract/rg.ts
+++ b/packages/core/src/compliance/contract/rg.ts
@@ -81,6 +81,14 @@ export const LiftSelfExclusionInputSchema = z.object({
 });
 export type LiftSelfExclusionInput = z.infer<typeof LiftSelfExclusionInputSchema>;
 
+// No `confirm` gate, unlike self-exclusion: a cooling-off is a support convenience an
+// admin must be able to undo (wrong player, wrong duration), not a regulatory lock.
+export const LiftCoolingOffInputSchema = z.object({
+  userId: UuidSchema,
+  reason: z.string().trim().min(1),
+});
+export type LiftCoolingOffInput = z.infer<typeof LiftCoolingOffInputSchema>;
+
 export const RgSectionSchema = z.object({
   limits: z.array(LimitSchema),
   coolingOff: RgExclusionSchema.nullable(),
@@ -168,6 +176,11 @@ export const rgContract = {
   liftSelfExclusion: oc
     .route({ method: 'POST', path: '/compliance/players/{userId}/self-exclusion/lift' })
     .input(LiftSelfExclusionInputSchema)
+    .output(RgExclusionSchema),
+
+  liftCoolingOff: oc
+    .route({ method: 'POST', path: '/compliance/players/{userId}/cooling-off/lift' })
+    .input(LiftCoolingOffInputSchema)
     .output(RgExclusionSchema),
 
   getRgSection: oc

--- a/packages/core/src/compliance/contract/rg.ts
+++ b/packages/core/src/compliance/contract/rg.ts
@@ -81,8 +81,6 @@ export const LiftSelfExclusionInputSchema = z.object({
 });
 export type LiftSelfExclusionInput = z.infer<typeof LiftSelfExclusionInputSchema>;
 
-// No `confirm` gate, unlike self-exclusion: a cooling-off is a support convenience an
-// admin must be able to undo (wrong player, wrong duration), not a regulatory lock.
 export const LiftCoolingOffInputSchema = z.object({
   userId: UuidSchema,
   reason: z.string().trim().min(1),

--- a/packages/core/src/compliance/plugin.ts
+++ b/packages/core/src/compliance/plugin.ts
@@ -10,6 +10,7 @@ import {
   LOGIN_ENFORCEMENT,
   PLATFORM_CONFIG,
   SEND_EMAIL,
+  EMAIL_TEMPLATE_RENDERER,
   UuidSchema,
   domainEventSchemas,
   queue,
@@ -155,6 +156,7 @@ export default definePlugin({
         loginEnforcement: c.get(LOGIN_ENFORCEMENT),
         email: c.has(SEND_EMAIL) ? c.get(SEND_EMAIL) : null,
         directory,
+        templateRenderer: c.has(EMAIL_TEMPLATE_RENDERER) ? c.get(EMAIL_TEMPLATE_RENDERER) : null,
       });
       rgRef = rg;
       const rgMonitoring = new RgMonitoringService({ drizzle: c.get(DRIZZLE), directory });

--- a/packages/core/src/compliance/router/index.ts
+++ b/packages/core/src/compliance/router/index.ts
@@ -123,6 +123,13 @@ export function createComplianceRouter({
       );
     }),
 
+    liftCoolingOff: os.liftCoolingOff.handler(async ({ input, context }) => {
+      const { userId, ip, userAgent } = await adminGuard.assert(context, 'compliance', 'manage-rg');
+      return mapErrors({ NOT_FOUND: ExclusionNotFoundError }, () =>
+        rg.liftCoolingOff(input.userId, input, userId, { ip, userAgent }),
+      );
+    }),
+
     getRgSection: os.getRgSection.handler(async ({ input, context }) => {
       await adminGuard.assert(context, 'compliance', 'view');
       return rg.getRgSection(input.userId);

--- a/packages/core/src/compliance/service/rg.service.ts
+++ b/packages/core/src/compliance/service/rg.service.ts
@@ -470,10 +470,6 @@ export class RgService {
     }
   }
 
-  // Best-effort player notification. The email port, the directory and the renderer are
-  // all optional (guarded by c.has at wiring). A lookup/render/send failure must not fail
-  // an RG action that already committed - log without PII (no email, no reason text) and
-  // move on.
   private async notify<K extends EmailTemplateKey>(
     userId: User['id'],
     key: K,

--- a/packages/core/src/compliance/service/rg.service.ts
+++ b/packages/core/src/compliance/service/rg.service.ts
@@ -239,6 +239,7 @@ export class RgService {
       actorId,
       exclusionId: row.id,
       isPermanent: input.isPermanent,
+      durationMonths: input.isPermanent ? null : (input.durationMonths ?? null),
       expiresAt: expiresAt ? expiresAt.toISOString() : null,
       reason: input.reason,
       ip: meta?.ip ?? null,

--- a/packages/core/src/compliance/service/rg.service.ts
+++ b/packages/core/src/compliance/service/rg.service.ts
@@ -11,6 +11,9 @@ import { and, eq, or, gt, lte, desc } from 'drizzle-orm';
 import type {
   LoginEnforcementPort,
   SendEmailPort,
+  EmailTemplateRenderer,
+  EmailTemplateData,
+  EmailTemplateKey,
   AdminUserDirectory,
   User,
   ClientMeta,
@@ -22,6 +25,7 @@ import type {
   RgExclusion,
   SetPlayerLimitInput,
   ActivateCoolingOffInput,
+  LiftCoolingOffInput,
   ActivateSelfExclusionInput,
   LiftSelfExclusionInput,
   RgSection,
@@ -70,6 +74,7 @@ export type RgServiceDeps = {
   loginEnforcement: LoginEnforcementPort;
   email?: SendEmailPort | null;
   directory?: AdminUserDirectory | null;
+  templateRenderer?: EmailTemplateRenderer | null;
 };
 
 /**
@@ -87,6 +92,7 @@ export class RgService {
   private readonly loginEnforcement: LoginEnforcementPort;
   private readonly email: SendEmailPort | null;
   private readonly directory: AdminUserDirectory | null;
+  private readonly templateRenderer: EmailTemplateRenderer | null;
 
   constructor(deps: RgServiceDeps) {
     this.drizzle = deps.drizzle;
@@ -94,6 +100,7 @@ export class RgService {
     this.loginEnforcement = deps.loginEnforcement;
     this.email = deps.email ?? null;
     this.directory = deps.directory ?? null;
+    this.templateRenderer = deps.templateRenderer ?? null;
   }
 
   async setPlayerLimit(
@@ -137,12 +144,12 @@ export class RgService {
       ip: meta?.ip ?? null,
       userAgent: meta?.userAgent ?? null,
     });
-    const limitDescription = input.type === 'session' ? `${input.minutes} minutes` : input.amount;
-    await this.notify(
-      userId,
-      'Your gambling limit was updated',
-      `A ${input.period} ${input.type} limit of ${limitDescription} is now active on your account.`,
-    );
+    const limitDescription = input.amount ?? `${input.minutes} minutes`;
+    await this.notify(userId, 'rgLimitUpdated', {
+      period: input.period,
+      type: input.type,
+      description: limitDescription,
+    });
     return toLimitDto(row);
   }
 
@@ -185,11 +192,7 @@ export class RgService {
       ip: meta?.ip ?? null,
       userAgent: meta?.userAgent ?? null,
     });
-    await this.notify(
-      userId,
-      'Cooling-off period activated',
-      `A cooling-off period is active on your account until ${expiresAt.toISOString()}.`,
-    );
+    await this.notify(userId, 'rgCoolingOffActivated', { expiresAt });
     return toExclusionDto(row);
   }
 
@@ -241,13 +244,10 @@ export class RgService {
       ip: meta?.ip ?? null,
       userAgent: meta?.userAgent ?? null,
     });
-    await this.notify(
-      userId,
-      'Self-exclusion activated',
-      expiresAt
-        ? `A self-exclusion is active on your account until at least ${expiresAt.toISOString()}.`
-        : 'A permanent self-exclusion is now active on your account.',
-    );
+    await this.notify(userId, 'rgSelfExclusionActivated', {
+      expiresAt,
+      isPermanent: input.isPermanent,
+    });
     return toExclusionDto(row);
   }
 
@@ -309,11 +309,59 @@ export class RgService {
       ip: meta?.ip ?? null,
       userAgent: meta?.userAgent ?? null,
     });
-    await this.notify(
+    await this.notify(userId, 'rgSelfExclusionLifted', {});
+    return toExclusionDto(row);
+  }
+
+  /**
+   * Ends an active cooling-off early. Unlike `liftSelfExclusion` there is no minimum
+   * period and no permanent variant to refuse - a cooling-off is a support action an
+   * admin must be able to reverse. `syncEnforcement` still recomputes the block from
+   * what remains, so a player who is ALSO self-excluded stays blocked after this lift.
+   */
+  async liftCoolingOff(
+    userId: User['id'],
+    input: LiftCoolingOffInput,
+    actorId: User['id'],
+    meta?: ClientMeta,
+  ): Promise<RgExclusion> {
+    const [existing] = await this.drizzle.db
+      .select()
+      .from(rgExclusion)
+      .where(
+        and(
+          eq(rgExclusion.userId, userId),
+          eq(rgExclusion.kind, 'cooling_off'),
+          eq(rgExclusion.status, 'active'),
+        ),
+      )
+      .limit(1);
+    if (!existing) {
+      throw new ExclusionNotFoundError(userId);
+    }
+
+    const now = new Date();
+    const row = await this.drizzle.db.transaction(async (tx) => {
+      const r = findOneOrThrow(
+        await tx
+          .update(rgExclusion)
+          .set({ status: 'lifted', liftedAt: now, liftedReason: input.reason, liftedBy: actorId })
+          .where(eq(rgExclusion.id, existing.id))
+          .returning(),
+        new ExclusionNotFoundError(existing.id),
+      );
+      await this.syncEnforcement(userId, tx);
+      return r;
+    });
+    this.events.emit('rg.cooling_off.lifted', {
       userId,
-      'Self-exclusion lifted',
-      'Your self-exclusion has been lifted and you can log in again.',
-    );
+      actorId,
+      exclusionId: row.id,
+      reason: input.reason,
+      ip: meta?.ip ?? null,
+      userAgent: meta?.userAgent ?? null,
+    });
+    await this.notify(userId, 'rgCoolingOffLifted', {});
     return toExclusionDto(row);
   }
 
@@ -422,11 +470,16 @@ export class RgService {
     }
   }
 
-  // Best-effort player notification. Both the email port and the directory are optional
-  // (guarded by c.has at wiring). A lookup/send failure must not fail an RG action that
-  // already committed - log without PII (no email, no reason text) and move on.
-  private async notify(userId: User['id'], subject: string, body: string) {
-    if (!this.email || !this.directory) {
+  // Best-effort player notification. The email port, the directory and the renderer are
+  // all optional (guarded by c.has at wiring). A lookup/render/send failure must not fail
+  // an RG action that already committed - log without PII (no email, no reason text) and
+  // move on.
+  private async notify<K extends EmailTemplateKey>(
+    userId: User['id'],
+    key: K,
+    data: EmailTemplateData[K],
+  ) {
+    if (!this.email || !this.directory || !this.templateRenderer) {
       return;
     }
     try {
@@ -434,6 +487,11 @@ export class RgService {
       if (!summary?.email) {
         return;
       }
+      const { subject, body } = await this.templateRenderer.render(
+        key,
+        data,
+        summary.language ?? 'en',
+      );
       await this.email.send({ to: summary.email, subject, body });
     } catch (err) {
       logger.warn({ err, userId }, 'RG player notification failed');

--- a/packages/core/src/contracts/adapters/admin-user-directory.ts
+++ b/packages/core/src/contracts/adapters/admin-user-directory.ts
@@ -45,6 +45,7 @@ export type AdminPlayerSummary = {
   username: string;
   email: string;
   kycStatus: KycStatus | null;
+  language: string | null;
 };
 
 export type AdminUserDirectory = {

--- a/packages/core/src/contracts/adapters/email-template.ts
+++ b/packages/core/src/contracts/adapters/email-template.ts
@@ -1,11 +1,34 @@
 import { createToken, type Token } from './token.js';
 
-export type EmailTemplateKey = 'verifyEmail' | 'resetPasswordOtp';
+export type EmailTemplateKey =
+  | 'verifyEmail'
+  | 'resetPasswordOtp'
+  | 'rgLimitUpdated'
+  | 'rgCoolingOffActivated'
+  | 'rgCoolingOffLifted'
+  | 'rgSelfExclusionActivated'
+  | 'rgSelfExclusionLifted';
 
 export type EmailTemplateData = {
   verifyEmail: { url: string; token: string };
   resetPasswordOtp: { otp: string };
+  rgLimitUpdated: { period: string; type: string; description: string };
+  rgCoolingOffActivated: { expiresAt: Date };
+  rgCoolingOffLifted: Record<string, never>;
+  rgSelfExclusionActivated: { expiresAt: Date | null; isPermanent: boolean };
+  rgSelfExclusionLifted: Record<string, never>;
 };
+
+// Player-facing copy states an absolute instant, so it is pinned to UTC rather than the
+// server's zone - an ISO string in an email is unreadable, a local-zone one is ambiguous.
+const formatEmailDate = (value: Date | null): string =>
+  value === null
+    ? 'further notice'
+    : `${new Intl.DateTimeFormat('en-GB', {
+        dateStyle: 'long',
+        timeStyle: 'short',
+        timeZone: 'UTC',
+      }).format(value)} UTC`;
 
 export type EmailTemplateRenderer = {
   render<K extends EmailTemplateKey>(
@@ -34,5 +57,27 @@ export const DEFAULT_EMAIL_TEMPLATES: {
   resetPasswordOtp: (data) => ({
     subject: 'Reset your password',
     body: `Your password reset code is: ${data.otp}`,
+  }),
+  rgLimitUpdated: (data) => ({
+    subject: 'Your gambling limit was updated',
+    body: `A ${data.period} ${data.type} limit of ${data.description} is now active on your account.`,
+  }),
+  rgCoolingOffActivated: (data) => ({
+    subject: 'Your cooling-off period has started',
+    body: `A cooling-off period is active on your account until ${formatEmailDate(data.expiresAt)}.\n\nYou will not be able to log in or place bets until then.`,
+  }),
+  rgCoolingOffLifted: () => ({
+    subject: 'Your cooling-off period has ended',
+    body: 'Your cooling-off period has been ended and you can log in again.',
+  }),
+  rgSelfExclusionActivated: (data) => ({
+    subject: 'Your self-exclusion has started',
+    body: data.isPermanent
+      ? 'Your account has been permanently self-excluded and you will not be able to log in.'
+      : `Your account is self-excluded until ${formatEmailDate(data.expiresAt)}.\n\nYou will not be able to log in until then.`,
+  }),
+  rgSelfExclusionLifted: () => ({
+    subject: 'Your self-exclusion has been lifted',
+    body: 'Your self-exclusion has been lifted and you can log in again.',
   }),
 };

--- a/packages/core/src/contracts/adapters/email-template.ts
+++ b/packages/core/src/contracts/adapters/email-template.ts
@@ -19,8 +19,6 @@ export type EmailTemplateData = {
   rgSelfExclusionLifted: Record<string, never>;
 };
 
-// Player-facing copy states an absolute instant, so it is pinned to UTC rather than the
-// server's zone - an ISO string in an email is unreadable, a local-zone one is ambiguous.
 const formatEmailDate = (value: Date | null): string =>
   value === null
     ? 'further notice'

--- a/packages/core/src/contracts/adapters/index.ts
+++ b/packages/core/src/contracts/adapters/index.ts
@@ -147,3 +147,5 @@ export { IDENTITY_OPTIONS, SESSION_COMMANDS } from './identity.js';
 
 export type { LoginEnforcementPort } from './login-enforcement.js';
 export { LOGIN_ENFORCEMENT } from './login-enforcement.js';
+export type { PlayEligibilityPort } from './play-eligibility.js';
+export { PLAY_ELIGIBILITY } from './play-eligibility.js';

--- a/packages/core/src/contracts/adapters/play-eligibility.ts
+++ b/packages/core/src/contracts/adapters/play-eligibility.ts
@@ -1,0 +1,17 @@
+import { createToken, type Token } from './token.js';
+
+/**
+ * Read port for Responsible-Gambling play enforcement. Owned + bound by the identity
+ * module (it owns the `user` table and the `rgBlocked`/`rgBlockedUntil` projection that
+ * `LOGIN_ENFORCEMENT` writes). Gaming and wallet depend only on this port to refuse a
+ * wager, never on the identity schema.
+ *
+ * A cooling-off whose `rgBlockedUntil` has elapsed reports `false` without waiting for
+ * the expiry sweep, matching the login gate's lazy-expiry behaviour.
+ */
+export type PlayEligibilityPort = {
+  isRestricted(userId: string): Promise<boolean>;
+};
+
+export const PLAY_ELIGIBILITY: Token<PlayEligibilityPort> =
+  createToken<PlayEligibilityPort>('PLAY_ELIGIBILITY');

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -203,11 +203,14 @@ export const domainEventSchemas = {
   'rg.cooling_off.activated': actorReasonBase
     .extend({ userId: UuidSchema, exclusionId: UuidSchema, expiresAt: TimestampSchema })
     .extend(authContextBase.shape),
+  // durationMonths is the admin's chosen term, null when permanent - the regulatory
+  // export reads the decision as made rather than re-deriving it from expiresAt.
   'rg.self_exclusion.activated': actorReasonBase
     .extend({
       userId: UuidSchema,
       exclusionId: UuidSchema,
       isPermanent: z.boolean(),
+      durationMonths: z.number().int().nullable(),
       expiresAt: TimestampSchema.nullable(),
     })
     .extend(authContextBase.shape),
@@ -316,7 +319,8 @@ export const domainEventVersions: Partial<Record<DomainEventName, number>> = {
   // pair (money limit vs session-time limit), never a JS number.
   'rg.limit.set': 2,
   // v2: permanent renamed to isPermanent (non-predicate boolean naming rule).
-  'rg.self_exclusion.activated': 2,
+  // v3: durationMonths added - the chosen term, explicit for the regulatory export.
+  'rg.self_exclusion.activated': 3,
 };
 
 export function getEventVersion(event: string): number {

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -219,7 +219,7 @@ export const domainEventSchemas = {
     .extend(authContextBase.shape),
   'rg.cooling_off.lifted': actorReasonBase
     .extend({ userId: UuidSchema, exclusionId: UuidSchema })
-    .merge(authContextBase),
+    .extend(authContextBase.shape),
   'rg.exclusion.login_blocked': authContextBase.extend({ userId: UuidSchema }),
 
   // A player's KYC status changed. userId = subject player; actorId = the admin who

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -214,6 +214,9 @@ export const domainEventSchemas = {
   'rg.self_exclusion.lifted': actorReasonBase
     .extend({ userId: UuidSchema, exclusionId: UuidSchema, kind: ExclusionKindSchema })
     .extend(authContextBase.shape),
+  'rg.cooling_off.lifted': actorReasonBase
+    .extend({ userId: UuidSchema, exclusionId: UuidSchema })
+    .merge(authContextBase),
   'rg.exclusion.login_blocked': authContextBase.extend({ userId: UuidSchema }),
 
   // A player's KYC status changed. userId = subject player; actorId = the admin who

--- a/packages/core/src/pam/identity/__tests__/play-eligibility.test.ts
+++ b/packages/core/src/pam/identity/__tests__/play-eligibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { makeDrizzle } from '../../../testing/mock.js';
+import { PlayEligibilityService } from '../service/play-eligibility.service.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function serviceFor(rows: Record<string, unknown>[]) {
+  return new PlayEligibilityService(makeDrizzle({ select: [rows] }));
+}
+
+describe('PlayEligibilityService', () => {
+  it('reports an indefinitely blocked player as restricted', async () => {
+    const svc = serviceFor([{ rgBlocked: true, rgBlockedUntil: null }]);
+
+    await expect(svc.isRestricted('user-1')).resolves.toBe(true);
+  });
+
+  it('reports a cooling-off still in its window as restricted', async () => {
+    const svc = serviceFor([{ rgBlocked: true, rgBlockedUntil: new Date(Date.now() + HOUR_MS) }]);
+
+    await expect(svc.isRestricted('user-1')).resolves.toBe(true);
+  });
+
+  it('reports an elapsed cooling-off as unrestricted before the expiry sweep runs', async () => {
+    const svc = serviceFor([{ rgBlocked: true, rgBlockedUntil: new Date(Date.now() - HOUR_MS) }]);
+
+    await expect(svc.isRestricted('user-1')).resolves.toBe(false);
+  });
+
+  it('reports an unblocked player as unrestricted', async () => {
+    const svc = serviceFor([{ rgBlocked: false, rgBlockedUntil: null }]);
+
+    await expect(svc.isRestricted('user-1')).resolves.toBe(false);
+  });
+
+  it('fails closed for an unknown user', async () => {
+    const svc = serviceFor([]);
+
+    await expect(svc.isRestricted('ghost')).resolves.toBe(true);
+  });
+});

--- a/packages/core/src/pam/identity/admin-user-directory.ts
+++ b/packages/core/src/pam/identity/admin-user-directory.ts
@@ -121,6 +121,7 @@ export class DrizzleAdminUserDirectory implements AdminUserDirectory {
         username: player.displayName,
         kycStatus: player.kycStatus,
         email: user.email,
+        language: user.language,
       })
       .from(player)
       .innerJoin(user, eq(player.userId, user.id))
@@ -130,9 +131,7 @@ export class DrizzleAdminUserDirectory implements AdminUserDirectory {
       // so the port's KycStatus contract holds without a cast.
       const kyc = KycStatusSchema.safeParse(r.kycStatus);
       return {
-        userId: r.userId,
-        username: r.username,
-        email: r.email,
+        ...r,
         kycStatus: kyc.success ? kyc.data : null,
       };
     });

--- a/packages/core/src/pam/identity/plugin.ts
+++ b/packages/core/src/pam/identity/plugin.ts
@@ -4,6 +4,7 @@ import {
   IDENTITY_READER,
   KYC_ADAPTER,
   LOGIN_ENFORCEMENT,
+  PLAY_ELIGIBILITY,
   NOTIFICATION_DELIVERY_ADAPTER,
   SEND_EMAIL,
   EMAIL_TEMPLATE_RENDERER,
@@ -24,6 +25,7 @@ import { createIdentityRouter } from './router/index.js';
 import { IdentityService } from './service/identity.service.js';
 import { SessionService } from './service/session.service.js';
 import { LoginEnforcementService } from './service/login-enforcement.service.js';
+import { PlayEligibilityService } from './service/play-eligibility.service.js';
 
 export default definePlugin({
   id: 'identity',
@@ -54,6 +56,9 @@ export default definePlugin({
           new SessionService({ drizzle: c.get(DRIZZLE), events: c.get(EVENT_BUS) }),
         ),
     );
+    // RG wager gate. Gaming and wallet refuse a bet through this port so a restricted
+    // player cannot keep playing on a session that outlived the block.
+    ctx.provide(PLAY_ELIGIBILITY, (c) => new PlayEligibilityService(c.get(DRIZZLE)));
     ctx.provide(SESSION_COMMANDS, (c) => {
       const sessionSvc = new SessionService({ drizzle: c.get(DRIZZLE), events: c.get(EVENT_BUS) });
       return {

--- a/packages/core/src/pam/identity/plugin.ts
+++ b/packages/core/src/pam/identity/plugin.ts
@@ -56,8 +56,6 @@ export default definePlugin({
           new SessionService({ drizzle: c.get(DRIZZLE), events: c.get(EVENT_BUS) }),
         ),
     );
-    // RG wager gate. Gaming and wallet refuse a bet through this port so a restricted
-    // player cannot keep playing on a session that outlived the block.
     ctx.provide(PLAY_ELIGIBILITY, (c) => new PlayEligibilityService(c.get(DRIZZLE)));
     ctx.provide(SESSION_COMMANDS, (c) => {
       const sessionSvc = new SessionService({ drizzle: c.get(DRIZZLE), events: c.get(EVENT_BUS) });

--- a/packages/core/src/pam/identity/service/play-eligibility.service.ts
+++ b/packages/core/src/pam/identity/service/play-eligibility.service.ts
@@ -1,0 +1,25 @@
+import { DrizzleService } from '@openora/core/server';
+import { eq } from 'drizzle-orm';
+import type { PlayEligibilityPort, User } from '@openora/core/contracts';
+import { user } from '../schema/index.js';
+import { isRgBlocked } from './rg-guard.service.js';
+
+// Identity-owned reader for the PLAY_ELIGIBILITY port, sharing the `isRgBlocked`
+// predicate with the login gate so a wager and a login can never disagree about
+// whether a player is restricted. An unknown user is treated as restricted: the
+// gate fails closed rather than letting an unresolvable caller wager.
+export class PlayEligibilityService implements PlayEligibilityPort {
+  constructor(private readonly drizzle: DrizzleService) {}
+
+  async isRestricted(userId: User['id']): Promise<boolean> {
+    const [row] = await this.drizzle.db
+      .select({ rgBlocked: user.rgBlocked, rgBlockedUntil: user.rgBlockedUntil })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    if (!row) {
+      return true;
+    }
+    return isRgBlocked(row);
+  }
+}

--- a/packages/core/src/pam/identity/service/play-eligibility.service.ts
+++ b/packages/core/src/pam/identity/service/play-eligibility.service.ts
@@ -4,10 +4,6 @@ import type { PlayEligibilityPort, User } from '@openora/core/contracts';
 import { user } from '../schema/index.js';
 import { isRgBlocked } from './rg-guard.service.js';
 
-// Identity-owned reader for the PLAY_ELIGIBILITY port, sharing the `isRgBlocked`
-// predicate with the login gate so a wager and a login can never disagree about
-// whether a player is restricted. An unknown user is treated as restricted: the
-// gate fails closed rather than letting an unresolvable caller wager.
 export class PlayEligibilityService implements PlayEligibilityPort {
   constructor(private readonly drizzle: DrizzleService) {}
 

--- a/packages/core/src/wallet/__tests__/wallet-commands.service.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-commands.service.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import type { WalletTransactionType } from '@openora/core/contracts';
-import { WalletCommandsService } from '../service/wallet-commands.service.js';
+import { describe, it, expect, vi } from 'vitest';
+import type { PlayEligibilityPort, WalletTransactionType } from '@openora/core/contracts';
+import { mock } from '../../testing/mock.js';
+import {
+  WalletCommandsService,
+  WalletRgRestrictedError,
+} from '../service/wallet-commands.service.js';
 
 type Row = Record<string, unknown>;
 
@@ -34,8 +38,34 @@ function makeTxn({ walletRow, updateReturns }: { walletRow?: Row; updateReturns?
   return { txn, inserts, calls };
 }
 
-const svc = new WalletCommandsService();
+const eligibility = (isRestricted: boolean) =>
+  mock<PlayEligibilityPort>({ isRestricted: vi.fn().mockResolvedValue(isRestricted) });
+
+const svc = new WalletCommandsService(eligibility(false));
 const usdWallet = { id: 'w1', userId: 'u1', balance: '100', currency: 'USD' };
+
+describe('WalletCommandsService responsible-gambling gate', () => {
+  it('refuses a bet debit for a restricted player without touching the ledger', async () => {
+    const restricted = new WalletCommandsService(eligibility(true));
+    const { txn, inserts, calls } = makeTxn({ walletRow: usdWallet });
+
+    await expect(
+      restricted.debit(txn, { userId: 'u1', amount: '10', type: 'bet' }),
+    ).rejects.toBeInstanceOf(WalletRgRestrictedError);
+    expect(calls.update).toBe(0);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('leaves a non-bet debit unaffected for a restricted player', async () => {
+    const restricted = new WalletCommandsService(eligibility(true));
+    const { txn, inserts } = makeTxn({ walletRow: usdWallet });
+
+    const res = await restricted.debit(txn, { userId: 'u1', amount: '0', type: 'loss' });
+
+    expect(res).toEqual({ ok: true, newBalance: '100' });
+    expect(inserts[0]).toMatchObject({ type: 'loss' });
+  });
+});
 
 describe('WalletCommandsService.debit', () => {
   it('debits the balance and writes a completed bet ledger row', async () => {

--- a/packages/core/src/wallet/plugin.ts
+++ b/packages/core/src/wallet/plugin.ts
@@ -10,6 +10,7 @@ import {
   PLATFORM_CONFIG,
   RATE_LIMITER,
   PLAYER_TAGS,
+  PLAY_ELIGIBILITY,
   AUDIT_WRITER,
 } from '@openora/core/contracts';
 import { WalletService } from './service/wallet.service.js';
@@ -38,7 +39,7 @@ export default definePlugin({
       return new HmacPaymentWebhookVerifier(webhookSecret);
     });
     // Other modules debit through this port within their own transaction (never importing wallet tables). See ADR-0016.
-    ctx.provide(WALLET_COMMANDS, () => new WalletCommandsService());
+    ctx.provide(WALLET_COMMANDS, (c) => new WalletCommandsService(c.get(PLAY_ELIGIBILITY)));
     // Read-only queries for cross-module consumers (eg tag evaluation). Never exposes wallet internals.
     ctx.provide(WALLET_READER, (c) => new WalletReaderService(c.get(DRIZZLE)));
     ctx.provide(ADMIN_WALLET_REPORTING, (c) => new DrizzleAdminWalletReporting(c.get(DRIZZLE)));

--- a/packages/core/src/wallet/service/wallet-commands.service.ts
+++ b/packages/core/src/wallet/service/wallet-commands.service.ts
@@ -52,8 +52,6 @@ export class WalletCommandsService implements WalletCommands {
   async debit(tx: unknown, { userId, amount, type }: WalletDebitArgs): Promise<WalletDebitOutcome> {
     const txn = tx as DrizzleDb;
 
-    // Only the stake is gated. `loss`/`win` settle a round that was already staked, and
-    // refusing them would strand an in-flight round rather than protect the player.
     if (type === 'bet' && (await this.playEligibility.isRestricted(userId))) {
       throw new WalletRgRestrictedError();
     }

--- a/packages/core/src/wallet/service/wallet-commands.service.ts
+++ b/packages/core/src/wallet/service/wallet-commands.service.ts
@@ -1,4 +1,5 @@
 import type {
+  PlayEligibilityPort,
   WalletCommands,
   WalletDebitArgs,
   WalletDebitOutcome,
@@ -6,7 +7,7 @@ import type {
   WalletCreditOutcome,
   WalletTransactionType,
 } from '@openora/core/contracts';
-import { createDomainError, type DrizzleDb } from '@openora/core/server';
+import { createDomainError, makeConflictError, type DrizzleDb } from '@openora/core/server';
 import { and, eq, gte, sql } from 'drizzle-orm';
 import { wallet, walletTransaction } from '../schema/index.js';
 import { railFor } from './wallet.service.js';
@@ -23,7 +24,14 @@ export const WalletCommandAmountError = createDomainError<[operation: string, am
 // (status `completed`, internal settlement so no provider ref) so gameplay shows in
 // transaction history. The `balance >= amount` guard in the UPDATE makes concurrent
 // debits safe (a lost race updates zero rows and we report the shortfall).
+export const WalletRgRestrictedError = makeConflictError(
+  'WalletRgRestrictedError',
+  'wager is restricted by an active responsible-gambling exclusion',
+);
+
 export class WalletCommandsService implements WalletCommands {
+  constructor(private readonly playEligibility: PlayEligibilityPort) {}
+
   // Completed, internal-settlement ledger row (no provider ref) shared by every gameplay move.
   private writeLedgerRow(
     txn: DrizzleDb,
@@ -43,6 +51,12 @@ export class WalletCommandsService implements WalletCommands {
 
   async debit(tx: unknown, { userId, amount, type }: WalletDebitArgs): Promise<WalletDebitOutcome> {
     const txn = tx as DrizzleDb;
+
+    // Only the stake is gated. `loss`/`win` settle a round that was already staked, and
+    // refusing them would strand an in-flight round rather than protect the player.
+    if (type === 'bet' && (await this.playEligibility.isRestricted(userId))) {
+      throw new WalletRgRestrictedError();
+    }
 
     // `loss` is informational (stake already left at bet time): 0-amount row, balance untouched. Every other debit is real money.
     if (type !== 'loss' && Number(amount) <= 0) {

--- a/packages/testing/src/__tests__/rg.e2e.test.ts
+++ b/packages/testing/src/__tests__/rg.e2e.test.ts
@@ -210,6 +210,35 @@ describe('RG limits, cooling-off, self-exclusion happy path', () => {
   });
 });
 
+describe('RG self-exclusion leaves player funds unlocked', () => {
+  it('keeps a pending withdrawal in the admin queue and approvable after the exclusion lands', async () => {
+    const email = `rg-withdraw-${randomUUID()}@e2e.test`;
+    const { client, userId } = await registerPlayer(email);
+
+    const depositRes = await client.post('/wallet/deposit', { amount: '50', currency: 'USD' });
+    expect(depositRes.status).toBe(200);
+    const withdrawRes = await client.post('/wallet/withdraw', { amount: '20', currency: 'USD' });
+    expect(withdrawRes.status).toBe(200);
+    const withdrawalId = (await readJson(withdrawRes)).transactionId as string;
+
+    const exclusionRes = await admin.post(`/compliance/players/${userId}/self-exclusion`, {
+      isPermanent: true,
+      reason: 'player requested, permanent',
+      confirm: true,
+    });
+    expect(exclusionRes.status).toBe(200);
+
+    const queueRes = await admin.get('/wallet/withdrawals?status=pending&currency=USD&limit=100');
+    expect(queueRes.status).toBe(200);
+    const queued = (await readJson(queueRes)).items as Array<{ transactionId: string }>;
+    expect(queued.map((i) => i.transactionId)).toContain(withdrawalId);
+
+    const approveRes = await admin.post(`/wallet/withdrawals/${withdrawalId}/approve`, {});
+    expect(approveRes.status).toBe(200);
+    expect((await readJson(approveRes)).status).not.toBe('pending');
+  });
+});
+
 describe('RG login enforcement', () => {
   it('blocks login + revokes sessions after cooling-off; wrong password stays indistinguishable pre-auth', async () => {
     const email = `rg-enforce-cooloff-${randomUUID()}@e2e.test`;
@@ -645,7 +674,14 @@ describe('RG audit trail', () => {
       const body = await readJson(res);
       expect(body.items).toHaveLength(1);
       expect(body.items[0].actorType).toBe('admin');
-      expect(body.items[0].after).toMatchObject({ isPermanent: false });
+      expect(body.items[0].after).toMatchObject({
+        isPermanent: false,
+        durationMonths: 6,
+        reason: 'audit trail check',
+        actorId: expect.any(String),
+      });
+      expect(body.items[0].after.expiresAt).toEqual(expect.any(String));
+      expect(body.items[0].createdAt).toEqual(expect.any(String));
     });
 
     await vi.waitFor(async () => {

--- a/packages/testing/src/__tests__/rg.e2e.test.ts
+++ b/packages/testing/src/__tests__/rg.e2e.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
 import { loadExtensions, DRIZZLE, type Container } from '@openora/core/server';
-import { JOB_QUEUE, queue } from '@openora/core/contracts';
+import { JOB_QUEUE, PLAY_ELIGIBILITY, queue } from '@openora/core/contracts';
 import { rgExclusion } from '@openora/core/compliance/schema';
 import { user } from '@openora/core/pam/schema/identity';
 import {
@@ -267,6 +267,94 @@ describe('RG login enforcement', () => {
     expect(wrongPwRes.status).toBe(401);
     const wrongPwBody = await readJson(wrongPwRes);
     expect(String(wrongPwBody.message).toLowerCase()).not.toContain('gambling');
+  });
+});
+
+describe('RG cooling-off lift', () => {
+  const isRestricted = (userId: string) => app.container.get(PLAY_ELIGIBILITY).isRestricted(userId);
+
+  it('restores login and play when an admin lifts an active cooling-off early', async () => {
+    const email = `rg-cooloff-lift-${randomUUID()}@e2e.test`;
+    const { userId } = await registerPlayer(email);
+
+    const activateRes = await admin.post(`/compliance/players/${userId}/cooling-off`, {
+      durationHours: 1008,
+      reason: 'activated on the wrong player',
+    });
+    expect(activateRes.status).toBe(200);
+    const exclusionId = (await readJson(activateRes)).id as string;
+
+    expect((await attemptLogin(email, 'password123')).status).toBe(403);
+    await expect(isRestricted(userId)).resolves.toBe(true);
+
+    const liftRes = await admin.post(`/compliance/players/${userId}/cooling-off/lift`, {
+      reason: 'raised in error, support ticket 42',
+    });
+    expect(liftRes.status).toBe(200);
+    const lifted = await readJson(liftRes);
+    expect(lifted.status).toBe('lifted');
+    expect(lifted.liftedReason).toBe('raised in error, support ticket 42');
+    expect(await exclusionStatus(app.container, exclusionId)).toBe('lifted');
+
+    expect((await attemptLogin(email, 'password123')).status).toBe(200);
+    await expect(isRestricted(userId)).resolves.toBe(false);
+
+    const section = await readJson(await admin.get(`/compliance/players/${userId}/rg`));
+    expect(section.coolingOff).toBeNull();
+  });
+
+  it('keeps the player blocked when a self-exclusion is still active', async () => {
+    const email = `rg-cooloff-lift-se-${randomUUID()}@e2e.test`;
+    const { userId } = await registerPlayer(email);
+
+    await admin.post(`/compliance/players/${userId}/cooling-off`, {
+      durationHours: 24,
+      reason: 'short break',
+    });
+    await admin.post(`/compliance/players/${userId}/self-exclusion`, {
+      isPermanent: true,
+      reason: 'player requested, permanent',
+      confirm: true,
+    });
+
+    const liftRes = await admin.post(`/compliance/players/${userId}/cooling-off/lift`, {
+      reason: 'superseded by the self-exclusion',
+    });
+    expect(liftRes.status).toBe(200);
+
+    expect((await attemptLogin(email, 'password123')).status).toBe(403);
+    await expect(isRestricted(userId)).resolves.toBe(true);
+  });
+
+  it('rejects lifting when the player has no active cooling-off', async () => {
+    const { userId } = await registerPlayer(`rg-cooloff-lift-none-${randomUUID()}@e2e.test`);
+
+    const res = await admin.post(`/compliance/players/${userId}/cooling-off/lift`, {
+      reason: 'nothing to lift',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('records the lift in the audit trail with actor, reason and subject', async () => {
+    const { userId } = await registerPlayer(`rg-cooloff-lift-audit-${randomUUID()}@e2e.test`);
+
+    await admin.post(`/compliance/players/${userId}/cooling-off`, {
+      durationHours: 24,
+      reason: 'player requested a break',
+    });
+    await admin.post(`/compliance/players/${userId}/cooling-off/lift`, {
+      reason: 'player changed their mind',
+    });
+
+    await vi.waitFor(async () => {
+      const res = await admin.get(`/audit/logs?resourceId=${userId}&action=rg.cooling_off.lifted`);
+      const body = await readJson(res);
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].actorType).toBe('admin');
+      expect(body.items[0].resourceType).toBe('player');
+      expect(body.items[0].before).toMatchObject({ status: 'active' });
+      expect(body.items[0].after).toMatchObject({ reason: 'player changed their mind' });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Responsible-gambling exclusions were enforced only at login, which does not stop play already in flight - a launched game's provider token outlives our session and aggregator settlement is inbound, so revoking sessions never reaches it. This adds real enforcement at wager time, lets an admin end a cooling-off early, and moves the RG player emails onto the template renderer. BF-215.

## Changes

- **contracts** - new `PLAY_ELIGIBILITY` read port (`isRestricted(userId)`), modelled on `LOGIN_ENFORCEMENT`. New `rg.cooling_off.lifted` event. `AdminPlayerSummary` gains `language` so RG emails can pick a locale. Four RG template keys added to `EmailTemplateKey`/`EmailTemplateData`/`DEFAULT_EMAIL_TEMPLATES`, plus `rgLimitUpdated`.
- **pam/identity** - `PlayEligibilityService` binds the port, reading the same `rgBlocked`/`rgBlockedUntil` projection `LOGIN_ENFORCEMENT` writes and reusing the existing `isRgBlocked` predicate, so a wager and a login can never disagree (including lazy expiry). `DrizzleAdminUserDirectory` now returns `language`.
- **casino/gaming** - `startRound` refuses a restricted player before touching the provider (`RgRestrictedError` -> CONFLICT). Plugin declares `requiresPorts: [PLAY_ELIGIBILITY]`.
- **wallet** - `WalletCommandsService.debit` refuses `type: 'bet'` for a restricted player (`WalletRgRestrictedError`). `win`/`loss` stay ungated - they settle an already-staked round rather than opening a new one.
- **compliance** - new route `POST /compliance/players/{userId}/cooling-off/lift` (`compliance:manage-rg`, mandatory reason, no confirm gate) + `RgService.liftCoolingOff`. `syncEnforcement` still recomputes, so a player who is also self-excluded stays blocked. `RgService.notify` now renders through `EMAIL_TEMPLATE_RENDERER` and stays best-effort.
- **audit** - `rg.cooling_off.lifted` added to `SUBSCRIBED_TOPICS` and to the RG branch of `mapEventToRecord`, with a before-snapshot so the regulatory export stays diffable.
- **docs** - ADR-0032 records the enforcement-depth change. The `compliance/AGENTS.md` paragraph asserting "NO per-transaction gating" is corrected, since it now states the opposite of the code.

No schema change: `rg_exclusion` already carries `liftedAt`/`liftedReason`/`liftedBy`, so there is no migration.

## Acceptance criteria

- [x] Duration configurable: minimum 24 hours, maximum 6 weeks (already enforced by `ActivateCoolingOffInputSchema`)
- [x] Mandatory reason required (activation and lift)
- [x] Cooling off takes effect immediately - player cannot log in **or place bets** (the bets half is what this PR adds)
- [x] Cooling off expiry lifts the restriction automatically (unchanged; now also liftable early by an admin)
- [x] All actions recorded in audit log: actor, player, duration, reason, timestamp
- [x] Player notified via email on activation (now templated rather than an inline string)

Admin activation from the player profile RG section is consumer-side UI and is not in this repo.

## Checklist

- [x] `pnpm verify` is green (typecheck + lint + boundaries + module-shape + tests)
- [x] `pnpm verify:drift` is green (catalog / OpenAPI not stale) - run `pnpm regen` if not
- [x] New cross-module talk goes through events / command ports / contracts / the `/schema` subpath (no direct module imports)
- [ ] New data tables carry `tenantId` and are RLS-covered - N/A, no new tables
- [x] No secrets, real player data, or internal/customer names added
- [x] Docs / AGENTS.md updated if behavior or extension points changed

## Notes

- Coverage: 620 unit tests green; the RG e2e suite (21 tests, real Postgres over real HTTP) covers lift-restores-login, lift-keeps-block-when-self-excluded, lift-with-no-active-cooling-off, and the audit trail.
- The wager gate's negative path is not reachable over HTTP: activating a block revokes sessions, so a player request 401s before reaching the gate. That path is precisely the aggregator/settlement seam, so e2e asserts it through `PLAY_ELIGIBILITY` and unit tests cover both enforcement points directly.
- Fixed in passing: the limit-updated email rendered `null` for a session-time limit, since `amount` is null on that branch.
- Follow-up, deliberately out of scope: email login drops the `RG_BLOCKED` code, so a restricted player is told "invalid username or password" while phone login handles it correctly. That fix is consumer-side.

Closes BF-215
