### PR TITLE
feat(analytics): add financial analytics and conversion funnel reporting

### DIFF
--- a/packages/core/src/analytics/__tests__/analytics.contract.test.ts
+++ b/packages/core/src/analytics/__tests__/analytics.contract.test.ts
@@ -24,6 +24,24 @@ describe('analytics contract schemas', () => {
     expect(() => FunnelQuerySchema.parse({})).not.toThrow();
   });
 
+  it('rejects a funnel query whose dateFrom is after its dateTo', () => {
+    expect(() =>
+      FunnelQuerySchema.parse({
+        dateFrom: '2026-02-01T00:00:00.000Z',
+        dateTo: '2026-01-01T00:00:00.000Z',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a financial summary query whose dateFrom is after its dateTo', () => {
+    expect(() =>
+      FinancialSummaryQuerySchema.parse({
+        dateFrom: '2026-02-01T00:00:00.000Z',
+        dateTo: '2026-01-01T00:00:00.000Z',
+      }),
+    ).toThrow();
+  });
+
   it('rejects a funnel stage count below zero', () => {
     expect(() =>
       FunnelStageSchema.parse({ stage: 'registered', count: -1, dropOffRate: 0 }),

--- a/packages/core/src/analytics/__tests__/financial-analytics.service.test.ts
+++ b/packages/core/src/analytics/__tests__/financial-analytics.service.test.ts
@@ -16,10 +16,10 @@ describe('FinancialAnalyticsService.summary', () => {
     const drizzle = makeDrizzle({
       select: [
         [
-          { currency: 'USD', rail: 'fiat', type: 'deposit', total: '500.00' },
-          { currency: 'USD', rail: 'crypto', type: 'withdrawal', total: '120.00' },
-          { currency: 'EUR', rail: null, type: 'deposit', total: '75.00' },
+          { currency: 'USD', rail: 'fiat', total: '500.00' },
+          { currency: 'EUR', rail: null, total: '75.00' },
         ],
+        [{ currency: 'USD', rail: 'crypto', total: '120.00' }],
         [
           { currency: 'USD', netRevenue: '350.00', bonusCost: '30.00' },
           { currency: 'EUR', netRevenue: '75.00', bonusCost: '0' },

--- a/packages/core/src/analytics/service/financial-analytics.service.ts
+++ b/packages/core/src/analytics/service/financial-analytics.service.ts
@@ -78,23 +78,26 @@ export class FinancialAnalyticsService {
       baseConditions.push(eq(walletTransaction.currency, currency));
     }
 
-    const [byRail, byCurrency] = await Promise.all([
+    const totalsByRail = (type: 'deposit' | 'withdrawal') =>
       db
         .select({
           currency: walletTransaction.currency,
           rail: walletTransaction.rail,
-          type: walletTransaction.type,
           total: sql<string>`sum(${walletTransaction.amount})`,
         })
         .from(walletTransaction)
         .where(
           and(
             eq(walletTransaction.status, COMPLETED_STATUS),
-            inArray(walletTransaction.type, ['deposit', 'withdrawal']),
+            eq(walletTransaction.type, type),
             ...baseConditions,
           ),
         )
-        .groupBy(walletTransaction.currency, walletTransaction.rail, walletTransaction.type),
+        .groupBy(walletTransaction.currency, walletTransaction.rail);
+
+    const [deposits, withdrawals, byCurrency] = await Promise.all([
+      totalsByRail('deposit'),
+      totalsByRail('withdrawal'),
       db
         .select({
           currency: walletTransaction.currency,
@@ -117,12 +120,8 @@ export class FinancialAnalyticsService {
     ]);
 
     return {
-      deposits: byRail
-        .filter((r) => r.type === 'deposit')
-        .map((r) => ({ currency: r.currency, rail: r.rail, total: r.total })),
-      withdrawals: byRail
-        .filter((r) => r.type === 'withdrawal')
-        .map((r) => ({ currency: r.currency, rail: r.rail, total: r.total })),
+      deposits,
+      withdrawals,
       netRevenue: byCurrency.map((r) => ({ currency: r.currency, total: r.netRevenue })),
       bonusCost: byCurrency.map((r) => ({ currency: r.currency, total: r.bonusCost })),
     };

--- a/packages/core/src/analytics/service/funnel-analytics.service.ts
+++ b/packages/core/src/analytics/service/funnel-analytics.service.ts
@@ -84,18 +84,13 @@ export class FunnelAnalyticsService {
       first_bet: Number(row?.first_bet ?? 0),
     };
 
-    const orderedCounts = [
-      counts.registered,
-      counts.email_verified,
-      counts.first_deposit,
-      counts.first_bet,
-    ];
-
-    return FUNNEL_STAGES.map((stage, index) => ({
-      stage,
-      count: orderedCounts[index] ?? 0,
-      dropOffRate:
-        index === 0 ? 0 : dropOffRate(orderedCounts[index - 1] ?? 0, orderedCounts[index] ?? 0),
-    }));
+    return FUNNEL_STAGES.map((stage, index) => {
+      const previousStage = FUNNEL_STAGES[index - 1];
+      return {
+        stage,
+        count: counts[stage],
+        dropOffRate: previousStage ? dropOffRate(counts[previousStage], counts[stage]) : 0,
+      };
+    });
   }
 }

--- a/packages/core/src/contracts/schemas/reporting.ts
+++ b/packages/core/src/contracts/schemas/reporting.ts
@@ -1,15 +1,20 @@
 import { z } from 'zod';
 import { TimestampSchema } from './common.js';
 
-export const DateRangeSchema = z.object({
+const DateRangeShapeSchema = z.object({
   dateFrom: TimestampSchema.optional(),
   dateTo: TimestampSchema.optional(),
 });
-export type DateRange = z.infer<typeof DateRangeSchema>;
+export type DateRange = z.infer<typeof DateRangeShapeSchema>;
 
 export function isDateRangeOrdered(range: DateRange): boolean {
   return !range.dateFrom || !range.dateTo || new Date(range.dateFrom) <= new Date(range.dateTo);
 }
+
+export const DateRangeSchema = DateRangeShapeSchema.refine(
+  isDateRangeOrdered,
+  'dateFrom must be before or equal to dateTo',
+);
 
 export const GRANULARITIES = ['day', 'week', 'month'] as const;
 export const GranularitySchema = z.enum(GRANULARITIES);


### PR DESCRIPTION
## Summary

Adds a read-only financial analytics + conversion funnel domain for the backoffice dashboard (BF-219). Deposits/withdrawals by currency and rail, net revenue, bonus cost, a GGR trend, and a registration-to-first-bet conversion funnel, all grouped by currency since the platform has no FX rates.

## Changes

- New top-level domain `packages/core/src/analytics/` (module id `analytics`, published as `@openora/core/analytics`) - owns no tables, reads `wallet`/`pam/identity`/`pam/profile` via their published `/schema` subpaths.
- Two contract slices: `financial` (`GET /analytics/financial/summary`, `GET /analytics/financial/ggr`) and `funnel` (`GET /analytics/funnel/conversion`). All routes guard on the existing `analytics` permission resource and cache reads briefly via the `CACHE` port.
- Shared `DateRangeSchema` / `GranularitySchema` added to `packages/core/src/contracts/schemas/`.
- New composite indexes: `wallet_transaction (status, type, created_at)`, `wallet_transaction (wallet_id, type, status)`, `user (created_at)`.
- `docs/adr/0033-analytics-as-a-read-only-domain.md` records the domain-placement decision and alternatives rejected.
- Unit tests (service, router, contract) plus an integration test in `packages/testing` covering multi-currency splits, zero-filled ranges, and nested funnel stages against a real Postgres + real HTTP app.

## Acceptance criteria

- [x] Financial dashboard: deposits by currency and rail, withdrawals by currency and rail, net revenue, bonus cost, GGR trend over time
- [x] Filterable by date range and currency
- [x] Conversion funnel: registrations - email verified - first deposit - first bet, with drop-off rates at each stage
- [x] Funnel filterable by date range

## Checklist

- [x] `pnpm verify` is green (typecheck + lint + boundaries + module-shape + tests)
- [x] `pnpm verify:drift` is green (catalog / OpenAPI not stale)
- [x] New cross-module talk goes through events / command ports / contracts / the `/schema` subpath (no direct module imports)
- [ ] New data tables carry `tenantId` and are RLS-covered - n/a, this domain adds no tables (single-tenant platform, ADR-0026)
- [x] No secrets, real player data, or internal/customer names added
- [x] Docs / AGENTS.md updated

## Notes

- Bonus cost reports credited bonus amount only ("bonus credited vs wagered" from the source spec is not achievable - no bonus wagering model exists on the platform).
- GGR is computed from `wallet_transaction` (`bet` minus `win`), not from `game_round.betAmount`/`winAmount` - `casino/gaming` never calls `WALLET_COMMANDS`, so those columns stay unwritten today. Wiring real stake debit/win credit into gameplay is a separate, larger change to the gaming domain, out of scope here (see ADR-0033 consequences).
- The consumer-side backoffice page depends on this contract; that PR follows once this lands and a canary publishes.

Closes BF-219
