### PR TITLE
feat(identity): admin-triggered player password reset (BF-415)

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -206,6 +206,7 @@
         "verification"
       ],
       "routes": [
+        "identity.adminRequestPasswordReset",
         "identity.changeEmail",
         "identity.changePassword",
         "identity.disable2fa",
@@ -770,6 +771,7 @@
     "identity.2fa.disabled",
     "identity.2fa.enabled",
     "identity.email.verified",
+    "identity.password.admin_reset_requested",
     "identity.password.reset",
     "identity.phone_otp.cancelled",
     "identity.phone_otp.requested",

--- a/packages/core/src/audit/plugin.ts
+++ b/packages/core/src/audit/plugin.ts
@@ -167,6 +167,19 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
     };
   }
 
+  // Admin triggered a password-reset OTP send for a player. resource = the subject
+  // player; actor = the admin who acted.
+  if (topic === 'identity.password.admin_reset_requested') {
+    return {
+      ...base,
+      actorType: 'admin',
+      actorId: str(p['actorId']),
+      resourceType: 'user',
+      resourceId: str(p['userId']),
+      after: { email: p['email'] ?? null },
+    };
+  }
+
   if (topic === 'identity.user.unauthorized_access') {
     const resource = str(p['resource']) ?? 'admin';
     const action = str(p['action']);
@@ -498,6 +511,7 @@ const SUBSCRIBED_TOPICS: DomainEventName[] = [
   'identity.user.login.failed',
   'identity.user.lockout.triggered',
   'identity.user.unlocked',
+  'identity.password.admin_reset_requested',
   'identity.user.logout',
   'identity.user.phone_login',
   'identity.phone_otp.requested',

--- a/packages/core/src/contracts/adapters/email-template.ts
+++ b/packages/core/src/contracts/adapters/email-template.ts
@@ -11,7 +11,7 @@ export type EmailTemplateKey =
 
 export type EmailTemplateData = {
   verifyEmail: { url: string; token: string };
-  resetPasswordOtp: { otp: string };
+  resetPasswordOtp: { otp: string; email: string };
   rgLimitUpdated: { period: string; type: string; description: string };
   rgCoolingOffActivated: { expiresAt: Date };
   rgCoolingOffLifted: Record<string, never>;

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -103,6 +103,13 @@ export const domainEventSchemas = {
     action: z.string(),
     role: z.string().optional(),
   }),
+  // An admin triggered a password-reset OTP send on a player's behalf (backoffice
+  // "send reset link" action). userId = subject player, actorId = the admin.
+  'identity.password.admin_reset_requested': authContextBase.extend({
+    userId: UuidSchema,
+    email: z.email(),
+    actorId: UuidSchema,
+  }),
 
   'wallet.deposit.completed': walletTxnBase,
   'wallet.withdrawal.completed': walletTxnBase,

--- a/packages/core/src/pam/identity/__tests__/identity.service.int.test.ts
+++ b/packages/core/src/pam/identity/__tests__/identity.service.int.test.ts
@@ -560,6 +560,52 @@ describe('IdentityService.unlockUser (real PG)', () => {
   });
 });
 
