### PR TITLE
feat(compliance): record the chosen self-exclusion term in the activation event

### DIFF
--- a/packages/core/src/compliance/__tests__/rg.service.test.ts
+++ b/packages/core/src/compliance/__tests__/rg.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { DrizzleService } from '@openora/core/server';
-import type { LoginEnforcementPort } from '@openora/core/contracts';
+import { domainEventSchemas, type LoginEnforcementPort } from '@openora/core/contracts';
 import { mock, mockDb } from '../../testing/mock.js';
 import { userLimit, rgExclusion } from '../schema/index.js';
 import {
@@ -113,6 +113,9 @@ function exclusionRow(overrides: Record<string, unknown> = {}) {
 
 const USER = 'user-1';
 const ADMIN = 'admin-1';
+const USER_UUID = '11111111-1111-4111-8111-111111111111';
+const ADMIN_UUID = '22222222-2222-4222-8222-222222222222';
+const EXCLUSION_UUID = '33333333-3333-4333-8333-333333333333';
 const future = () => new Date(Date.now() + 200 * 24 * 3600_000);
 
 describe('RgService.setPlayerLimit', () => {
@@ -207,8 +210,38 @@ describe('RgService.activateSelfExclusion', () => {
     expect(enforcement.block).toHaveBeenCalledWith(USER, { until: null });
     expect(events.emit).toHaveBeenCalledWith(
       'rg.self_exclusion.activated',
-      expect.objectContaining({ isPermanent: true, expiresAt: null }),
+      expect.objectContaining({ isPermanent: true, durationMonths: null, expiresAt: null }),
     );
+  });
+
+  it('carries the chosen term and a matching expiry for a fixed-term exclusion', async () => {
+    const expiresAt = future();
+    const row = exclusionRow({
+      id: EXCLUSION_UUID,
+      userId: USER_UUID,
+      isPermanent: false,
+      expiresAt,
+    });
+    const db = routingDb({
+      rgExclusion: [[], [{ kind: 'self_exclusion', expiresAt }]],
+      returning: [row],
+    });
+    const { svc, events, enforcement } = newSvc(db);
+    await svc.activateSelfExclusion(
+      USER_UUID,
+      { userId: USER_UUID, isPermanent: false, durationMonths: 6, reason: 'stop', confirm: true },
+      ADMIN_UUID,
+    );
+    expect(enforcement.block).toHaveBeenCalledWith(USER_UUID, { until: null });
+    const [topic, payload] = events.emit.mock.calls[0] ?? [];
+    expect(topic).toBe('rg.self_exclusion.activated');
+    expect(domainEventSchemas['rg.self_exclusion.activated'].parse(payload)).toMatchObject({
+      isPermanent: false,
+      durationMonths: 6,
+      reason: 'stop',
+      actorId: ADMIN_UUID,
+      userId: USER_UUID,
+    });
   });
 });
 

--- a/packages/core/src/compliance/service/rg.service.ts
+++ b/packages/core/src/compliance/service/rg.service.ts
@@ -239,6 +239,7 @@ export class RgService {
       actorId,
       exclusionId: row.id,
       isPermanent: input.isPermanent,
+      durationMonths: input.isPermanent ? null : (input.durationMonths ?? null),
       expiresAt: expiresAt ? expiresAt.toISOString() : null,
       reason: input.reason,
       ip: meta?.ip ?? null,

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -203,11 +203,14 @@ export const domainEventSchemas = {
   'rg.cooling_off.activated': actorReasonBase
     .extend({ userId: UuidSchema, exclusionId: UuidSchema, expiresAt: TimestampSchema })
     .merge(authContextBase),
+  // durationMonths is the admin's chosen term, null when permanent - the regulatory
+  // export reads the decision as made rather than re-deriving it from expiresAt.
   'rg.self_exclusion.activated': actorReasonBase
     .extend({
       userId: UuidSchema,
       exclusionId: UuidSchema,
       isPermanent: z.boolean(),
+      durationMonths: z.number().int().nullable(),
       expiresAt: TimestampSchema.nullable(),
     })
     .merge(authContextBase),
@@ -316,7 +319,8 @@ export const domainEventVersions: Partial<Record<DomainEventName, number>> = {
   // pair (money limit vs session-time limit), never a JS number.
   'rg.limit.set': 2,
   // v2: permanent renamed to isPermanent (non-predicate boolean naming rule).
-  'rg.self_exclusion.activated': 2,
+  // v3: durationMonths added - the chosen term, explicit for the regulatory export.
+  'rg.self_exclusion.activated': 3,
 };
 
 export function getEventVersion(event: string): number {

--- a/packages/testing/src/__tests__/rg.e2e.test.ts
+++ b/packages/testing/src/__tests__/rg.e2e.test.ts
@@ -210,6 +210,35 @@ describe('RG limits, cooling-off, self-exclusion happy path', () => {
   });
 });
 
+describe('RG self-exclusion leaves player funds unlocked', () => {
+  it('keeps a pending withdrawal in the admin queue and approvable after the exclusion lands', async () => {
+    const email = `rg-withdraw-${randomUUID()}@e2e.test`;
+    const { client, userId } = await registerPlayer(email);
+
+    const depositRes = await client.post('/wallet/deposit', { amount: '50', currency: 'USD' });
+    expect(depositRes.status).toBe(200);
+    const withdrawRes = await client.post('/wallet/withdraw', { amount: '20', currency: 'USD' });
+    expect(withdrawRes.status).toBe(200);
+    const withdrawalId = (await readJson(withdrawRes)).transactionId as string;
+
+    const exclusionRes = await admin.post(`/compliance/players/${userId}/self-exclusion`, {
+      isPermanent: true,
+      reason: 'player requested, permanent',
+      confirm: true,
+    });
+    expect(exclusionRes.status).toBe(200);
+
+    const queueRes = await admin.get('/wallet/withdrawals?status=pending&currency=USD&limit=100');
+    expect(queueRes.status).toBe(200);
+    const queued = (await readJson(queueRes)).items as Array<{ transactionId: string }>;
+    expect(queued.map((i) => i.transactionId)).toContain(withdrawalId);
+
+    const approveRes = await admin.post(`/wallet/withdrawals/${withdrawalId}/approve`, {});
+    expect(approveRes.status).toBe(200);
+    expect((await readJson(approveRes)).status).not.toBe('pending');
+  });
+});
+
 describe('RG login enforcement', () => {
   it('blocks login + revokes sessions after cooling-off; wrong password stays indistinguishable pre-auth', async () => {
     const email = `rg-enforce-cooloff-${randomUUID()}@e2e.test`;
@@ -645,7 +674,14 @@ describe('RG audit trail', () => {
       const body = await readJson(res);
       expect(body.items).toHaveLength(1);
       expect(body.items[0].actorType).toBe('admin');
-      expect(body.items[0].after).toMatchObject({ isPermanent: false });
+      expect(body.items[0].after).toMatchObject({
+        isPermanent: false,
+        durationMonths: 6,
+        reason: 'audit trail check',
+        actorId: expect.any(String),
+      });
+      expect(body.items[0].after.expiresAt).toEqual(expect.any(String));
+      expect(body.items[0].createdAt).toEqual(expect.any(String));
     });
 
     await vi.waitFor(async () => {


### PR DESCRIPTION
BF-216 - self-exclusion management. Stacked on #36; base is the BF-215 branch so this diff stays BF-216-only. Retarget to `dev` once #36 merges.

## What

Most of the self-exclusion write surface already existed. This closes the two remaining gaps.

- `rg.self_exclusion.activated` carries `durationMonths` (null when permanent), `schemaVersion` 2 -> 3. The regulatory export reads the admin's decision directly instead of re-deriving a term from `expiresAt`.
- Integration coverage for the two acceptance criteria that had none: a self-excluded player's pending withdrawal stays in the admin queue and approvable, and the audit row carries actor, subject, duration, reason and timestamp.

## Why

Deriving "6 months" from a timestamp delta is lossy the moment an exclusion is edited, migrated or re-dated, and a regulator asks what was decided, not what the row implies. Funds-not-locked was asserted nowhere - a future gate added to the withdrawal path would have shipped silently.

## Acceptance criteria

- Duration options: minimum 6 months or permanent - already enforced by `ActivateSelfExclusionInputSchema`
- Mandatory reason + confirmation before activation - already enforced
- Takes effect immediately, all active sessions terminated - `LOGIN_ENFORCEMENT.block` + covered by `rg.e2e.test.ts`
- Pending withdrawals processed normally, funds not locked - **now covered**
- Player notified by email on activation and on lift - via the RG email templates from #36
- Cannot be lifted before the minimum period; permanent can never be lifted - already enforced
- All actions in the audit log with actor, player, duration, reason, timestamp - **duration now explicit**

## Verification

`pnpm verify` (621 unit tests) + `pnpm verify:drift` green. `rg.e2e.test.ts` 22 passed against real Postgres.