### PR TITLE
feat(iam): audit access denials reported by client-side page guards

### DIFF
--- a/.changeset/iam-report-access-denied.md
+++ b/.changeset/iam-report-access-denied.md
@@ -1,0 +1,8 @@
+---
+'@openora/core': patch
+---
+
+Add `iam.reportAccessDenied` so a consumer's client-side page guard (e.g. `PermissionGate`) can produce a real audit signal: the guard's own redirect never reaches the server, so on its own it left no trail.
+
+- `POST /iam/report-access-denied` takes `{ resource, level }`, re-verifies the caller's actual permission level server-side, and only emits `identity.user.unauthorized_access` (the same event `AdminGuard` denials produce) when the caller genuinely lacks that level - a caller who actually holds the permission cannot produce a false denial entry.
+- Rate-limited per caller/resource (throttle only - a throttled repeat is silently skipped, never surfaced as an error, since this is a fire-and-forget report).

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -186,6 +186,7 @@
         "iam.listInvitations",
         "iam.listRoles",
         "iam.previewEffectivePermissions",
+        "iam.reportAccessDenied",
         "iam.setRolePermissions",
         "iam.unassignRole",
         "iam.updateRole"

--- a/packages/core/src/contracts/adapters/rate-limit.ts
+++ b/packages/core/src/contracts/adapters/rate-limit.ts
@@ -23,6 +23,7 @@ export const RATE_LIMIT_KEYS = {
   WALLET_MUTATION: 'wallet-mutation',
   CHAT_ROOM_JOIN: 'chat-room-join',
   CHAT_SEND: 'chat-send',
+  REPORT_ACCESS_DENIED: 'report-access-denied',
 } as const;
 
 export type RateLimitKeyPrefix = (typeof RATE_LIMIT_KEYS)[keyof typeof RATE_LIMIT_KEYS];

--- a/packages/core/src/iam/__tests__/iam.service.int.test.ts
+++ b/packages/core/src/iam/__tests__/iam.service.int.test.ts
@@ -2,7 +2,13 @@ import { randomUUID } from 'node:crypto';
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { mock, NO_CLIENT_META, makeEventBus } from '../../testing/mock.js';
-import { statement, findOneOrThrow, RedisCache, type ResourceName } from '@openora/core/server';
+import {
+  statement,
+  findOneOrThrow,
+  RedisCache,
+  RedisRateLimiter,
+  type ResourceName,
+} from '@openora/core/server';
 import type { SendEmailPort, SessionCommands } from '@openora/core/contracts';
 import { createTestDb, createTestRedis, type TestDb, type TestRedis } from '@openora/core/testing';
 import { migrate as migrateIam } from '@openora/core/iam/migrate';
@@ -655,6 +661,68 @@ describe('IamService paginated lists', () => {
     expect(result.total).toBe(1);
     expect(result.items).toHaveLength(1);
     expect(findOneOrThrow(result.items, new Error('expected an item')).roleName).toBe('Ops');
+  });
+});
+
+describe('IamService.reportAccessDenied', () => {
+  it('records and audits a genuine denial (caller lacks the resource/level)', async () => {
+    const events = makeEventBus();
+    const svc = new IamService(db.drizzle, events, makeEmail());
+
+    const result = await svc.reportAccessDenied({
+      resource: 'withdrawal',
+      level: 'read',
+      caller: SUPPORT_CALLER,
+    });
+
+    expect(result).toEqual({ recorded: true });
+    expect(events.emit).toHaveBeenCalledWith(
+      'identity.user.unauthorized_access',
+      expect.objectContaining({
+        userId: SUPPORT_CALLER.userId,
+        resource: 'withdrawal',
+        action: 'access',
+        role: 'support',
+      }),
+    );
+  });
+
+  it('does not record or emit when the caller genuinely holds the permission', async () => {
+    const events = makeEventBus();
+    const svc = new IamService(db.drizzle, events, makeEmail());
+
+    const result = await svc.reportAccessDenied({
+      resource: 'player',
+      level: 'read_write',
+      caller: ADMIN_CALLER,
+    });
+
+    expect(result).toEqual({ recorded: false });
+    expect(events.emit).not.toHaveBeenCalled();
+  });
+
+  it('with a rate limiter wired, a repeat report within the window is throttled and not recorded again', async () => {
+    const events = makeEventBus();
+    const limiter = new RedisRateLimiter(redis.client);
+    const svc = new IamService(db.drizzle, events, makeEmail(), undefined, limiter);
+
+    const first = await svc.reportAccessDenied({
+      resource: 'withdrawal',
+      level: 'read',
+      caller: SUPPORT_CALLER,
+    });
+    const second = await svc.reportAccessDenied({
+      resource: 'withdrawal',
+      level: 'read',
+      caller: SUPPORT_CALLER,
+    });
+
+    expect(first).toEqual({ recorded: true });
+    expect(second).toEqual({ recorded: false });
+    const denialCalls = (events.emit as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[0] === 'identity.user.unauthorized_access',
+    );
+    expect(denialCalls).toHaveLength(1);
   });
 });
 