+describe('IdentityService.adminRequestPasswordReset (real PG)', () => {
+  it('requests an OTP for the user email, sets the admin-marker in cache, and emits the audit event', async () => {
+    requestPasswordResetEmailOTPMock.mockResolvedValue(jsonResponse({ success: true }, 200));
+    const account = await seedUser();
+    const events = makeEventBus();
+    const cache = realCache();
+    const svc = buildService({ events, cache });
+
+    const res = await svc.adminRequestPasswordReset(account.id, 'admin1', {
+      ip: '1.2.3.4',
+      userAgent: 'ua',
+    });
+
+    expect(res).toEqual({ success: true });
+    expect(requestPasswordResetEmailOTPMock).toHaveBeenCalledWith(
+      expect.objectContaining({ body: { email: EMAIL } }),
+    );
+    expect(await cache.get(`admin-password-reset:${EMAIL}`)).toBe(true);
+    expect(events.emit).toHaveBeenCalledWith(
+      'identity.password.admin_reset_requested',
+      expect.objectContaining({
+        userId: account.id,
+        email: EMAIL,
+        actorId: 'admin1',
+        ip: '1.2.3.4',
+        userAgent: 'ua',
+      }),
+    );
+  });
+
+  it('throws NOT_FOUND when the user does not exist', async () => {
+    await expect(
+      buildService().adminRequestPasswordReset(randomUUID(), 'admin1'),
+    ).rejects.toThrow();
+  });
+
+  it('swallows an OTP-send failure and still returns SUCCESS', async () => {
+    requestPasswordResetEmailOTPMock.mockRejectedValue(new Error('boom'));
+    const account = await seedUser();
+
+    await expect(buildService().adminRequestPasswordReset(account.id, 'admin1')).resolves.toEqual({
+      success: true,
+    });
+  });
+});
+
 describe('IdentityService.requestPasswordReset', () => {
   it('calls the non-deprecated requestPasswordResetEmailOTP endpoint and returns SUCCESS', async () => {
     requestPasswordResetEmailOTPMock.mockResolvedValue(jsonResponse({ success: true }, 200));

--- a/packages/core/src/pam/identity/adapters/__tests__/default-email-template-renderer.test.ts
+++ b/packages/core/src/pam/identity/adapters/__tests__/default-email-template-renderer.test.ts
@@ -18,7 +18,11 @@ describe('DefaultEmailTemplateRenderer', () => {
   });
 
   it('renders the resetPasswordOtp template with the otp interpolated', () => {
-    const result = renderer.render('resetPasswordOtp', { otp: '123456' }, 'fr');
+    const result = renderer.render(
+      'resetPasswordOtp',
+      { otp: '123456', email: 'test@example.com' },
+      'fr',
+    );
 
     expect(result).toEqual({
       subject: 'Reset your password',
@@ -27,8 +31,16 @@ describe('DefaultEmailTemplateRenderer', () => {
   });
 
   it('ignores locale - always English', () => {
-    const en = renderer.render('resetPasswordOtp', { otp: '000000' }, 'en');
-    const de = renderer.render('resetPasswordOtp', { otp: '000000' }, 'de');
+    const en = renderer.render(
+      'resetPasswordOtp',
+      { otp: '000000', email: 'test@example.com' },
+      'en',
+    );
+    const de = renderer.render(
+      'resetPasswordOtp',
+      { otp: '000000', email: 'test@example.com' },
+      'de',
+    );
 
     expect(en).toEqual(de);
   });

--- a/packages/core/src/pam/identity/contract/index.ts
+++ b/packages/core/src/pam/identity/contract/index.ts
@@ -144,6 +144,11 @@ export const identityContract = {
     .input(z.object({ userId: UuidSchema }))
     .output(IdentitySuccessSchema),
 
+  adminRequestPasswordReset: oc
+    .route({ method: 'POST', path: '/identity/admin/password-reset' })
+    .input(z.object({ userId: UuidSchema }))
+    .output(IdentitySuccessSchema),
+
   sessions: {
     list: oc
       .route({ method: 'GET', path: '/identity/sessions' })

--- a/packages/core/src/pam/identity/router/index.ts
+++ b/packages/core/src/pam/identity/router/index.ts
@@ -139,6 +139,16 @@ export function createIdentityRouter(
       );
     }),
 
+    adminRequestPasswordReset: os.adminRequestPasswordReset.handler(async ({ input, context }) => {
+      const caller = await adminGuard.assert(context, 'player', 'update');
+      return mapErrors({ NOT_FOUND: UserNotFoundError }, () =>
+        identity.adminRequestPasswordReset(input.userId, caller.userId, {
+          ip: caller.ip,
+          userAgent: caller.userAgent,
+        }),
+      );
+    }),
+
     sessions: {
       list: os.sessions.list.handler(async ({ input, context }) => {
         await adminGuard.assert(context, 'sessions', 'view');

--- a/packages/core/src/pam/identity/service/identity.service.ts
+++ b/packages/core/src/pam/identity/service/identity.service.ts
@@ -241,6 +241,7 @@ function loginShadowKey(email: string): string {
 }
 
 const loginShadowLogger = createLogger('login-shadow');
+const identityLogger = createLogger('identity');
 
 function computeLockoutState({
   attempts,
@@ -687,6 +688,53 @@ export class IdentityService {
     } catch (err) {
       loginShadowLogger.warn({ key, err }, 'login shadow cache write failed');
     }
+  }
+
+  // Read by a downstream custom EmailTemplateRenderer (same CACHE binding) to tell an
+  // admin-triggered reset apart from a self-service one within the synchronous
+  // sendVerificationOTP -> templateRenderer.render call chain below.
+  private adminPasswordResetMarkerKey(email: string): string {
+    return `admin-password-reset:${email.toLowerCase()}`;
+  }
+
+  async adminRequestPasswordReset(userId: User['id'], actorId: User['id'], meta?: ClientMeta) {
+    const existingUser = findOneOrThrow(
+      await this.drizzle.db
+        .select({ id: user.id, email: user.email })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1),
+      new UserNotFoundError(userId),
+    );
+    const email = existingUser.email.toLowerCase();
+
+    try {
+      await this.cache?.set(this.adminPasswordResetMarkerKey(email), true, { ttlMs: 120_000 });
+    } catch (err) {
+      identityLogger.warn({ email, err }, 'admin password reset marker cache write failed');
+    }
+
+    // Mirrors requestPasswordReset: the OTP email (if any) is delivered through the
+    // sendEmail hook -> notifications; any underlying error is swallowed the same way.
+    try {
+      await this.api.requestPasswordResetEmailOTP({
+        body: { email },
+        headers: new Headers(),
+        asResponse: true,
+      });
+    } catch {
+      // intentionally ignored
+    }
+
+    this.events.emit('identity.password.admin_reset_requested', {
+      userId,
+      email,
+      actorId,
+      ip: meta?.ip ?? null,
+      userAgent: meta?.userAgent ?? null,
+    });
+
+    return SUCCESS;
   }
 
   async unlockUser(userId: User['id'], actorId: User['id'], meta?: ClientMeta) {

--- a/packages/core/src/server/auth/__tests__/auth.test.ts
+++ b/packages/core/src/server/auth/__tests__/auth.test.ts
@@ -50,7 +50,7 @@ describe('createAuth', () => {
       expect(getUserLanguage).toHaveBeenCalledWith('test@example.com');
       expect(templateRenderer.render).toHaveBeenCalledWith(
         'resetPasswordOtp',
-        { otp: '123456' },
+        { otp: '123456', email: 'test@example.com' },
         'pl',
       );
       expect(sendEmail).toHaveBeenCalledWith({

--- a/packages/core/src/server/auth/auth.ts
+++ b/packages/core/src/server/auth/auth.ts
@@ -118,7 +118,7 @@ export function createAuth(options: AuthOptions): BetterAuthType {
           const locale = (await options.getUserLanguage?.(email)) ?? 'en';
           const { subject, body } = await templateRenderer.render(
             'resetPasswordOtp',
-            { otp },
+            { otp, email },
             locale,
           );
           await sendEmail({ to: email, subject, body });


### PR DESCRIPTION
## Summary

BF-415: adds an admin-gated `identity.adminRequestPasswordReset` endpoint so an admin can send a password-reset OTP to a player's registered email, and threads the recipient email into the `resetPasswordOtp` email-template data.

## Why

The admin-triggered "send password reset" action had no core endpoint. Downstream (betfeel) worked around it with a raw `player`+`user` join (bypassing the `PlayerService` DI seam) and an internal loopback HTTP call to the public forgot-password route (bypassing the `IdentityService` seam). `EmailTemplateData['resetPasswordOtp']` also didn't carry the recipient email, so a downstream `EmailTemplateRenderer` couldn't build a working reset link.

## Alternatives considered

None.

## Risks

None. Both changes are additive: the new route mirrors `unlockUser`'s existing admin-gate shape and error handling, and `email` is an additive field on `EmailTemplateData['resetPasswordOtp']` that core's built-in (OTP-only) template ignores.