### PR TITLE
fix(analytics): use null for first funnel stage drop-off rate

### DIFF
--- a/packages/core/src/analytics/__tests__/funnel-analytics.service.test.ts
+++ b/packages/core/src/analytics/__tests__/funnel-analytics.service.test.ts
@@ -21,7 +21,7 @@ describe('FunnelAnalyticsService.conversion', () => {
     const result = await service.conversion({});
 
     expect(result).toEqual([
-      { stage: 'registered', count: 100, dropOffRate: 0 },
+      { stage: 'registered', count: 100, dropOffRate: null },
       { stage: 'email_verified', count: 80, dropOffRate: 0.2 },
       { stage: 'first_deposit', count: 40, dropOffRate: 0.5 },
       { stage: 'first_bet', count: 10, dropOffRate: 0.75 },
@@ -36,11 +36,11 @@ describe('FunnelAnalyticsService.conversion', () => {
 
     const result = await service.conversion({});
 
-    expect(result.every((stage) => stage.dropOffRate === 0)).toBe(true);
+    expect(result.slice(1).every((stage) => stage.dropOffRate === 0)).toBe(true);
   });
 
   it('serves a repeat query from cache without querying the database', async () => {
-    const cached = [{ stage: 'registered', count: 5, dropOffRate: 0 }];
+    const cached = [{ stage: 'registered', count: 5, dropOffRate: null }];
     const execute = vi.fn();
     const service = new FunnelAnalyticsService(mock({ db: { execute } }), fakeCache(cached));
 

--- a/packages/core/src/analytics/contract/funnel.ts
+++ b/packages/core/src/analytics/contract/funnel.ts
@@ -14,7 +14,7 @@ export type FunnelStageName = z.infer<typeof FunnelStageNameSchema>;
 export const FunnelStageSchema = z.object({
   stage: FunnelStageNameSchema,
   count: z.number().int().nonnegative(),
-  dropOffRate: z.number().min(0).max(1),
+  dropOffRate: z.number().min(0).max(1).nullable(),
 });
 export type FunnelStage = z.infer<typeof FunnelStageSchema>;
 

--- a/packages/core/src/analytics/service/funnel-analytics.service.ts
+++ b/packages/core/src/analytics/service/funnel-analytics.service.ts
@@ -89,7 +89,7 @@ export class FunnelAnalyticsService {
       return {
         stage,
         count: counts[stage],
-        dropOffRate: previousStage ? dropOffRate(counts[previousStage], counts[stage]) : 0,
+        dropOffRate: previousStage ? dropOffRate(counts[previousStage], counts[stage]) : null,
       };
     });
   }


### PR DESCRIPTION
## Summary

Funnel stage `dropOffRate` is now `null` for the first stage instead of `0`.

## Why

The first stage has no previous stage to compare against, so reporting `0` misrepresented it as zero drop-off rather than not applicable.

## Worth knowing

- [x] `pnpm verify` is green (typecheck + lint + boundaries + module-shape + tests)
- [x] `pnpm check:drift` is green (catalog / OpenAPI not stale) - run `pnpm regen` if not
- [x] New cross-module talk goes through events / command ports / contracts / the `/schema` subpath (no direct module imports)
- [ ] New data tables carry `tenantId` and are RLS-covered (`pnpm regen` runs `gen:rls`)
- [x] No secrets, real player data, or internal/customer names added