--- a/packages/core/src/iam/contract/index.ts
+++ b/packages/core/src/iam/contract/index.ts
@@ -189,6 +189,14 @@ export const iamContract = {
   getMyPermissions: oc
     .route({ method: 'GET', path: '/iam/my-permissions' })
     .output(EffectivePermissionsSchema),
+
+  // Server-side verification for a client-side page-guard denial: the consumer's
+  // PermissionGate redirect never reaches the server on its own, so it never audits.
+  // This route re-checks the caller's actual level and records the denial only when real.
+  reportAccessDenied: oc
+    .route({ method: 'POST', path: '/iam/report-access-denied' })
+    .input(GrantInputSchema)
+    .output(z.object({ recorded: z.boolean() })),
 };
 
 export type AdminRole = z.infer<typeof AdminRoleSchema>;

--- a/packages/core/src/iam/contract/index.ts
+++ b/packages/core/src/iam/contract/index.ts
@@ -190,9 +190,6 @@ export const iamContract = {
     .route({ method: 'GET', path: '/iam/my-permissions' })
     .output(EffectivePermissionsSchema),
 
-  // Server-side verification for a client-side page-guard denial: the consumer's
-  // PermissionGate redirect never reaches the server on its own, so it never audits.
-  // This route re-checks the caller's actual level and records the denial only when real.
   reportAccessDenied: oc
     .route({ method: 'POST', path: '/iam/report-access-denied' })
     .input(GrantInputSchema)

--- a/packages/core/src/iam/plugin.ts
+++ b/packages/core/src/iam/plugin.ts
@@ -6,6 +6,7 @@ import {
   SEND_EMAIL,
   SESSION_COMMANDS,
   CACHE,
+  RATE_LIMITER,
   domainEventSchemas,
 } from '@openora/core/contracts';
 import { IamService, DbAdminPermissionResolver } from './service/iam.service.js';
@@ -66,6 +67,7 @@ export default {
           c.get(EVENT_BUS),
           c.get(SEND_EMAIL),
           c.get(SESSION_COMMANDS),
+          c.get(RATE_LIMITER),
         ),
         c.get(ADMIN_GUARD),
       ),

--- a/packages/core/src/iam/router/index.ts
+++ b/packages/core/src/iam/router/index.ts
@@ -114,5 +114,13 @@ export function createIamRouter(svc: IamService, adminGuard: AdminGuard) {
       const caller = await adminGuard.assert(context);
       return svc.previewEffectivePermissions({ userId: caller.userId });
     }),
+
+    // Just a valid admin session - the resource-specific check happens inside the service
+    // via level comparison, not adminGuard.assert(context, resource, action), because this
+    // route's whole point is auditing an attempted-but-denied access, not gating one.
+    reportAccessDenied: os.reportAccessDenied.handler(async ({ input, context }) => {
+      const caller = await adminGuard.assert(context);
+      return svc.reportAccessDenied({ ...input, caller });
+    }),
   });
 }

--- a/packages/core/src/iam/router/index.ts
+++ b/packages/core/src/iam/router/index.ts
@@ -115,9 +115,6 @@ export function createIamRouter(svc: IamService, adminGuard: AdminGuard) {
       return svc.previewEffectivePermissions({ userId: caller.userId });
     }),
 
-    // Just a valid admin session - the resource-specific check happens inside the service
-    // via level comparison, not adminGuard.assert(context, resource, action), because this
-    // route's whole point is auditing an attempted-but-denied access, not gating one.
     reportAccessDenied: os.reportAccessDenied.handler(async ({ input, context }) => {
       const caller = await adminGuard.assert(context);
       return svc.reportAccessDenied({ ...input, caller });

--- a/packages/core/src/iam/service/iam.service.ts
+++ b/packages/core/src/iam/service/iam.service.ts
@@ -877,12 +877,6 @@ export class IamService {
     return { success: true as const };
   }
 
-  /**
-   * Server-side verification for a client-side page-guard denial (e.g. the consumer's
-   * PermissionGate). Re-checks the caller's actual level so a caller who genuinely holds
-   * the permission cannot produce a false denial entry, then records the same
-   * `identity.user.unauthorized_access` event AdminGuard emits for a real denial.
-   */
   async reportAccessDenied(input: {
     resource: string;
     level: PermissionLevel;
@@ -898,8 +892,6 @@ export class IamService {
         RATE_LIMIT_KEYS.REPORT_ACCESS_DENIED,
         `${input.caller.userId}:${input.resource}`,
       );
-      // Throttle only, never reject: this is a fire-and-forget report, not an abuse-prone
-      // mutation, so a throttled repeat is silently skipped rather than surfaced as a 429.
       const { allowed } = await this.rateLimiter.consume(key, { limit: 1, windowMs: 60_000 });
       if (!allowed) {
         return { recorded: false };

--- a/packages/core/src/iam/service/iam.service.ts
+++ b/packages/core/src/iam/service/iam.service.ts
@@ -33,7 +33,10 @@ import type {
   SortOrder,
   PageQuery,
   PaginationOptions,
+  RateLimiterAdapter,
+  RateLimitKey,
 } from '@openora/core/contracts';
+import { RATE_LIMIT_KEYS, makeRateLimitKey } from '@openora/core/contracts';
 import {
   adminRole,
   adminRolePermission,
@@ -262,6 +265,7 @@ export class IamService {
     private readonly events: EventBus,
     private readonly email: SendEmailPort,
     private readonly sessionCommands?: SessionCommands,
+    private readonly rateLimiter?: RateLimiterAdapter<RateLimitKey>,
   ) {}
 
   private async callerGrants(caller: Caller) {
@@ -871,5 +875,37 @@ export class IamService {
     }
     await this.sessionCommands.revokeAll(input.userId, input.caller.userId);
     return { success: true as const };
+  }
+
+  /**
+   * Server-side verification for a client-side page-guard denial (e.g. the consumer's
+   * PermissionGate). Re-checks the caller's actual level so a caller who genuinely holds
+   * the permission cannot produce a false denial entry, then records the same
+   * `identity.user.unauthorized_access` event AdminGuard emits for a real denial.
+   */
+  async reportAccessDenied(input: {
+    resource: string;
+    level: PermissionLevel;
+    caller: Caller;
+  }): Promise<{ recorded: boolean }> {
+    const grantMap = grantsToLevelMap(await this.callerGrants(input.caller));
+    const actualLevel = grantMap[input.resource] ?? 'no_access';
+    if (isLevelSufficient(actualLevel, input.level)) {
+      return { recorded: false };
+    }
+    if (this.rateLimiter) {
+      const key = makeRateLimitKey(
+        RATE_LIMIT_KEYS.REPORT_ACCESS_DENIED,
+        `${input.caller.userId}:${input.resource}`,
+      );
+      // Throttle only, never reject: this is a fire-and-forget report, not an abuse-prone
+      // mutation, so a throttled repeat is silently skipped rather than surfaced as a 429.
+      const { allowed } = await this.rateLimiter.consume(key, { limit: 1, windowMs: 60_000 });
+      if (!allowed) {
+        return { recorded: false };
+      }
+    }
+    this.emitDenied(input.caller, input.resource, 'access');
+    return { recorded: true };
   }
 }


### PR DESCRIPTION
## Summary
- Adds `iam.reportAccessDenied` so a client-side `PermissionGate` redirect (which never reaches the server on its own) can be recorded server-side, closing the gap called out in `docs/standards/audit.md`.
- Service re-verifies the caller's actual level before recording — a caller who genuinely holds the permission cannot produce a false denial entry.
- Throttled to one audit row per 60s per (caller, resource) via the existing `RATE_LIMITER` adapter; throttled repeats are silently skipped, never surfaced as an error.
- Reuses the existing `identity.user.unauthorized_access` event, so the audit module needs no changes.

## Why
BF-412 (downstream MR !142): a restricted admin blocked from a page produced no audit trail, since `PermissionGate`'s redirect is client-side only. This is the core-side half — the platform route the consumer calls to report the denial.

## Test plan
- [x] `pnpm --filter @openora/core check:types` clean
- [x] `pnpm regen` — `docs/catalog.json` picks up the new route
- [x] Iam integration suite: 44/44 passing (incl. 3 new tests: genuine denial records + emits, genuine holder does not, throttled repeat is skipped)
- [x] Full `pnpm verify` gate (typecheck, lint, format, boundaries, shape, deprecations, unit, integration, drift) passed pre-commit