### PR TITLE
fix(audit): resolve player resource ids

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -569,8 +569,14 @@
       "token": "IDENTITY_READER",
       "status": "wired",
       "boundIn": [
+        "packages/core/src/casino/gaming/plugin.ts",
+        "packages/core/src/compliance/plugin.ts",
+        "packages/core/src/engagement/chat/plugin.ts",
+        "packages/core/src/iam/plugin.ts",
         "packages/core/src/pam/identity/plugin.ts",
-        "packages/core/src/pam/tag/plugin.ts"
+        "packages/core/src/pam/tag/plugin.ts",
+        "packages/core/src/server/runtime/create-app.ts",
+        "packages/core/src/wallet/plugin.ts"
       ]
     },
     {

--- a/packages/core/src/audit/__tests__/audit.service.int.test.ts
+++ b/packages/core/src/audit/__tests__/audit.service.int.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
 import { createTestDb, type TestDb } from '@openora/core/testing';
+import { player } from '@openora/core/pam/schema/profile';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import { makeEventBus } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
+import { mapEventToRecord } from '../plugin.js';
 import { auditLog } from '../schema/index.js';
 import { AuditService, computeHash, startOfDayUtc, endOfDayUtc } from '../service/audit.service.js';
 import { AuditListFiltersSchema } from '../contract/index.js';
@@ -87,8 +91,16 @@ function makeService() {
   return new AuditService(db.drizzle, makeEventBus());
 }
 
+async function seedPlayer(overrides: Partial<typeof player.$inferInsert> = {}) {
+  const [row] = await db.drizzle.db
+    .insert(player)
+    .values({ userId: randomUUID(), displayName: 'Player', ...overrides })
+    .returning();
+  return row!;
+}
+
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {
@@ -96,7 +108,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await db.drizzle.db.execute(sql`TRUNCATE ${auditLog} RESTART IDENTITY CASCADE`);
+  await db.drizzle.db.execute(sql`TRUNCATE ${auditLog}, ${player} RESTART IDENTITY CASCADE`);
 });
 
 describe('AuditService.record() (real PG)', () => {
@@ -408,5 +420,188 @@ describe('AuditService.exportCsv() (real PG)', () => {
     const csv = await makeService().exportCsv({});
 
     expect(csv).toContain('has ""quotes""');
+  });
+});
+
+describe('AuditService.resolvePlayerId() (real PG)', () => {
+  it('returns the true player.id for a userId with a matching player row', async () => {
+    const row = await seedPlayer();
+
+    const resolved = await makeService().resolvePlayerId(row.userId);
+
+    expect(resolved).toBe(row.id);
+    expect(resolved).not.toBe(row.userId);
+  });
+
+  it('returns null when no player row exists for that userId', async () => {
+    expect(await makeService().resolvePlayerId(randomUUID())).toBeNull();
+  });
+
+  it('returns null when passed null', async () => {
+    expect(await makeService().resolvePlayerId(null)).toBeNull();
+  });
+});
+
+describe('mapEventToRecord() player.id resolution (BF-335)', () => {
+  // Exercises the exact composition the plugin's event handler uses: topic + raw
+  // payload -> mapEventToRecord(..., svc.resolvePlayerId) -> record(). Uses the
+  // real AuditService.resolvePlayerId against Postgres rather than a stub, so the
+  // DB lookup itself is covered, not just the branch wiring.
+  async function mapAndRecord(topic: string, payload: Record<string, unknown>) {
+    const svc = makeService();
+    const record = await mapEventToRecord(topic, payload, (userId) => svc.resolvePlayerId(userId));
+    return svc.record(record);
+  }
+
+  it('compliance.kyc.updated: resourceId is the player.id, not the event userId', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('compliance.kyc.updated', {
+      userId: p.userId,
+      actorId: null,
+      previousStatus: 'pending',
+      status: 'verified',
+    });
+
+    expect(row.resourceId).toBe(p.id);
+    expect(row.resourceId).not.toBe(p.userId);
+    expect(row.resourceType).toBe('player');
+  });
+
+  it('compliance.kyc.updated: resourceId is null when the subject has no player row', async () => {
+    const row = await mapAndRecord('compliance.kyc.updated', {
+      userId: randomUUID(),
+      actorId: null,
+      previousStatus: 'pending',
+      status: 'verified',
+    });
+
+    expect(row.resourceId).toBeNull();
+  });
+
+  it('compliance.kyc.submitted: resourceId resolves to player.id while actorId keeps the raw userId', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('compliance.kyc.submitted', {
+      userId: p.userId,
+      referenceId: 'ref-1',
+      provider: 'sumsub',
+    });
+
+    expect(row.resourceId).toBe(p.id);
+    expect(row.actorId).toBe(p.userId);
+  });
+
+  it('compliance.kyc.reverify_required: resourceId resolves to player.id', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('compliance.kyc.reverify_required', {
+      userId: p.userId,
+      reason: 'address change',
+    });
+
+    expect(row.resourceId).toBe(p.id);
+  });
+
+  it('compliance.kyc.high_risk_signal_detected: resourceId resolves to player.id', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('compliance.kyc.high_risk_signal_detected', {
+      userId: p.userId,
+      referenceId: 'ref-2',
+    });
+
+    expect(row.resourceId).toBe(p.id);
+  });
+
+  it('chat.user.blocked: resourceId resolves blockedId to player.id, not blockerId', async () => {
+    const blocker = await seedPlayer();
+    const blocked = await seedPlayer();
+
+    const row = await mapAndRecord('chat.user.blocked', {
+      blockerId: blocker.userId,
+      blockedId: blocked.userId,
+    });
+
+    expect(row.resourceId).toBe(blocked.id);
+    expect(row.actorId).toBe(blocker.userId);
+  });
+
+  it('chat.user.ignored: resourceId resolves ignoredId to player.id, not ignorerId', async () => {
+    const ignorer = await seedPlayer();
+    const ignored = await seedPlayer();
+
+    const row = await mapAndRecord('chat.user.ignored', {
+      ignorerId: ignorer.userId,
+      ignoredId: ignored.userId,
+    });
+
+    expect(row.resourceId).toBe(ignored.id);
+    expect(row.actorId).toBe(ignorer.userId);
+  });
+
+  it('player.level.changed: resourceId resolves to player.id', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('player.level.changed', {
+      userId: p.userId,
+      actorId: randomUUID(),
+      previousLevel: 1,
+      newLevel: 2,
+    });
+
+    expect(row.resourceId).toBe(p.id);
+  });
+
+  it('rg.limit.set / rg.self_exclusion.activated / rg.cooling_off.lifted: shared branch resolves resourceId to player.id', async () => {
+    const p = await seedPlayer();
+
+    for (const topic of ['rg.limit.set', 'rg.self_exclusion.activated', 'rg.cooling_off.lifted']) {
+      const row = await mapAndRecord(topic, { userId: p.userId, actorId: randomUUID() });
+      expect(row.resourceId).toBe(p.id);
+    }
+  });
+
+  it('rg.exclusion.login_blocked: resourceId resolves to player.id', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('rg.exclusion.login_blocked', { userId: p.userId });
+
+    expect(row.resourceId).toBe(p.id);
+  });
+
+  it('player.login_blocked: resourceId resolves to player.id', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('player.login_blocked', { userId: p.userId });
+
+    expect(row.resourceId).toBe(p.id);
+  });
+
+  it('tag.player.assigned is unaffected - resourceId still comes straight from playerId (already a player.id)', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('tag.player.assigned', {
+      playerId: p.id,
+      actorId: randomUUID(),
+      tagKey: 'vip',
+      reason: 'manual',
+    });
+
+    expect(row.resourceId).toBe(p.id);
+  });
+
+  it('wallet.withdrawal.requested is unaffected - actorId still comes straight from userId, no resolution', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('wallet.withdrawal.requested', {
+      userId: p.userId,
+      transactionId: 'txn-1',
+      amount: '10.00',
+      currency: 'USD',
+    });
+
+    expect(row.actorId).toBe(p.userId);
+    expect(row.actorId).not.toBe(p.id);
   });
 });

--- a/packages/core/src/audit/__tests__/audit.service.int.test.ts
+++ b/packages/core/src/audit/__tests__/audit.service.int.test.ts
@@ -423,33 +423,14 @@ describe('AuditService.exportCsv() (real PG)', () => {
   });
 });
 
-describe('AuditService.resolvePlayerId() (real PG)', () => {
-  it('returns the true player.id for a userId with a matching player row', async () => {
-    const row = await seedPlayer();
-
-    const resolved = await makeService().resolvePlayerId(row.userId);
-
-    expect(resolved).toBe(row.id);
-    expect(resolved).not.toBe(row.userId);
-  });
-
-  it('returns null when no player row exists for that userId', async () => {
-    expect(await makeService().resolvePlayerId(randomUUID())).toBeNull();
-  });
-
-  it('returns null when passed null', async () => {
-    expect(await makeService().resolvePlayerId(null)).toBeNull();
-  });
-});
-
 describe('mapEventToRecord() player.id resolution (BF-335)', () => {
-  // Exercises the exact composition the plugin's event handler uses: topic + raw
-  // payload -> mapEventToRecord(..., svc.resolvePlayerId) -> record(). Uses the
-  // real AuditService.resolvePlayerId against Postgres rather than a stub, so the
-  // DB lookup itself is covered, not just the branch wiring.
+  // The emitter (never mapEventToRecord/AuditService) resolves playerId before the
+  // event is published - these tests exercise the mapper as a pure function that
+  // just reads p['playerId']/p['actorPlayerId'] straight off an already-resolved
+  // payload, exactly as the real event bus delivers it.
   async function mapAndRecord(topic: string, payload: Record<string, unknown>) {
     const svc = makeService();
-    const record = await mapEventToRecord(topic, payload, (userId) => svc.resolvePlayerId(userId));
+    const record = await mapEventToRecord(topic, payload);
     return svc.record(record);
   }
 
@@ -458,6 +439,7 @@ describe('mapEventToRecord() player.id resolution (BF-335)', () => {
 
     const row = await mapAndRecord('compliance.kyc.updated', {
       userId: p.userId,
+      playerId: p.id,
       actorId: null,
       previousStatus: 'pending',
       status: 'verified',
@@ -468,9 +450,10 @@ describe('mapEventToRecord() player.id resolution (BF-335)', () => {
     expect(row.resourceType).toBe('player');
   });
 
-  it('compliance.kyc.updated: resourceId is null when the subject has no player row', async () => {
+  it('compliance.kyc.updated: resourceId is null when the payload carries no playerId', async () => {
     const row = await mapAndRecord('compliance.kyc.updated', {
       userId: randomUUID(),
+      playerId: null,
       actorId: null,
       previousStatus: 'pending',
       status: 'verified',
@@ -479,72 +462,80 @@ describe('mapEventToRecord() player.id resolution (BF-335)', () => {
     expect(row.resourceId).toBeNull();
   });
 
-  it('compliance.kyc.submitted: resourceId resolves to player.id while actorId keeps the raw userId', async () => {
+  it('compliance.kyc.submitted: actorId and resourceId both come from the resolved playerId (self-action)', async () => {
     const p = await seedPlayer();
 
     const row = await mapAndRecord('compliance.kyc.submitted', {
       userId: p.userId,
+      playerId: p.id,
       referenceId: 'ref-1',
       provider: 'sumsub',
     });
 
     expect(row.resourceId).toBe(p.id);
-    expect(row.actorId).toBe(p.userId);
+    expect(row.actorId).toBe(p.id);
   });
 
-  it('compliance.kyc.reverify_required: resourceId resolves to player.id', async () => {
+  it('compliance.kyc.reverify_required: resourceId comes from the payload playerId', async () => {
     const p = await seedPlayer();
 
     const row = await mapAndRecord('compliance.kyc.reverify_required', {
       userId: p.userId,
+      playerId: p.id,
       reason: 'address change',
     });
 
     expect(row.resourceId).toBe(p.id);
   });
 
-  it('compliance.kyc.high_risk_signal_detected: resourceId resolves to player.id', async () => {
+  it('compliance.kyc.high_risk_signal_detected: resourceId comes from the payload playerId', async () => {
     const p = await seedPlayer();
 
     const row = await mapAndRecord('compliance.kyc.high_risk_signal_detected', {
       userId: p.userId,
+      playerId: p.id,
       referenceId: 'ref-2',
     });
 
     expect(row.resourceId).toBe(p.id);
   });
 
-  it('chat.user.blocked: resourceId resolves blockedId to player.id, not blockerId', async () => {
+  it('chat.user.blocked: resourceId is the blocked player, actorId is the blocking player', async () => {
     const blocker = await seedPlayer();
     const blocked = await seedPlayer();
 
     const row = await mapAndRecord('chat.user.blocked', {
       blockerId: blocker.userId,
+      actorPlayerId: blocker.id,
       blockedId: blocked.userId,
+      playerId: blocked.id,
     });
 
     expect(row.resourceId).toBe(blocked.id);
-    expect(row.actorId).toBe(blocker.userId);
+    expect(row.actorId).toBe(blocker.id);
   });
 
-  it('chat.user.ignored: resourceId resolves ignoredId to player.id, not ignorerId', async () => {
+  it('chat.user.ignored: resourceId is the ignored player, actorId is the ignoring player', async () => {
     const ignorer = await seedPlayer();
     const ignored = await seedPlayer();
 
     const row = await mapAndRecord('chat.user.ignored', {
       ignorerId: ignorer.userId,
+      actorPlayerId: ignorer.id,
       ignoredId: ignored.userId,
+      playerId: ignored.id,
     });
 
     expect(row.resourceId).toBe(ignored.id);
-    expect(row.actorId).toBe(ignorer.userId);
+    expect(row.actorId).toBe(ignorer.id);
   });
 
-  it('player.level.changed: resourceId resolves to player.id', async () => {
+  it('player.level.changed: resourceId comes from the payload playerId', async () => {
     const p = await seedPlayer();
 
     const row = await mapAndRecord('player.level.changed', {
       userId: p.userId,
+      playerId: p.id,
       actorId: randomUUID(),
       previousLevel: 1,
       newLevel: 2,
@@ -553,27 +544,34 @@ describe('mapEventToRecord() player.id resolution (BF-335)', () => {
     expect(row.resourceId).toBe(p.id);
   });
 
-  it('rg.limit.set / rg.self_exclusion.activated / rg.cooling_off.lifted: shared branch resolves resourceId to player.id', async () => {
+  it('rg.limit.set / rg.self_exclusion.activated / rg.cooling_off.lifted: shared branch resolves resourceId from the payload playerId', async () => {
     const p = await seedPlayer();
 
     for (const topic of ['rg.limit.set', 'rg.self_exclusion.activated', 'rg.cooling_off.lifted']) {
-      const row = await mapAndRecord(topic, { userId: p.userId, actorId: randomUUID() });
+      const row = await mapAndRecord(topic, {
+        userId: p.userId,
+        playerId: p.id,
+        actorId: randomUUID(),
+      });
       expect(row.resourceId).toBe(p.id);
     }
   });
 
-  it('rg.exclusion.login_blocked: resourceId resolves to player.id', async () => {
+  it('rg.exclusion.login_blocked: resourceId comes from the payload playerId', async () => {
     const p = await seedPlayer();
 
-    const row = await mapAndRecord('rg.exclusion.login_blocked', { userId: p.userId });
+    const row = await mapAndRecord('rg.exclusion.login_blocked', {
+      userId: p.userId,
+      playerId: p.id,
+    });
 
     expect(row.resourceId).toBe(p.id);
   });
 
-  it('player.login_blocked: resourceId resolves to player.id', async () => {
+  it('player.login_blocked: resourceId comes from the payload playerId', async () => {
     const p = await seedPlayer();
 
-    const row = await mapAndRecord('player.login_blocked', { userId: p.userId });
+    const row = await mapAndRecord('player.login_blocked', { userId: p.userId, playerId: p.id });
 
     expect(row.resourceId).toBe(p.id);
   });
@@ -591,17 +589,18 @@ describe('mapEventToRecord() player.id resolution (BF-335)', () => {
     expect(row.resourceId).toBe(p.id);
   });
 
-  it('wallet.withdrawal.requested is unaffected - actorId still comes straight from userId, no resolution', async () => {
+  it('wallet.withdrawal.requested: actorId comes from the resolved playerId, not the raw userId', async () => {
     const p = await seedPlayer();
 
     const row = await mapAndRecord('wallet.withdrawal.requested', {
       userId: p.userId,
+      playerId: p.id,
       transactionId: 'txn-1',
       amount: '10.00',
       currency: 'USD',
     });
 
-    expect(row.actorId).toBe(p.userId);
-    expect(row.actorId).not.toBe(p.id);
+    expect(row.actorId).toBe(p.id);
+    expect(row.actorId).not.toBe(p.userId);
   });
 });

--- a/packages/core/src/audit/plugin.ts
+++ b/packages/core/src/audit/plugin.ts
@@ -10,7 +10,11 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null;
 }
 
-function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInput {
+export async function mapEventToRecord(
+  topic: string,
+  p: Record<string, unknown>,
+  resolvePlayerId: (userId: string | null) => Promise<string | null>,
+): Promise<RecordInput> {
   const result = /\.(failed|rejected|declined)$/.test(topic) ? 'failure' : 'success';
 
   const base: RecordInput = {
@@ -31,7 +35,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       actorType: p['actorId'] ? 'admin' : 'system',
       actorId: str(p['actorId']),
       resourceType: 'player',
-      resourceId: str(p['userId']),
+      resourceId: await resolvePlayerId(str(p['userId'])),
       before: { kycStatus: p['previousStatus'] ?? null },
       after: {
         kycStatus: p['status'] ?? null,
@@ -48,7 +52,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       actorType: 'player',
       actorId: str(p['userId']),
       resourceType: 'player',
-      resourceId: str(p['userId']),
+      resourceId: await resolvePlayerId(str(p['userId'])),
       after: { referenceId: p['referenceId'] ?? null, provider: p['provider'] ?? null },
     };
   }
@@ -59,7 +63,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       ...base,
       actorType: 'system',
       resourceType: 'player',
-      resourceId: str(p['userId']),
+      resourceId: await resolvePlayerId(str(p['userId'])),
       after: { reason: p['reason'] ?? null },
     };
   }
@@ -69,7 +73,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       ...base,
       actorType: 'system',
       resourceType: 'player',
-      resourceId: str(p['userId']),
+      resourceId: await resolvePlayerId(str(p['userId'])),
       after: {
         referenceId: p['referenceId'] ?? null,
         vpnOrTorDetected: p['vpnOrTorDetected'] ?? null,
@@ -265,7 +269,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       actorType: 'player',
       actorId: str(p['blockerId']),
       resourceType: 'player',
-      resourceId: str(p['blockedId']),
+      resourceId: await resolvePlayerId(str(p['blockedId'])),
     };
   }
 
@@ -276,7 +280,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       actorType: 'player',
       actorId: str(p['ignorerId']),
       resourceType: 'player',
-      resourceId: str(p['ignoredId']),
+      resourceId: await resolvePlayerId(str(p['ignoredId'])),
     };
   }
 
@@ -359,7 +363,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       actorType: 'admin',
       actorId: str(p['actorId']),
       resourceType: 'player',
-      resourceId: str(p['userId']),
+      resourceId: await resolvePlayerId(str(p['userId'])),
       before: { level: p['previousLevel'] ?? null },
       after: { level: p['newLevel'] ?? null },
     };
@@ -453,7 +457,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       actorType: 'admin',
       actorId: str(p['actorId']),
       resourceType: 'player',
-      resourceId: str(p['userId']),
+      resourceId: await resolvePlayerId(str(p['userId'])),
       before,
       after: p,
     };
@@ -467,7 +471,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       ...base,
       actorType: 'system',
       resourceType: 'player',
-      resourceId: str(p['userId']),
+      resourceId: await resolvePlayerId(str(p['userId'])),
       result: 'failure',
     };
   }
@@ -480,7 +484,7 @@ function mapEventToRecord(topic: string, p: Record<string, unknown>): RecordInpu
       ...base,
       actorType: 'system',
       resourceType: 'player',
-      resourceId: str(p['userId']),
+      resourceId: await resolvePlayerId(str(p['userId'])),
       result: 'failure',
     };
   }
@@ -610,8 +614,9 @@ export default {
         if (!svcRef || !isRecord(payload)) {
           return;
         }
-        void svcRef
-          .record(mapEventToRecord(topic, payload))
+        const svc = svcRef;
+        void mapEventToRecord(topic, payload, (userId) => svc.resolvePlayerId(userId))
+          .then((record) => svc.record(record))
           .catch((err) => logger.error({ err, topic }, 'audit record failed'));
       });
     }

--- a/packages/core/src/audit/plugin.ts
+++ b/packages/core/src/audit/plugin.ts
@@ -13,7 +13,6 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 export async function mapEventToRecord(
   topic: string,
   p: Record<string, unknown>,
-  resolvePlayerId: (userId: string | null) => Promise<string | null>,
 ): Promise<RecordInput> {
   const result = /\.(failed|rejected|declined)$/.test(topic) ? 'failure' : 'success';
 
@@ -35,7 +34,7 @@ export async function mapEventToRecord(
       actorType: p['actorId'] ? 'admin' : 'system',
       actorId: str(p['actorId']),
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['userId'])),
+      resourceId: str(p['playerId']),
       before: { kycStatus: p['previousStatus'] ?? null },
       after: {
         kycStatus: p['status'] ?? null,
@@ -45,14 +44,15 @@ export async function mapEventToRecord(
     };
   }
 
-  // Player submitted KYC documents. actorId = the player; resourceId = the player.
+  // Player submitted KYC documents. actorId = resourceId = the player (self-action),
+  // both resolved by the emitter as playerId.
   if (topic === 'compliance.kyc.submitted') {
     return {
       ...base,
       actorType: 'player',
-      actorId: str(p['userId']),
+      actorId: str(p['playerId']),
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['userId'])),
+      resourceId: str(p['playerId']),
       after: { referenceId: p['referenceId'] ?? null, provider: p['provider'] ?? null },
     };
   }
@@ -63,7 +63,7 @@ export async function mapEventToRecord(
       ...base,
       actorType: 'system',
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['userId'])),
+      resourceId: str(p['playerId']),
       after: { reason: p['reason'] ?? null },
     };
   }
@@ -73,7 +73,7 @@ export async function mapEventToRecord(
       ...base,
       actorType: 'system',
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['userId'])),
+      resourceId: str(p['playerId']),
       after: {
         referenceId: p['referenceId'] ?? null,
         vpnOrTorDetected: p['vpnOrTorDetected'] ?? null,
@@ -96,13 +96,13 @@ export async function mapEventToRecord(
     };
   }
 
-  // Player requested a withdrawal (funds held). actorId = the player; resourceId =
-  // the withdrawal transaction.
+  // Player requested a withdrawal (funds held). actorId = the player (resolved
+  // playerId); resourceId = the withdrawal transaction.
   if (topic === 'wallet.withdrawal.requested') {
     return {
       ...base,
       actorType: 'player',
-      actorId: str(p['userId']),
+      actorId: str(p['playerId']),
       resourceType: 'withdrawal',
       resourceId: str(p['transactionId']),
       after: { amount: p['amount'], currency: p['currency'] },
@@ -184,14 +184,17 @@ export async function mapEventToRecord(
     };
   }
 
+  // actorId = the resolved playerId when the caller was a player, else the raw
+  // (admin) userId.
   if (topic === 'identity.user.unauthorized_access') {
     const resource = str(p['resource']) ?? 'admin';
     const action = str(p['action']);
     const role = p['role'] ? str(p['role']) : undefined;
+    const isPlayer = role === 'player';
     return {
       ...base,
-      actorType: role === 'player' ? 'player' : 'admin',
-      actorId: str(p['userId']),
+      actorType: isPlayer ? 'player' : 'admin',
+      actorId: isPlayer ? str(p['playerId']) : str(p['userId']),
       resourceType: resource,
       resourceId: action ? `${resource}:${action}` : null,
       result: 'failure',
@@ -203,7 +206,7 @@ export async function mapEventToRecord(
     return {
       ...base,
       actorType: 'player',
-      actorId: str(p['userId']),
+      actorId: str(p['playerId']),
       resourceType: 'user',
       resourceId: str(p['userId']),
       result: 'success',
@@ -249,10 +252,12 @@ export async function mapEventToRecord(
   }
 
   // Player/Admin revoked one or all of their own sessions, or an admin forced it.
+  // actorId = the resolved playerId on the self-revoke path, else the acting admin's
+  // raw userId (never resolved - actor is an admin, not the subject player).
   if (topic === 'identity.session.revoked' || topic === 'identity.sessions.revoked_all') {
     const isSingle = topic === 'identity.session.revoked';
-    const actorId = p['actorId'] ? str(p['actorId']) : str(p['userId']);
     const isForced = !!p['actorId'];
+    const actorId = isForced ? str(p['actorId']) : str(p['playerId']);
     return {
       ...base,
       actorType: isForced ? 'admin' : 'player',
@@ -262,47 +267,49 @@ export async function mapEventToRecord(
     };
   }
 
-  // actorId = the player who (un)blocked; resource = the blocked player.
+  // actorId = the (un)blocking player's resolved playerId; resource = the
+  // blocked/unblocked player's resolved playerId.
   if (topic === 'chat.user.blocked' || topic === 'chat.user.unblocked') {
     return {
       ...base,
       actorType: 'player',
-      actorId: str(p['blockerId']),
+      actorId: str(p['actorPlayerId']),
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['blockedId'])),
+      resourceId: str(p['playerId']),
     };
   }
 
-  // actorId = the player who (un)ignored; resource = the ignored player.
+  // actorId = the (un)ignoring player's resolved playerId; resource = the
+  // ignored/unignored player's resolved playerId.
   if (topic === 'chat.user.ignored' || topic === 'chat.user.unignored') {
     return {
       ...base,
       actorType: 'player',
-      actorId: str(p['ignorerId']),
+      actorId: str(p['actorPlayerId']),
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['ignoredId'])),
+      resourceId: str(p['playerId']),
     };
   }
 
-  // actorId = the moderator who acted; resource = the affected player in that room.
+  // actorId = the moderator's resolved playerId; resource = the affected player in
+  // that room (not player-typed - resourceId stays the raw member userId).
   if (topic === 'chat.room.member.kicked' || topic === 'chat.room.member.banned') {
-    const actorKey = topic === 'chat.room.member.kicked' ? 'kickedBy' : 'bannedBy';
     return {
       ...base,
       actorType: 'player',
-      actorId: str(p[actorKey]),
+      actorId: str(p['playerId']),
       resourceType: 'chat_room_member',
       resourceId: str(p['userId']),
       after: { roomId: str(p['roomId']) },
     };
   }
 
-  // actorId = the player who created/deleted the room; resource = the room.
+  // actorId = the creating/deleting player's resolved playerId; resource = the room.
   if (topic === 'chat.private_room.created' || topic === 'chat.private_room.deleted') {
     return {
       ...base,
       actorType: 'player',
-      actorId: str(p['creatorId']),
+      actorId: str(p['playerId']),
       resourceType: 'chat_room',
       resourceId: str(p['roomId']),
     };
@@ -329,11 +336,13 @@ export async function mapEventToRecord(
     };
   }
 
+  // actorId = the joining/leaving player's resolved playerId; resource is not
+  // player-typed - resourceId stays the raw member userId.
   if (topic === 'chat.room.member.joined' || topic === 'chat.room.member.left') {
     return {
       ...base,
       actorType: 'player',
-      actorId: str(p['userId']),
+      actorId: str(p['playerId']),
       resourceType: 'chat_room_member',
       resourceId: str(p['userId']),
       after: { roomId: str(p['roomId']) },
@@ -363,7 +372,7 @@ export async function mapEventToRecord(
       actorType: 'admin',
       actorId: str(p['actorId']),
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['userId'])),
+      resourceId: str(p['playerId']),
       before: { level: p['previousLevel'] ?? null },
       after: { level: p['newLevel'] ?? null },
     };
@@ -457,7 +466,7 @@ export async function mapEventToRecord(
       actorType: 'admin',
       actorId: str(p['actorId']),
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['userId'])),
+      resourceId: str(p['playerId']),
       before,
       after: p,
     };
@@ -471,7 +480,7 @@ export async function mapEventToRecord(
       ...base,
       actorType: 'system',
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['userId'])),
+      resourceId: str(p['playerId']),
       result: 'failure',
     };
   }
@@ -484,26 +493,31 @@ export async function mapEventToRecord(
       ...base,
       actorType: 'system',
       resourceType: 'player',
-      resourceId: await resolvePlayerId(str(p['userId'])),
+      resourceId: str(p['playerId']),
       result: 'failure',
     };
   }
 
   // Wallet events carry the txn ref in transactionId; surface it as resourceId so
   // a transaction reference is searchable (it otherwise stays buried in `after`).
+  // actorId = the resolved playerId (the wallet owner).
   if (topic.startsWith('wallet.')) {
     return {
       ...base,
       actorType: 'player',
-      actorId: str(p['userId']),
+      actorId: str(p['playerId']),
       resourceType: 'transaction',
       resourceId: str(p['transactionId']),
       after: p,
     };
   }
 
+  // Generic player-self-action fallback (login/logout/registered/2fa/password
+  // reset/email verified/profile updated, gaming rounds, self-service RG limits,
+  // ...): actorId = the resolved playerId. `identity.user.registered` legitimately
+  // has no player row yet at emit time, so this can be null.
   if (typeof p['userId'] === 'string') {
-    return { ...base, actorId: p['userId'], actorType: 'player' };
+    return { ...base, actorId: str(p['playerId']), actorType: 'player' };
   }
 
   return base;
@@ -615,7 +629,7 @@ export default {
           return;
         }
         const svc = svcRef;
-        void mapEventToRecord(topic, payload, (userId) => svc.resolvePlayerId(userId))
+        void mapEventToRecord(topic, payload)
           .then((record) => svc.record(record))
           .catch((err) => logger.error({ err, topic }, 'audit record failed'));
       });

--- a/packages/core/src/audit/service/audit.service.ts
+++ b/packages/core/src/audit/service/audit.service.ts
@@ -8,7 +8,6 @@ import {
 } from '@openora/core/server';
 import { eq, and, or, gt, gte, lte, like, asc, desc, sql } from 'drizzle-orm';
 import type { AuditWritePort } from '@openora/core/contracts';
-import { player } from '@openora/core/pam/schema/profile';
 import { auditLog, type AuditLog } from '../schema/index.js';
 import type { AuditListFilters, AuditExportFilters } from '../contract/index.js';
 
@@ -180,17 +179,6 @@ export class AuditService {
       return inserted;
     });
     return row;
-  }
-
-  async resolvePlayerId(userId: string | null): Promise<string | null> {
-    if (!userId) {
-      return null;
-    }
-    const [row] = await this.drizzle.db
-      .select({ id: player.id })
-      .from(player)
-      .where(eq(player.userId, userId));
-    return row?.id ?? null;
   }
 
   async list(filters: AuditListFilters) {

--- a/packages/core/src/audit/service/audit.service.ts
+++ b/packages/core/src/audit/service/audit.service.ts
@@ -182,10 +182,6 @@ export class AuditService {
     return row;
   }
 
-  // Resolves the PAM `player.id` for a subject `user.id`, so player-typed audit
-  // records store the true player row id rather than the identity user id.
-  // `player` is read via the profile module's sanctioned read-only /schema
-  // subpath (plain query, no FK/dependsOn needed).
   async resolvePlayerId(userId: string | null): Promise<string | null> {
     if (!userId) {
       return null;

--- a/packages/core/src/audit/service/audit.service.ts
+++ b/packages/core/src/audit/service/audit.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@openora/core/server';
 import { eq, and, or, gt, gte, lte, like, asc, desc, sql } from 'drizzle-orm';
 import type { AuditWritePort } from '@openora/core/contracts';
+import { player } from '@openora/core/pam/schema/profile';
 import { auditLog, type AuditLog } from '../schema/index.js';
 import type { AuditListFilters, AuditExportFilters } from '../contract/index.js';
 
@@ -179,6 +180,21 @@ export class AuditService {
       return inserted;
     });
     return row;
+  }
+
+  // Resolves the PAM `player.id` for a subject `user.id`, so player-typed audit
+  // records store the true player row id rather than the identity user id.
+  // `player` is read via the profile module's sanctioned read-only /schema
+  // subpath (plain query, no FK/dependsOn needed).
+  async resolvePlayerId(userId: string | null): Promise<string | null> {
+    if (!userId) {
+      return null;
+    }
+    const [row] = await this.drizzle.db
+      .select({ id: player.id })
+      .from(player)
+      .where(eq(player.userId, userId));
+    return row?.id ?? null;
   }
 
   async list(filters: AuditListFilters) {

--- a/packages/core/src/casino/gaming/__tests__/gaming.service.int.test.ts
+++ b/packages/core/src/casino/gaming/__tests__/gaming.service.int.test.ts
@@ -7,7 +7,8 @@ import type {
   WalletDebitOutcome,
 } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
-import { mock, makeEventBus } from '../../../testing/mock.js';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
+import { mock, makeEventBus, makeIdentityReader } from '../../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { game, gameRound } from '../schema/index.js';
 import {
@@ -45,7 +46,14 @@ function makeService({
   playEligibility?: PlayEligibilityPort;
   walletCommands?: WalletCommands;
 } = {}) {
-  return new GamingService(db.drizzle, noopEvents, provider, playEligibility, walletCommands);
+  return new GamingService(
+    db.drizzle,
+    noopEvents,
+    provider,
+    playEligibility,
+    walletCommands,
+    makeIdentityReader(),
+  );
 }
 
 async function seedGame(overrides: Partial<typeof game.$inferInsert> = {}) {
@@ -57,7 +65,7 @@ async function seedGame(overrides: Partial<typeof game.$inferInsert> = {}) {
 }
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {

--- a/packages/core/src/casino/gaming/plugin.ts
+++ b/packages/core/src/casino/gaming/plugin.ts
@@ -3,6 +3,7 @@ import type { CoreTokenCatalog, Plugin } from '@openora/core/server';
 import {
   ADMIN_GAME_REPORTING,
   GAME_ADAPTER,
+  IDENTITY_READER,
   PLAY_ELIGIBILITY,
   RNG_ADAPTER,
   WALLET_COMMANDS,
@@ -15,7 +16,7 @@ import { DrizzleAdminGameReporting } from './admin-reporting.js';
 
 export default {
   id: 'gaming',
-  requiresPorts: [PLAY_ELIGIBILITY],
+  requiresPorts: [PLAY_ELIGIBILITY, IDENTITY_READER],
   dependsOn: ['wallet'],
   register(ctx) {
     ctx.provide(GAME_ADAPTER, () => new MockGameAdapter());
@@ -29,6 +30,7 @@ export default {
           c.get(GAME_ADAPTER),
           c.get(PLAY_ELIGIBILITY),
           c.get(WALLET_COMMANDS),
+          c.get(IDENTITY_READER),
         ),
       ),
     );

--- a/packages/core/src/casino/gaming/service/gaming.service.ts
+++ b/packages/core/src/casino/gaming/service/gaming.service.ts
@@ -12,6 +12,7 @@ import {
   type GameAdapter,
   type PlayEligibilityPort,
   type WalletCommands,
+  type IdentityReader,
   type User,
 } from '@openora/core/contracts';
 import { game, gameRound, type Game, type GameRound } from '../schema/index.js';
@@ -53,6 +54,7 @@ export class GamingService {
     private readonly provider: GameAdapter,
     private readonly playEligibility: PlayEligibilityPort,
     private readonly walletCommands: WalletCommands,
+    private readonly identityReader: IdentityReader,
   ) {}
 
   async listGames() {
@@ -109,6 +111,7 @@ export class GamingService {
       roundId: round.id,
       gameId,
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       currency,
     });
 
@@ -135,7 +138,11 @@ export class GamingService {
       .set({ status: 'completed', endedAt: new Date() })
       .where(and(eq(gameRound.id, roundId), eq(gameRound.userId, userId)));
 
-    this.events.emit('gaming.round.ended', { roundId, userId });
+    this.events.emit('gaming.round.ended', {
+      roundId,
+      userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
+    });
 
     return { success: true };
   }

--- a/packages/core/src/compliance/__tests__/compliance.service.int.test.ts
+++ b/packages/core/src/compliance/__tests__/compliance.service.int.test.ts
@@ -3,7 +3,8 @@ import { randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
 import type { GeoIpAdapter } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
-import { mock, makeEventBus } from '../../testing/mock.js';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
+import { mock, makeEventBus, makeIdentityReader } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { userLimit, geoRule } from '../schema/index.js';
 import {
@@ -20,7 +21,7 @@ function makeService(countryCode?: string | null) {
     countryCode === undefined
       ? null
       : mock<GeoIpAdapter>({ lookup: vi.fn(async () => ({ countryCode })) });
-  const svc = new ComplianceService(db.drizzle, events, geoIp);
+  const svc = new ComplianceService(db.drizzle, events, geoIp, makeIdentityReader());
   return { svc, events };
 }
 
@@ -40,7 +41,7 @@ async function seedLimit(userId: string, overrides: Partial<typeof userLimit.$in
 }
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {

--- a/packages/core/src/compliance/__tests__/kyc-admin.router.int.test.ts
+++ b/packages/core/src/compliance/__tests__/kyc-admin.router.int.test.ts
@@ -13,7 +13,13 @@ import {
 import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
 import { player } from '@openora/core/pam/schema/profile';
 import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
-import { mock, makeEventBus, makeAuditWriter, NO_CLIENT_META } from '../../testing/mock.js';
+import {
+  makeIdentityReader,
+  mock,
+  makeEventBus,
+  makeAuditWriter,
+  NO_CLIENT_META,
+} from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { kycVerification } from '../schema/index.js';
 import { createComplianceRouter } from '../router/index.js';
@@ -61,6 +67,7 @@ function build(guard: AdminGuard) {
     events,
     kycAdapter: mock<KycAdapter>({}),
     statusWriter,
+    identityReader: makeIdentityReader(),
   });
   const audit = makeAuditWriter();
   const router = createComplianceRouter({

--- a/packages/core/src/compliance/__tests__/kyc.service.int.test.ts
+++ b/packages/core/src/compliance/__tests__/kyc.service.int.test.ts
@@ -12,7 +12,7 @@ import { player } from '@openora/core/pam/schema/profile';
 import { wallet, walletTransaction } from '@openora/core/wallet/schema';
 import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import { migrate as migrateWallet } from '@openora/core/wallet/migrate';
-import { mock, makeEventBus } from '../../testing/mock.js';
+import { makeIdentityReader, mock, makeEventBus } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { kycVerification } from '../schema/index.js';
 import { KycVerificationService } from '../service/kyc.service.js';
@@ -38,6 +38,7 @@ function makeService(options: { adapter?: Partial<AdapterResult>; config?: Platf
     events: events,
     kycAdapter,
     statusWriter,
+    identityReader: makeIdentityReader(),
     ...(options.config ? { platformConfig: options.config } : {}),
   });
   return { svc, events, kycAdapter, statusWriter, adapterResult };

--- a/packages/core/src/compliance/__tests__/rg.router.int.test.ts
+++ b/packages/core/src/compliance/__tests__/rg.router.int.test.ts
@@ -13,7 +13,9 @@ import type {
 } from '@openora/core/contracts';
 import { queue } from '@openora/core/contracts';
 import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import {
+  makeIdentityReader,
   mock,
   makeEventBus,
   makeAdminGuard,
@@ -36,7 +38,7 @@ const HOURS = 3600_000;
 let db: TestDb;
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {
@@ -64,6 +66,7 @@ function build(adminGuard: AdminGuard) {
     loginEnforcement: enforcement,
     email: mock<SendEmailPort>({ send: vi.fn(async () => undefined) }),
     directory: mock<AdminUserDirectory>({ lookupPlayers: vi.fn(async () => []) }),
+    identityReader: makeIdentityReader(),
   });
   const router = createComplianceRouter({
     compliance: mock<ComplianceService>({}),

--- a/packages/core/src/compliance/__tests__/rg.service.int.test.ts
+++ b/packages/core/src/compliance/__tests__/rg.service.int.test.ts
@@ -9,7 +9,8 @@ import type {
   SendEmailPort,
 } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
-import { mock, makeEventBus } from '../../testing/mock.js';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
+import { makeIdentityReader, mock, makeEventBus } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { userLimit, rgExclusion } from '../schema/index.js';
 import {
@@ -55,6 +56,7 @@ function makeService(notifier?: Notifier) {
     email: notifier?.email ?? null,
     directory: notifier?.directory ?? null,
     templateRenderer: notifier?.templateRenderer ?? null,
+    identityReader: makeIdentityReader(),
   });
   return { svc, events, enforcement };
 }
@@ -84,7 +86,7 @@ const future = () => new Date(Date.now() + 200 * 24 * HOURS);
 const past = () => new Date(Date.now() - 1000);
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {

--- a/packages/core/src/compliance/plugin.ts
+++ b/packages/core/src/compliance/plugin.ts
@@ -8,6 +8,7 @@ import {
   GEO_IP_ADAPTER,
   JOB_QUEUE,
   KYC_ADAPTER,
+  IDENTITY_READER,
   KYC_STATUS_WRITER,
   KYC_VENDOR_STATUSES,
   KYC_WEBHOOK_VERIFIER,
@@ -185,6 +186,7 @@ export default {
         events: c.get(EVENT_BUS),
         kycAdapter,
         statusWriter: c.get(KYC_STATUS_WRITER),
+        identityReader: c.get(IDENTITY_READER),
         platformConfig,
       });
       kycRef = kyc;
@@ -194,6 +196,7 @@ export default {
         drizzle: c.get(DRIZZLE),
         events: c.get(EVENT_BUS),
         loginEnforcement: c.get(LOGIN_ENFORCEMENT),
+        identityReader: c.get(IDENTITY_READER),
         email: c.has(SEND_EMAIL) ? c.get(SEND_EMAIL) : null,
         directory,
         templateRenderer: c.has(EMAIL_TEMPLATE_RENDERER) ? c.get(EMAIL_TEMPLATE_RENDERER) : null,
@@ -212,6 +215,7 @@ export default {
           c.get(DRIZZLE),
           c.get(EVENT_BUS),
           c.has(GEO_IP_ADAPTER) ? c.get(GEO_IP_ADAPTER) : null,
+          c.get(IDENTITY_READER),
         ),
         adminGuard: c.get(ADMIN_GUARD),
         audit: c.get(AUDIT_WRITER),

--- a/packages/core/src/compliance/service/compliance.service.ts
+++ b/packages/core/src/compliance/service/compliance.service.ts
@@ -10,7 +10,7 @@ import {
 import { eq } from 'drizzle-orm';
 import { userLimit, geoRule } from '../schema/index.js';
 import type { UpsertLimitInput, AddGeoRuleInput } from '../contract/index.js';
-import { type ClientMeta, type GeoIpAdapter, type User } from '@openora/core/contracts';
+import type { ClientMeta, GeoIpAdapter, IdentityReader, User } from '@openora/core/contracts';
 
 export const LimitNotFoundError = makeNotFoundError('Limit');
 
@@ -22,7 +22,8 @@ export class ComplianceService {
   constructor(
     private readonly drizzle: DrizzleService,
     private readonly events: EventBus,
-    private readonly geoIp: GeoIpAdapter | null = null,
+    private readonly geoIp: GeoIpAdapter | null,
+    private readonly identityReader: IdentityReader,
   ) {}
 
   async getLimitsForUser(userId: User['id']) {
@@ -44,6 +45,7 @@ export class ComplianceService {
     );
     this.events.emit('compliance.limit.upserted', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       limitId: row.id,
       ip: meta?.ip ?? null,
       userAgent: meta?.userAgent ?? null,
@@ -60,6 +62,7 @@ export class ComplianceService {
     await this.drizzle.db.delete(userLimit).where(eq(userLimit.id, id));
     this.events.emit('compliance.limit.removed', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       limitId: id,
       ip: meta?.ip ?? null,
       userAgent: meta?.userAgent ?? null,

--- a/packages/core/src/compliance/service/kyc.service.ts
+++ b/packages/core/src/compliance/service/kyc.service.ts
@@ -18,6 +18,7 @@ import {
   type KycVendorStatus,
   type KycStatus,
   type PlatformConfig,
+  type IdentityReader,
   type User,
   ClientMeta,
 } from '@openora/core/contracts';
@@ -114,6 +115,7 @@ export type KycVerificationDeps = {
   events: EventBus;
   kycAdapter: KycAdapter;
   statusWriter: KycStatusWriter;
+  identityReader: IdentityReader;
   platformConfig?: PlatformConfig;
   reKycTrigger?: ReKycTrigger;
 };
@@ -123,6 +125,7 @@ export class KycVerificationService {
   private readonly events: EventBus;
   private readonly kycAdapter: KycAdapter;
   private readonly statusWriter: KycStatusWriter;
+  private readonly identityReader: IdentityReader;
   private readonly platformConfig?: PlatformConfig;
   private readonly reKycTrigger: ReKycTrigger;
 
@@ -131,6 +134,7 @@ export class KycVerificationService {
     this.events = deps.events;
     this.kycAdapter = deps.kycAdapter;
     this.statusWriter = deps.statusWriter;
+    this.identityReader = deps.identityReader;
     this.platformConfig = deps.platformConfig;
     this.reKycTrigger = deps.reKycTrigger ?? new CumulativeDepositReKycTrigger();
   }
@@ -190,6 +194,7 @@ export class KycVerificationService {
 
     this.events.emit('compliance.kyc.submitted', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       referenceId: result.referenceId,
       provider: this.provider,
       ip: meta?.ip ?? null,
@@ -299,6 +304,7 @@ export class KycVerificationService {
     if (opts.riskSignals && warrantsHighRiskTag(opts.riskSignals)) {
       this.events.emit('compliance.kyc.high_risk_signal_detected', {
         userId: existing.userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(existing.userId),
         referenceId,
         vpnOrTorDetected: opts.riskSignals.vpnOrTorDetected,
         dataCenterIpDetected: opts.riskSignals.dataCenterIpDetected,
@@ -354,7 +360,7 @@ export class KycVerificationService {
    */
   async handleDeposit(userId: User['id']) {
     const [current] = await this.drizzle.db
-      .select({ currency: player.currency, kycStatus: player.kycStatus })
+      .select({ id: player.id, currency: player.currency, kycStatus: player.kycStatus })
       .from(player)
       .where(eq(player.userId, userId));
     if (!current || normalizeKycStatus(current.kycStatus) !== 'approved') {
@@ -413,7 +419,7 @@ export class KycVerificationService {
       source: 'reverify',
       reason,
     });
-    this.events.emit('compliance.kyc.reverify_required', { userId, reason });
+    this.events.emit('compliance.kyc.reverify_required', { userId, playerId: current.id, reason });
   }
 
   /**

--- a/packages/core/src/compliance/service/rg.service.ts
+++ b/packages/core/src/compliance/service/rg.service.ts
@@ -15,6 +15,7 @@ import type {
   EmailTemplateData,
   EmailTemplateKey,
   AdminUserDirectory,
+  IdentityReader,
   User,
   ClientMeta,
 } from '@openora/core/contracts';
@@ -74,6 +75,7 @@ export type RgServiceDeps = {
   loginEnforcement: LoginEnforcementPort;
   email?: SendEmailPort | null;
   directory?: AdminUserDirectory | null;
+  identityReader: IdentityReader;
   templateRenderer?: EmailTemplateRenderer | null;
 };
 
@@ -92,6 +94,7 @@ export class RgService {
   private readonly loginEnforcement: LoginEnforcementPort;
   private readonly email: SendEmailPort | null;
   private readonly directory: AdminUserDirectory | null;
+  private readonly identityReader: IdentityReader;
   private readonly templateRenderer: EmailTemplateRenderer | null;
 
   constructor(deps: RgServiceDeps) {
@@ -100,6 +103,7 @@ export class RgService {
     this.loginEnforcement = deps.loginEnforcement;
     this.email = deps.email ?? null;
     this.directory = deps.directory ?? null;
+    this.identityReader = deps.identityReader;
     this.templateRenderer = deps.templateRenderer ?? null;
   }
 
@@ -133,6 +137,7 @@ export class RgService {
     );
     this.events.emit('rg.limit.set', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       actorId,
       limitId: row.id,
       type: input.type,
@@ -185,6 +190,7 @@ export class RgService {
     });
     this.events.emit('rg.cooling_off.activated', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       actorId,
       exclusionId: row.id,
       expiresAt: expiresAt.toISOString(),
@@ -236,6 +242,7 @@ export class RgService {
     });
     this.events.emit('rg.self_exclusion.activated', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       actorId,
       exclusionId: row.id,
       isPermanent: input.isPermanent,
@@ -303,6 +310,7 @@ export class RgService {
     });
     this.events.emit('rg.self_exclusion.lifted', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       actorId,
       exclusionId: row.id,
       kind: 'self_exclusion',
@@ -356,6 +364,7 @@ export class RgService {
     });
     this.events.emit('rg.cooling_off.lifted', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       actorId,
       exclusionId: row.id,
       reason: input.reason,

--- a/packages/core/src/contracts/adapters/identity-reader.ts
+++ b/packages/core/src/contracts/adapters/identity-reader.ts
@@ -9,6 +9,8 @@ export type IdentityReader = {
   getPlayerIdsInactiveSince(sinceDate: Date): Promise<User['id'][]>;
   /** Resolves the player profile id for a given auth user id, or null when no profile exists yet. */
   getPlayerIdByUserId(userId: User['id']): Promise<Player['id'] | null>;
+  /** Best-effort variant for optional event enrichment; lookup failures resolve to null. */
+  getPlayerIdByUserIdSafe(userId: User['id']): Promise<Player['id'] | null>;
   /** Resolves the player's current KYC status from PAM, or null when no profile exists yet. */
   getPlayerKycStatusByUserId(userId: User['id']): Promise<KycStatus | null>;
   /** Returns other player user ids that have authenticated from the same login IP. */

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -41,6 +41,7 @@ const walletTxnBase = z.object({
 
 export const KycStatusUpdatedSchema = z.object({
   userId: UuidSchema,
+  playerId: UuidSchema.nullable(),
   actorId: UuidSchema.nullable(),
   status: KycStatusSchema,
   previousStatus: KycStatusSchema,
@@ -49,16 +50,26 @@ export const KycStatusUpdatedSchema = z.object({
 });
 
 export const domainEventSchemas = {
-  'identity.user.registered': authContextBase.extend({ userId: UuidSchema }),
-  'identity.user.login': authContextBase.extend({ userId: UuidSchema }),
+  'identity.user.registered': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
+  'identity.user.login': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
   'identity.user.login.failed': authContextBase.extend({
     email: z.email(),
     reason: z.string().nullable().optional(),
     attemptsRemaining: z.number().int().optional(),
   }),
-  'identity.user.logout': authContextBase.extend({ userId: UuidSchema }),
+  'identity.user.logout': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
   'identity.user.phone_login': authContextBase.extend({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     method: z.literal('phone'),
   }),
   'identity.phone_otp.requested': authContextBase.extend({ userId: UuidSchema }),
@@ -78,11 +89,26 @@ export const domainEventSchemas = {
     previousFailedAttempts: z.number().int().optional(),
     previousLockoutUntil: TimestampSchema.nullable().optional(),
   }),
-  'identity.2fa.enabled': authContextBase.extend({ userId: UuidSchema }),
-  'identity.2fa.disabled': authContextBase.extend({ userId: UuidSchema }),
-  'identity.password.reset': authContextBase.extend({ userId: UuidSchema }),
-  'identity.email.verified': authContextBase.extend({ userId: UuidSchema }),
-  'identity.profile.updated': authContextBase.extend({ userId: UuidSchema }),
+  'identity.2fa.enabled': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
+  'identity.2fa.disabled': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
+  'identity.password.reset': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
+  'identity.email.verified': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
+  'identity.profile.updated': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
   // An admin toggled a user's active status (the only user-lifecycle flow today;
   // users are deactivated, never hard-deleted). userId = subject, actorId = the
   // admin who acted (for a complete audit trail).
@@ -90,15 +116,18 @@ export const domainEventSchemas = {
   'identity.user.reactivated': authContextBase.extend({ userId: UuidSchema, actorId: UuidSchema }),
   'identity.session.revoked': authContextBase.extend({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     sessionId: UuidSchema,
     actorId: UuidSchema.optional(),
   }),
   'identity.sessions.revoked_all': authContextBase.extend({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     actorId: UuidSchema.optional(),
   }),
   'identity.user.unauthorized_access': authContextBase.extend({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     resource: z.string(),
     action: z.string(),
     role: z.string().optional(),
@@ -111,11 +140,13 @@ export const domainEventSchemas = {
     actorId: UuidSchema,
   }),
 
-  'wallet.deposit.completed': walletTxnBase,
-  'wallet.withdrawal.completed': walletTxnBase,
+  'wallet.deposit.completed': walletTxnBase.extend({ playerId: UuidSchema.nullable() }),
+  'wallet.withdrawal.completed': walletTxnBase.extend({ playerId: UuidSchema.nullable() }),
   // A player requested a withdrawal; funds are held (balance debited) and the
   // request enters the back-office approval queue as `pending`.
-  'wallet.withdrawal.requested': walletTxnBase.extend(authContextBase.shape),
+  'wallet.withdrawal.requested': walletTxnBase
+    .extend({ playerId: UuidSchema.nullable() })
+    .extend(authContextBase.shape),
   // A payments admin approved a pending withdrawal; it moves to `processing` and
   // is sent to the PSP/Fireblocks rail. `adminId` is the acting reviewer.
   'wallet.withdrawal.approved': walletTxnBase
@@ -134,9 +165,14 @@ export const domainEventSchemas = {
     roundId: UuidSchema,
     gameId: UuidSchema,
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     currency: CurrencyCodeSchema,
   }),
-  'gaming.round.ended': z.object({ roundId: UuidSchema, userId: UuidSchema }),
+  'gaming.round.ended': z.object({
+    roundId: UuidSchema,
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
 
   'chat.message.sent': z.object({
     messageId: UuidSchema,
@@ -146,10 +182,31 @@ export const domainEventSchemas = {
   }),
 
   // A player muted/unmuted another player's messages for themselves (ABC-45 AC11).
-  'chat.user.blocked': authContextBase.extend({ blockerId: UuidSchema, blockedId: UuidSchema }),
-  'chat.user.unblocked': authContextBase.extend({ blockerId: UuidSchema, blockedId: UuidSchema }),
-  'chat.user.ignored': authContextBase.extend({ ignorerId: UuidSchema, ignoredId: UuidSchema }),
-  'chat.user.unignored': authContextBase.extend({ ignorerId: UuidSchema, ignoredId: UuidSchema }),
+  // actorPlayerId = the blocker/ignorer; playerId = the blocked/ignored subject (resourceId).
+  'chat.user.blocked': authContextBase.extend({
+    blockerId: UuidSchema,
+    actorPlayerId: UuidSchema.nullable(),
+    blockedId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
+  'chat.user.unblocked': authContextBase.extend({
+    blockerId: UuidSchema,
+    actorPlayerId: UuidSchema.nullable(),
+    blockedId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
+  'chat.user.ignored': authContextBase.extend({
+    ignorerId: UuidSchema,
+    actorPlayerId: UuidSchema.nullable(),
+    ignoredId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
+  'chat.user.unignored': authContextBase.extend({
+    ignorerId: UuidSchema,
+    actorPlayerId: UuidSchema.nullable(),
+    ignoredId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
 
   // Admin room CRUD (actorId = acting admin UUID).
   'chat.room.created': authContextBase.extend({
@@ -175,22 +232,34 @@ export const domainEventSchemas = {
   'chat.private_room.created': authContextBase.extend({
     roomId: UuidSchema,
     creatorId: UuidSchema,
+    playerId: UuidSchema.nullable(),
   }),
   'chat.private_room.deleted': authContextBase.extend({
     roomId: UuidSchema,
     creatorId: UuidSchema,
+    playerId: UuidSchema.nullable(),
   }),
-  'chat.room.member.joined': authContextBase.extend({ roomId: UuidSchema, userId: UuidSchema }),
-  'chat.room.member.left': authContextBase.extend({ roomId: UuidSchema, userId: UuidSchema }),
+  'chat.room.member.joined': authContextBase.extend({
+    roomId: UuidSchema,
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
+  'chat.room.member.left': authContextBase.extend({
+    roomId: UuidSchema,
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
   'chat.room.member.kicked': authContextBase.extend({
     roomId: UuidSchema,
     userId: UuidSchema,
     kickedBy: UuidSchema,
+    playerId: UuidSchema.nullable(),
   }),
   'chat.room.member.banned': authContextBase.extend({
     roomId: UuidSchema,
     userId: UuidSchema,
     bannedBy: UuidSchema,
+    playerId: UuidSchema.nullable(),
   }),
 
   // An admin added or changed a geo (country) rule (regulatory). `actorId` is the
@@ -201,8 +270,16 @@ export const domainEventSchemas = {
     actorId: UuidSchema.optional(),
   }),
 
-  'compliance.limit.upserted': authContextBase.extend({ userId: UuidSchema, limitId: UuidSchema }),
-  'compliance.limit.removed': authContextBase.extend({ userId: UuidSchema, limitId: UuidSchema }),
+  'compliance.limit.upserted': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+    limitId: UuidSchema,
+  }),
+  'compliance.limit.removed': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+    limitId: UuidSchema,
+  }),
 
   // Responsible-Gambling admin actions. `userId` = the subject player, `actorId` =
   // the acting admin (the envelope carries no caller, so it is explicit for the audit
@@ -213,6 +290,7 @@ export const domainEventSchemas = {
   // when this is the first limit of that (type, period).
   'rg.limit.set': authContextBase.extend({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     actorId: UuidSchema,
     limitId: UuidSchema,
     type: LimitTypeSchema,
@@ -223,13 +301,19 @@ export const domainEventSchemas = {
     previousMinutes: z.number().int().nullable(),
   }),
   'rg.cooling_off.activated': actorReasonBase
-    .extend({ userId: UuidSchema, exclusionId: UuidSchema, expiresAt: TimestampSchema })
+    .extend({
+      userId: UuidSchema,
+      playerId: UuidSchema.nullable(),
+      exclusionId: UuidSchema,
+      expiresAt: TimestampSchema,
+    })
     .extend(authContextBase.shape),
   // durationMonths is the admin's chosen term, null when permanent - the regulatory
   // export reads the decision as made rather than re-deriving it from expiresAt.
   'rg.self_exclusion.activated': actorReasonBase
     .extend({
       userId: UuidSchema,
+      playerId: UuidSchema.nullable(),
       exclusionId: UuidSchema,
       isPermanent: z.boolean(),
       durationMonths: z.number().int().nullable(),
@@ -237,12 +321,20 @@ export const domainEventSchemas = {
     })
     .extend(authContextBase.shape),
   'rg.self_exclusion.lifted': actorReasonBase
-    .extend({ userId: UuidSchema, exclusionId: UuidSchema, kind: ExclusionKindSchema })
+    .extend({
+      userId: UuidSchema,
+      playerId: UuidSchema.nullable(),
+      exclusionId: UuidSchema,
+      kind: ExclusionKindSchema,
+    })
     .extend(authContextBase.shape),
   'rg.cooling_off.lifted': actorReasonBase
-    .extend({ userId: UuidSchema, exclusionId: UuidSchema })
+    .extend({ userId: UuidSchema, playerId: UuidSchema.nullable(), exclusionId: UuidSchema })
     .extend(authContextBase.shape),
-  'rg.exclusion.login_blocked': authContextBase.extend({ userId: UuidSchema }),
+  'rg.exclusion.login_blocked': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
 
   // A player's KYC status changed. userId = subject player; actorId = the admin who
   // acted, or null for system-driven changes (vendor decision, webhook, threshold
@@ -253,6 +345,7 @@ export const domainEventSchemas = {
   // the provider. userId = the submitting player; referenceId = the provider reference.
   'compliance.kyc.submitted': authContextBase.extend({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     referenceId: z.string(),
     provider: z.string(),
   }),
@@ -261,11 +354,13 @@ export const domainEventSchemas = {
   // System-driven (no admin actor); reason records the metric that crossed.
   'compliance.kyc.reverify_required': z.object({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     reason: z.string(),
   }),
 
   'compliance.kyc.high_risk_signal_detected': z.object({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     referenceId: z.string(),
     vpnOrTorDetected: z.boolean(),
     dataCenterIpDetected: z.boolean(),
@@ -369,6 +464,7 @@ export const domainEventSchemas = {
   }),
   'player.level.changed': z.object({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     previousLevel: z.number().int(),
     newLevel: z.number().int(),
     actorId: UuidSchema,
@@ -378,6 +474,7 @@ export const domainEventSchemas = {
   // is a failure outcome. userId = the subject player; status = the blocking status.
   'player.login_blocked': authContextBase.extend({
     userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
     status: PlayerStatusSchema,
   }),
 } as const;

--- a/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
+++ b/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
@@ -4,8 +4,9 @@ import { eq, sql } from 'drizzle-orm';
 import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
 import { user } from '@openora/core/pam/schema/identity';
 import { migrate as migrateIdentity } from '@openora/core/pam/migrate/identity';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import type { AdminUserDirectory, AdminPlayerSummary } from '@openora/core/contracts';
-import { NO_CLIENT_META, makeEventBus, mock } from '../../../testing/mock.js';
+import { NO_CLIENT_META, makeEventBus, makeIdentityReader, mock } from '../../../testing/mock.js';
 import { CHAT_ROOM_CATEGORIES, type ChatMessage } from '../contract/index.js';
 import { MAX_PRIVATE_ROOMS_PER_PLAYER } from '../contract/constants.js';
 import { migrate } from '../migrate.js';
@@ -50,7 +51,11 @@ function makeService(
 ) {
   const transport = new InProcessRealtimeTransport();
   const events = makeEventBus();
-  return { svc: new ChatService(db.drizzle, events, transport, directory), events, transport };
+  return {
+    svc: new ChatService(db.drizzle, events, transport, directory, makeIdentityReader()),
+    events,
+    transport,
+  };
 }
 
 async function seedUser(name = 'Player') {
@@ -99,7 +104,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2000) {
 }
 
 beforeAll(async () => {
-  db = await createTestDb([migrate, migrateIdentity]);
+  db = await createTestDb([migrate, migrateIdentity, migrateProfile]);
 });
 
 afterAll(async () => {

--- a/packages/core/src/engagement/chat/plugin.ts
+++ b/packages/core/src/engagement/chat/plugin.ts
@@ -8,6 +8,7 @@ import {
   CHAT_BLOCK_WRITER,
   CHAT_ROOM_ACCESS,
   ADMIN_USER_DIRECTORY,
+  IDENTITY_READER,
   createToken,
   REALTIME_TRANSPORT,
   REALTIME_CLIENT_AUTHORIZER,
@@ -31,6 +32,7 @@ export default {
           c.get(EVENT_BUS),
           c.get(CHAT_REALTIME_TRANSPORT),
           c.get(ADMIN_USER_DIRECTORY),
+          c.get(IDENTITY_READER),
         ),
     );
     ctx.provide(CHAT_SYSTEM_WRITER, (c) => c.get(CHAT_SERVICE));

--- a/packages/core/src/engagement/chat/service/chat.service.ts
+++ b/packages/core/src/engagement/chat/service/chat.service.ts
@@ -21,6 +21,7 @@ import type {
   ChatSystemMessage,
   CommandChatMessage,
   AdminUserDirectory,
+  IdentityReader,
 } from '@openora/core/contracts';
 import { chatChannel } from '@openora/core/contracts';
 import { eq, and, isNull, lt, desc, asc, notInArray, inArray, count, ne } from 'drizzle-orm';
@@ -188,6 +189,7 @@ export class ChatService {
     private readonly events: EventBus,
     private readonly transport: RealtimeTransport,
     private readonly directory: AdminUserDirectory,
+    private readonly identityReader: IdentityReader,
   ) {}
 
   subscribeMessages(
@@ -584,7 +586,9 @@ export class ChatService {
     if (inserted.length > 0) {
       this.events.emit('chat.user.blocked', {
         blockerId,
+        actorPlayerId: await this.identityReader.getPlayerIdByUserIdSafe(blockerId),
         blockedId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(blockedId),
         ip: meta?.ip ?? null,
         userAgent: meta?.userAgent ?? null,
       });
@@ -610,7 +614,9 @@ export class ChatService {
     if (removed.length > 0) {
       this.events.emit('chat.user.unblocked', {
         blockerId,
+        actorPlayerId: await this.identityReader.getPlayerIdByUserIdSafe(blockerId),
         blockedId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(blockedId),
         ip: meta?.ip ?? null,
         userAgent: meta?.userAgent ?? null,
       });
@@ -704,7 +710,9 @@ export class ChatService {
     if (inserted.length > 0) {
       this.events.emit('chat.user.ignored', {
         ignorerId,
+        actorPlayerId: await this.identityReader.getPlayerIdByUserIdSafe(ignorerId),
         ignoredId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(ignoredId),
         ip: meta?.ip ?? null,
         userAgent: meta?.userAgent ?? null,
       });
@@ -729,7 +737,9 @@ export class ChatService {
     if (removed.length > 0) {
       this.events.emit('chat.user.unignored', {
         ignorerId,
+        actorPlayerId: await this.identityReader.getPlayerIdByUserIdSafe(ignorerId),
         ignoredId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(ignoredId),
         ip: meta?.ip ?? null,
         userAgent: meta?.userAgent ?? null,
       });
@@ -886,6 +896,7 @@ export class ChatService {
     this.events.emit('chat.private_room.deleted', {
       roomId,
       creatorId: userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       ip: ip ?? null,
       userAgent: userAgent ?? null,
     });
@@ -925,6 +936,7 @@ export class ChatService {
     userId: User['id'];
     name: string;
   } & ClientMeta) {
+    const playerId = await this.identityReader.getPlayerIdByUserIdSafe(userId);
     for (let attempt = 1; attempt <= 3; attempt++) {
       const joinCode = generateJoinCode();
       const slug = generatePrivateRoomSlug(joinCode);
@@ -966,6 +978,7 @@ export class ChatService {
         this.events.emit('chat.private_room.created', {
           roomId: record.id,
           creatorId: userId,
+          playerId,
           ip: ip ?? null,
           userAgent: userAgent ?? null,
         });
@@ -1035,6 +1048,7 @@ export class ChatService {
       this.events.emit('chat.room.member.joined', {
         roomId: room.id,
         userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
         ip: ip ?? null,
         userAgent: userAgent ?? null,
       });
@@ -1078,6 +1092,7 @@ export class ChatService {
       this.events.emit('chat.room.member.left', {
         roomId,
         userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
         ip: ip ?? null,
         userAgent: userAgent ?? null,
       });
@@ -1119,6 +1134,7 @@ export class ChatService {
         roomId,
         userId,
         kickedBy: moderatorId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(moderatorId),
         ip: ip ?? null,
         userAgent: userAgent ?? null,
       });
@@ -1166,6 +1182,7 @@ export class ChatService {
       roomId,
       userId,
       bannedBy: moderatorId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(moderatorId),
       ip: ip ?? null,
       userAgent: userAgent ?? null,
     });

--- a/packages/core/src/iam/__tests__/iam.service.int.test.ts
+++ b/packages/core/src/iam/__tests__/iam.service.int.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
-import { mock, NO_CLIENT_META, makeEventBus } from '../../testing/mock.js';
+import { makeIdentityReader, mock, NO_CLIENT_META, makeEventBus } from '../../testing/mock.js';
 import {
   statement,
   findOneOrThrow,
@@ -9,7 +9,12 @@ import {
   RedisRateLimiter,
   type ResourceName,
 } from '@openora/core/server';
-import type { SendEmailPort, SessionCommands } from '@openora/core/contracts';
+import type {
+  RateLimiterAdapter,
+  RateLimitKey,
+  SendEmailPort,
+  SessionCommands,
+} from '@openora/core/contracts';
 import { createTestDb, createTestRedis, type TestDb, type TestRedis } from '@openora/core/testing';
 import { migrate as migrateIam } from '@openora/core/iam/migrate';
 import { migrate as migrateIdentity } from '@openora/core/pam/migrate/identity';
@@ -37,6 +42,17 @@ let db: TestDb;
 let redis: TestRedis;
 
 const makeEmail = () => mock<SendEmailPort>({ send: vi.fn().mockResolvedValue(undefined) });
+const identityReader = makeIdentityReader();
+
+function makeIamService(
+  drizzle: typeof db.drizzle,
+  events: ReturnType<typeof makeEventBus>,
+  email: SendEmailPort,
+  sessionCommands?: SessionCommands,
+  rateLimiter?: RateLimiterAdapter<RateLimitKey>,
+) {
+  return new IamService(drizzle, events, email, identityReader, sessionCommands, rateLimiter);
+}
 
 // Bootstrap super-admin: no DB assignment row + user.role === 'admin' passes the static fallback.
 const ADMIN_CALLER = { userId: randomUUID(), role: 'admin', ...NO_CLIENT_META };
@@ -101,7 +117,7 @@ beforeEach(async () => {
 
 describe('IamService.listCatalog', () => {
   it('omits the admin module from the assignable catalog', () => {
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     const catalog = svc.listCatalog();
     expect(catalog.modules.some((m) => m.resource === 'admin')).toBe(false);
     expect(catalog.modules.some((m) => m.resource === 'player')).toBe(true);
@@ -206,7 +222,7 @@ describe('IamService.setRolePermissions', () => {
   it('rejects a non-super-admin caller and audits the denial', async () => {
     const role = await seedRole();
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
     await expect(
       svc.setRolePermissions({
         roleId: role.id,
@@ -226,7 +242,7 @@ describe('IamService.setRolePermissions', () => {
   });
 
   it('throws RoleNotFoundError when the role does not exist', async () => {
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(
       svc.setRolePermissions({
         roleId: randomUUID(),
@@ -238,7 +254,7 @@ describe('IamService.setRolePermissions', () => {
 
   it('throws InvalidGrantError for an unknown module', async () => {
     const role = await seedRole();
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(
       svc.setRolePermissions({
         roleId: role.id,
@@ -250,7 +266,7 @@ describe('IamService.setRolePermissions', () => {
 
   it('rejects a grant targeting the admin module (super-admin-only, A6)', async () => {
     const role = await seedRole();
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(
       svc.setRolePermissions({
         roleId: role.id,
@@ -262,7 +278,7 @@ describe('IamService.setRolePermissions', () => {
 
   it('blocks editing a super-admin role (always full)', async () => {
     const role = await seedRole({ isSuperAdmin: true, isSystem: true });
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(
       svc.setRolePermissions({
         roleId: role.id,
@@ -274,7 +290,7 @@ describe('IamService.setRolePermissions', () => {
 
   it('a super caller may grant any level and the rows are persisted', async () => {
     const role = await seedRole();
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     const result = await svc.setRolePermissions({
       roleId: role.id,
       grants: [{ resource: 'withdrawal', level: 'read_write' }],
@@ -293,7 +309,7 @@ describe('IamService.setRolePermissions', () => {
   it('emits iam.role.permissions.changed with actorId', async () => {
     const role = await seedRole();
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
     await svc.setRolePermissions({
       roleId: role.id,
       grants: [{ resource: 'player', level: 'read' }],
@@ -309,7 +325,7 @@ describe('IamService.setRolePermissions', () => {
 describe('IamService.updateRole', () => {
   it('blocks renaming the super-admin role', async () => {
     const role = await seedRole({ isSuperAdmin: true, isSystem: true });
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(
       svc.updateRole({ roleId: role.id, name: 'Renamed', caller: ADMIN_CALLER }),
     ).rejects.toBeInstanceOf(ProtectedRoleError);
@@ -318,7 +334,7 @@ describe('IamService.updateRole', () => {
   it('allows renaming a predefined (isSystem, non-super) role', async () => {
     const role = await seedRole({ isSystem: true, isSuperAdmin: false });
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
     const result = await svc.updateRole({ roleId: role.id, name: 'Renamed', caller: ADMIN_CALLER });
     expect(result.name).toBe('Renamed');
     expect(events.emit).toHaveBeenCalledWith(
@@ -334,7 +350,7 @@ describe('IamService.updateRole', () => {
 describe('IamService.deleteRole', () => {
   it('blocks deleting a system role', async () => {
     const role = await seedRole({ isSystem: true });
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(svc.deleteRole({ roleId: role.id, caller: ADMIN_CALLER })).rejects.toBeInstanceOf(
       ProtectedRoleError,
     );
@@ -342,7 +358,7 @@ describe('IamService.deleteRole', () => {
 
   it('blocks deleting a super-admin role', async () => {
     const role = await seedRole({ isSuperAdmin: true });
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(svc.deleteRole({ roleId: role.id, caller: ADMIN_CALLER })).rejects.toBeInstanceOf(
       ProtectedRoleError,
     );
@@ -351,7 +367,7 @@ describe('IamService.deleteRole', () => {
   it('deletes a custom role with no assignments and emits only iam.role.deleted', async () => {
     const role = await seedRole();
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
     const result = await svc.deleteRole({ roleId: role.id, caller: ADMIN_CALLER });
     expect(result).toEqual({ success: true });
     expect(events.emit).toHaveBeenCalledWith(
@@ -372,7 +388,7 @@ describe('IamService.deleteRole', () => {
     await seedAssignment(userA, role.id);
     await seedAssignment(userB, role.id);
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
 
     const result = await svc.deleteRole({ roleId: role.id, caller: ADMIN_CALLER });
     expect(result).toEqual({ success: true });
@@ -407,7 +423,7 @@ describe('IamService.assignRole', () => {
     const target = await seedUser('admin');
     await seedAssignment(target.id, role.id);
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
 
     const result = await svc.assignRole({
       userId: target.id,
@@ -424,7 +440,7 @@ describe('IamService.assignRole', () => {
   it('rejects assigning a role to a non-admin (player) account', async () => {
     const role = await seedRole();
     const player = await seedUser('player');
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(
       svc.assignRole({ userId: player.id, roleId: role.id, caller: ADMIN_CALLER }),
     ).rejects.toThrow(NotAnAdminUserError);
@@ -432,7 +448,7 @@ describe('IamService.assignRole', () => {
 
   it('rejects assigning a role to an unknown user', async () => {
     const role = await seedRole();
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(
       svc.assignRole({ userId: randomUUID(), roleId: role.id, caller: ADMIN_CALLER }),
     ).rejects.toThrow(AdminUserNotFoundError);
@@ -441,7 +457,7 @@ describe('IamService.assignRole', () => {
   it('the unique index keeps two concurrent assigns from double-inserting', async () => {
     const role = await seedRole();
     const target = await seedUser('admin');
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
 
     await Promise.allSettled([
       svc.assignRole({ userId: target.id, roleId: role.id, caller: ADMIN_CALLER }),
@@ -461,7 +477,7 @@ describe('IamService.unassignRole', () => {
     const superRole = await seedRole({ isSuperAdmin: true, isSystem: true });
     const target = randomUUID();
     await seedAssignment(target, superRole.id);
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
 
     await expect(
       svc.unassignRole({ userId: target, roleId: superRole.id, caller: ADMIN_CALLER }),
@@ -473,7 +489,7 @@ describe('IamService.unassignRole', () => {
   it('returns success but emits no revoked event when nothing was deleted', async () => {
     const role = await seedRole();
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
     const result = await svc.unassignRole({
       userId: randomUUID(),
       roleId: role.id,
@@ -488,7 +504,7 @@ describe('IamService.unassignRole', () => {
     const target = randomUUID();
     await seedAssignment(target, role.id);
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
 
     await svc.unassignRole({ userId: target, roleId: role.id, caller: ADMIN_CALLER });
     expect(events.emit).toHaveBeenCalledWith(
@@ -504,7 +520,7 @@ describe('IamService.unassignRole', () => {
     const userB = randomUUID();
     await seedAssignment(userA, superRole.id);
     await seedAssignment(userB, superRole.id);
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
 
     const results = await Promise.allSettled([
       svc.unassignRole({ userId: userA, roleId: superRole.id, caller: ADMIN_CALLER }),
@@ -526,7 +542,7 @@ describe('IamService.previewEffectivePermissions', () => {
     await seedPermission(roleA.id, 'player', 'read');
     await seedPermission(roleA.id, 'withdrawal', 'read');
     await seedPermission(roleB.id, 'player', 'read_write');
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
 
     const result = await svc.previewEffectivePermissions({ roleIds: [roleA.id, roleB.id] });
     expect(result.permissions).toContainEqual({ resource: 'player', level: 'read_write' });
@@ -536,7 +552,7 @@ describe('IamService.previewEffectivePermissions', () => {
 
   it('super-admin role in the set yields all modules read_write', async () => {
     const superRole = await seedRole({ isSuperAdmin: true });
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     const result = await svc.previewEffectivePermissions({ roleIds: [superRole.id] });
     expect(result.permissions).toHaveLength(Object.keys(statement).length);
     expect(result.permissions.every((p) => p.level === 'read_write')).toBe(true);
@@ -544,7 +560,7 @@ describe('IamService.previewEffectivePermissions', () => {
 
   it('falls back to static role permissions when the user has no dynamic role assignments', async () => {
     const u = await seedUser('support');
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     const result = await svc.previewEffectivePermissions({ userId: u.id });
     expect(result.permissions).not.toHaveLength(0);
     expect(result.permissions).toContainEqual({ resource: 'player', level: 'read' });
@@ -568,7 +584,7 @@ describe('IamService.acceptInvitation', () => {
   it('accepts once and emits exactly one event; a replay conflicts and emits nothing more', async () => {
     const token = await seedInvitation();
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
 
     const first = await svc.acceptInvitation(token);
     expect(first).toEqual({ success: true, email: 'who@admin.com' });
@@ -579,7 +595,7 @@ describe('IamService.acceptInvitation', () => {
   it('two concurrent accepts: exactly one succeeds, one event (atomic conditional UPDATE)', async () => {
     const token = await seedInvitation();
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
 
     const results = await Promise.allSettled([
       svc.acceptInvitation(token),
@@ -598,7 +614,7 @@ describe('IamService.inviteAdmin', () => {
   it('creates a pending invitation and calls SEND_EMAIL when caller is super-admin', async () => {
     const role = await seedRole();
     const email = makeEmail();
-    const svc = new IamService(db.drizzle, makeEventBus(), email);
+    const svc = makeIamService(db.drizzle, makeEventBus(), email);
     const result = await svc.inviteAdmin({
       email: 'new@admin.com',
       roleId: role.id,
@@ -617,7 +633,7 @@ describe('IamService.inviteAdmin', () => {
   it('rejects a non-super-admin caller', async () => {
     const role = await seedRole();
     const email = makeEmail();
-    const svc = new IamService(db.drizzle, makeEventBus(), email);
+    const svc = makeIamService(db.drizzle, makeEventBus(), email);
     await expect(
       svc.inviteAdmin({ email: 'new@admin.com', roleId: role.id, caller: SUPPORT_CALLER }),
     ).rejects.toBeInstanceOf(NotSuperAdminError);
@@ -628,7 +644,7 @@ describe('IamService.inviteAdmin', () => {
 describe('IamService paginated lists', () => {
   it('listRoles returns { items, total, page, limit }', async () => {
     const role = await seedRole();
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     const result = await svc.listRoles({ page: 1, limit: 10 });
     expect(result.total).toBe(1);
     expect(result.page).toBe(1);
@@ -646,7 +662,7 @@ describe('IamService paginated lists', () => {
       status: 'pending',
       expiresAt: new Date(Date.now() + 60_000),
     });
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     const result = await svc.listInvitations({ page: 1, limit: 20 });
     expect(result.total).toBe(1);
     expect(result.items).toHaveLength(1);
@@ -656,7 +672,7 @@ describe('IamService paginated lists', () => {
   it('listAssignments returns the paginated wrapper with joined role fields', async () => {
     const role = await seedRole({ name: 'Ops' });
     await seedAssignment(randomUUID(), role.id);
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     const result = await svc.listAssignments({ page: 1, limit: 20 });
     expect(result.total).toBe(1);
     expect(result.items).toHaveLength(1);
@@ -667,7 +683,7 @@ describe('IamService paginated lists', () => {
 describe('IamService.reportAccessDenied', () => {
   it('records and audits a genuine denial (caller lacks the resource/level)', async () => {
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
 
     const result = await svc.reportAccessDenied({
       resource: 'withdrawal',
@@ -689,7 +705,7 @@ describe('IamService.reportAccessDenied', () => {
 
   it('does not record or emit when the caller genuinely holds the permission', async () => {
     const events = makeEventBus();
-    const svc = new IamService(db.drizzle, events, makeEmail());
+    const svc = makeIamService(db.drizzle, events, makeEmail());
 
     const result = await svc.reportAccessDenied({
       resource: 'player',
@@ -704,7 +720,7 @@ describe('IamService.reportAccessDenied', () => {
   it('with a rate limiter wired, a repeat report within the window is throttled and not recorded again', async () => {
     const events = makeEventBus();
     const limiter = new RedisRateLimiter(redis.client);
-    const svc = new IamService(db.drizzle, events, makeEmail(), undefined, limiter);
+    const svc = makeIamService(db.drizzle, events, makeEmail(), undefined, limiter);
 
     const first = await svc.reportAccessDenied({
       resource: 'withdrawal',
@@ -728,7 +744,7 @@ describe('IamService.reportAccessDenied', () => {
 
 describe('IamService.forceLogout', () => {
   it('rejects a non-super-admin caller', async () => {
-    const svc = new IamService(db.drizzle, makeEventBus(), makeEmail());
+    const svc = makeIamService(db.drizzle, makeEventBus(), makeEmail());
     await expect(
       svc.forceLogout({ userId: randomUUID(), caller: SUPPORT_CALLER }),
     ).rejects.toBeInstanceOf(NotSuperAdminError);
@@ -739,7 +755,7 @@ describe('IamService.forceLogout', () => {
     const sessionCommands = mock<SessionCommands>({
       revokeAll: vi.fn().mockResolvedValue({ success: true }),
     });
-    const svc = new IamService(db.drizzle, events, makeEmail(), sessionCommands);
+    const svc = makeIamService(db.drizzle, events, makeEmail(), sessionCommands);
     const targetUserId = randomUUID();
     const result = await svc.forceLogout({ userId: targetUserId, caller: ADMIN_CALLER });
     expect(result).toEqual({ success: true });

--- a/packages/core/src/iam/plugin.ts
+++ b/packages/core/src/iam/plugin.ts
@@ -3,6 +3,7 @@ import type { CoreTokenCatalog, Plugin } from '@openora/core/server';
 import {
   ADMIN_PERMISSION_RESOLVER,
   ADMIN_PLAYER_ACTIVITY,
+  IDENTITY_READER,
   SEND_EMAIL,
   SESSION_COMMANDS,
   CACHE,
@@ -66,6 +67,7 @@ export default {
           c.get(DRIZZLE),
           c.get(EVENT_BUS),
           c.get(SEND_EMAIL),
+          c.get(IDENTITY_READER),
           c.get(SESSION_COMMANDS),
           c.get(RATE_LIMITER),
         ),

--- a/packages/core/src/iam/service/iam.service.ts
+++ b/packages/core/src/iam/service/iam.service.ts
@@ -16,6 +16,7 @@ import {
   isLevelSufficient,
   cached,
   invalidate,
+  createLogger,
   actionsToLevel,
   type ResourceName,
   type RoleName,
@@ -26,6 +27,7 @@ import type {
   SendEmailPort,
   AdminPermissionResolver,
   AdminGrant,
+  IdentityReader,
   CacheAdapter,
   SessionCommands,
   User,
@@ -51,6 +53,8 @@ import type {
   IamRoleSortBy,
   IamInvitationSortBy,
 } from '../contract/index.js';
+
+const logger = createLogger('iam-service');
 
 export const RoleNotFoundError = makeNotFoundError('AdminRole');
 export const InvitationNotFoundError = makeNotFoundError('AdminInvitation');
@@ -264,6 +268,7 @@ export class IamService {
     private readonly drizzle: DrizzleService,
     private readonly events: EventBus,
     private readonly email: SendEmailPort,
+    private readonly identityReader: IdentityReader,
     private readonly sessionCommands?: SessionCommands,
     private readonly rateLimiter?: RateLimiterAdapter<RateLimitKey>,
   ) {}
@@ -303,14 +308,25 @@ export class IamService {
   }
 
   private emitDenied(caller: Caller, resource: string, action: string) {
-    this.events.emit('identity.user.unauthorized_access', {
-      userId: caller.userId,
-      resource,
-      action,
-      ip: caller.ip,
-      userAgent: caller.userAgent,
-      role: caller.role,
-    });
+    void (async () => {
+      const playerId =
+        caller.role === 'player'
+          ? await this.identityReader.getPlayerIdByUserIdSafe(caller.userId)
+          : null;
+      try {
+        this.events.emit('identity.user.unauthorized_access', {
+          userId: caller.userId,
+          playerId,
+          resource,
+          action,
+          ip: caller.ip,
+          userAgent: caller.userAgent,
+          role: caller.role,
+        });
+      } catch (err) {
+        logger.error({ err, userId: caller.userId, resource, action }, 'denial audit event failed');
+      }
+    })();
   }
 
   listCatalog() {

--- a/packages/core/src/pam/identity/__tests__/identity.rate-limit.int.test.ts
+++ b/packages/core/src/pam/identity/__tests__/identity.rate-limit.int.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import { RedisRateLimiter } from '@openora/core/server';
 import { createTestDb, createTestRedis, type TestDb, type TestRedis } from '@openora/core/testing';
-import type { EmailTemplateRenderer, RateLimiterAdapter } from '@openora/core/contracts';
-import { mock, makeEventBus } from '../../../testing/mock.js';
+import type {
+  EmailTemplateRenderer,
+  IdentityReader,
+  RateLimiterAdapter,
+} from '@openora/core/contracts';
+import { makeIdentityReader, mock, makeEventBus } from '../../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { IdentityService, type IdentityServiceDeps } from '../service/identity.service.js';
 
@@ -10,8 +14,16 @@ const testTemplateRenderer: EmailTemplateRenderer = {
   render: () => ({ subject: 'subject', body: 'body' }),
 };
 
-function withTemplateRenderer(deps: Omit<IdentityServiceDeps, 'templateRenderer'>) {
-  return new IdentityService({ templateRenderer: testTemplateRenderer, ...deps });
+function withTemplateRenderer(
+  deps: Omit<IdentityServiceDeps, 'templateRenderer' | 'identityReader'> & {
+    identityReader?: IdentityReader;
+  },
+) {
+  return new IdentityService({
+    templateRenderer: testTemplateRenderer,
+    ...deps,
+    identityReader: deps.identityReader ?? makeIdentityReader(),
+  });
 }
 
 // Keep the real @openora/core/server (so assertRateLimit + RedisRateLimiter are real); only

--- a/packages/core/src/pam/identity/__tests__/identity.service.int.test.ts
+++ b/packages/core/src/pam/identity/__tests__/identity.service.int.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../service/identity.service.js';
 import { UnsupportedLanguageError } from '../../shared/language.js';
 import { user, session } from '../schema/index.js';
-import { mock, makeEventBus } from '../../../testing/mock.js';
+import { makeIdentityReader, mock, makeEventBus } from '../../../testing/mock.js';
 
 const {
   signInEmailMock,
@@ -86,6 +86,7 @@ function buildService(deps: Partial<Omit<IdentityServiceDeps, 'templateRenderer'
     templateRenderer: testTemplateRenderer,
     drizzle: db.drizzle,
     events: makeEventBus(),
+    identityReader: makeIdentityReader(),
     ...deps,
   });
 }
@@ -98,7 +99,7 @@ function jsonResponse(body: unknown, status: number) {
 }
 
 const betterAuthUser = {
-  id: 'u1',
+  id: '00000000-0000-4000-8000-000000000001',
   email: 'a@b.dev',
   name: 'A',
   emailVerified: true,

--- a/packages/core/src/pam/identity/__tests__/login-enforcement.service.int.test.ts
+++ b/packages/core/src/pam/identity/__tests__/login-enforcement.service.int.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
 import { createTestDb, type TestDb } from '@openora/core/testing';
-import { makeEventBus } from '../../../testing/mock.js';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
+import { makeEventBus, makeIdentityReader } from '../../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { user, session } from '../schema/index.js';
 import { LoginEnforcementService } from '../service/login-enforcement.service.js';
@@ -14,7 +15,11 @@ let db: TestDb;
 
 function makeService() {
   const events = makeEventBus();
-  const sessions = new SessionService({ drizzle: db.drizzle, events: events });
+  const sessions = new SessionService({
+    drizzle: db.drizzle,
+    events,
+    identityReader: makeIdentityReader(),
+  });
   return { svc: new LoginEnforcementService(db.drizzle, sessions), events };
 }
 
@@ -57,7 +62,7 @@ async function activeSessionCount(userId: string) {
 }
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {

--- a/packages/core/src/pam/identity/adapters/identity-reader.service.ts
+++ b/packages/core/src/pam/identity/adapters/identity-reader.service.ts
@@ -1,8 +1,10 @@
-import { DrizzleService } from '@openora/core/server';
+import { createLogger, DrizzleService } from '@openora/core/server';
 import type { IdentityReader, KycStatus, Player, User } from '@openora/core/contracts';
 import { and, eq, isNull, lt, max, ne, or } from 'drizzle-orm';
 import { session, user } from '../schema/index.js';
 import { player } from '@openora/core/pam/schema/profile';
+
+const logger = createLogger('identity-reader');
 
 export class IdentityReaderService implements IdentityReader {
   constructor(private readonly drizzle: DrizzleService) {}
@@ -47,6 +49,15 @@ export class IdentityReaderService implements IdentityReader {
       .where(eq(player.userId, userId))
       .limit(1);
     return row?.id ?? null;
+  }
+
+  async getPlayerIdByUserIdSafe(userId: User['id']): Promise<Player['id'] | null> {
+    try {
+      return await this.getPlayerIdByUserId(userId);
+    } catch (err) {
+      logger.warn({ err, userId }, 'player id lookup failed for event enrichment');
+      return null;
+    }
   }
 
   async getPlayerKycStatusByUserId(userId: User['id']): Promise<KycStatus | null> {

--- a/packages/core/src/pam/identity/plugin.ts
+++ b/packages/core/src/pam/identity/plugin.ts
@@ -54,12 +54,20 @@ export default {
       (c) =>
         new LoginEnforcementService(
           c.get(DRIZZLE),
-          new SessionService({ drizzle: c.get(DRIZZLE), events: c.get(EVENT_BUS) }),
+          new SessionService({
+            drizzle: c.get(DRIZZLE),
+            events: c.get(EVENT_BUS),
+            identityReader: c.get(IDENTITY_READER),
+          }),
         ),
     );
     ctx.provide(PLAY_ELIGIBILITY, (c) => new PlayEligibilityService(c.get(DRIZZLE)));
     ctx.provide(SESSION_COMMANDS, (c) => {
-      const sessionSvc = new SessionService({ drizzle: c.get(DRIZZLE), events: c.get(EVENT_BUS) });
+      const sessionSvc = new SessionService({
+        drizzle: c.get(DRIZZLE),
+        events: c.get(EVENT_BUS),
+        identityReader: c.get(IDENTITY_READER),
+      });
       return {
         revokeAll: (userId, actorId) => sessionSvc.revokeAllSessions(userId, actorId),
       };
@@ -69,6 +77,7 @@ export default {
         new IdentityService({
           drizzle: c.get(DRIZZLE),
           events: c.get(EVENT_BUS),
+          identityReader: c.get(IDENTITY_READER),
           email: c.get(SEND_EMAIL),
           templateRenderer: c.get(EMAIL_TEMPLATE_RENDERER),
           options: c.has(IDENTITY_OPTIONS) ? c.get(IDENTITY_OPTIONS) : undefined,
@@ -76,7 +85,11 @@ export default {
           platformConfig: c.has(PLATFORM_CONFIG) ? c.get(PLATFORM_CONFIG) : undefined,
           cache: c.get(CACHE),
         }),
-        new SessionService({ drizzle: c.get(DRIZZLE), events: c.get(EVENT_BUS) }),
+        new SessionService({
+          drizzle: c.get(DRIZZLE),
+          events: c.get(EVENT_BUS),
+          identityReader: c.get(IDENTITY_READER),
+        }),
         new PhoneLoginService({
           drizzle: c.get(DRIZZLE),
           events: c.get(EVENT_BUS),

--- a/packages/core/src/pam/identity/service/identity.service.ts
+++ b/packages/core/src/pam/identity/service/identity.service.ts
@@ -33,6 +33,7 @@ import type {
   UpdateProfileInput,
   Theme,
   User,
+  IdentityReader,
   ChangePasswordInput,
   ChangeEmailInput,
   IdentityServiceOptions,
@@ -261,6 +262,7 @@ function computeLockoutState({
 export type IdentityServiceDeps = {
   drizzle: DrizzleService;
   events: EventBus;
+  identityReader: IdentityReader;
   email?: SendEmailPort;
   templateRenderer: EmailTemplateRenderer;
   options?: IdentityServiceOptions;
@@ -282,6 +284,7 @@ export class IdentityService {
   private readonly auth: ReturnType<typeof createAuth>;
   private readonly drizzle: DrizzleService;
   private readonly events: EventBus;
+  private readonly identityReader: IdentityReader;
   private readonly email?: SendEmailPort;
   private readonly templateRenderer: EmailTemplateRenderer;
   private readonly options?: IdentityServiceOptions;
@@ -292,6 +295,7 @@ export class IdentityService {
   constructor({
     drizzle,
     events,
+    identityReader,
     email,
     templateRenderer,
     options,
@@ -301,6 +305,7 @@ export class IdentityService {
   }: IdentityServiceDeps) {
     this.drizzle = drizzle;
     this.events = events;
+    this.identityReader = identityReader;
     this.email = email;
     this.templateRenderer = templateRenderer;
     this.options = options;
@@ -316,6 +321,7 @@ export class IdentityService {
       onPasswordReset: async (resetUser) => {
         this.events.emit('identity.password.reset', {
           userId: resetUser.id,
+          playerId: await this.identityReader.getPlayerIdByUserIdSafe(resetUser.id),
           ...getCurrentClientMeta(),
         });
         await this.clearLockout(resetUser.id);
@@ -375,7 +381,12 @@ export class IdentityService {
     this.forwardCookies(authResponse, resHeaders);
     const body = (await authResponse.json()) as { user: BetterAuthUser };
 
-    this.events.emit('identity.user.registered', { userId: body.user.id, ip, userAgent });
+    this.events.emit('identity.user.registered', {
+      userId: body.user.id,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(body.user.id),
+      ip,
+      userAgent,
+    });
     return { user: toUser(body.user) };
   }
 
@@ -464,6 +475,18 @@ export class IdentityService {
       });
       await ensureOk(authResponse);
 
+      // Resolved once (only when a user was found), before either gate below, so both
+      // the RG-block and the Backoffice-block events - and the eventual login success
+      // event - can all carry playerId.
+      let playerRow: Pick<typeof player.$inferSelect, 'id' | 'status'> | undefined;
+      if (existingUser) {
+        [playerRow] = await this.drizzle.db
+          .select({ id: player.id, status: player.status })
+          .from(player)
+          .where(eq(player.userId, existingUser.id))
+          .limit(1);
+      }
+
       // RG login block, applied only AFTER credentials verify so a pre-auth probe can't
       // distinguish a restricted account from a wrong password. Kill the session
       // better-auth just issued and never forward its cookie. Cooling-off auto-expires
@@ -473,7 +496,12 @@ export class IdentityService {
           .update(session)
           .set({ expiresAt: new Date() })
           .where(eq(session.userId, existingUser.id));
-        this.events.emit('rg.exclusion.login_blocked', { userId: existingUser.id, ip, userAgent });
+        this.events.emit('rg.exclusion.login_blocked', {
+          userId: existingUser.id,
+          playerId: playerRow?.id ?? null,
+          ip,
+          userAgent,
+        });
         throw new ORPCError('FORBIDDEN', {
           message: 'Account access is currently restricted (responsible gambling).',
           data: { code: 'RG_BLOCKED' },
@@ -484,28 +512,26 @@ export class IdentityService {
       // RG gate above: applied only AFTER credentials verify, kills the just-issued
       // session and withholds its cookie. Distinct mechanism from RG (self_excluded is
       // out of scope here) - a suspended/closed player can never log back in.
-      if (existingUser) {
-        const [playerRow] = await this.drizzle.db
-          .select({ status: player.status })
-          .from(player)
-          .where(eq(player.userId, existingUser.id))
-          .limit(1);
-        if (playerRow && (playerRow.status === 'suspended' || playerRow.status === 'closed')) {
-          await this.drizzle.db
-            .update(session)
-            .set({ expiresAt: new Date() })
-            .where(eq(session.userId, existingUser.id));
-          this.events.emit('player.login_blocked', {
-            userId: existingUser.id,
-            status: playerRow.status,
-            ip,
-            userAgent,
-          });
-          throw new ORPCError('FORBIDDEN', {
-            message: 'This account has been suspended and can no longer be used.',
-            data: { code: 'ACCOUNT_SUSPENDED' },
-          });
-        }
+      if (
+        existingUser &&
+        playerRow &&
+        (playerRow.status === 'suspended' || playerRow.status === 'closed')
+      ) {
+        await this.drizzle.db
+          .update(session)
+          .set({ expiresAt: new Date() })
+          .where(eq(session.userId, existingUser.id));
+        this.events.emit('player.login_blocked', {
+          userId: existingUser.id,
+          playerId: playerRow.id,
+          status: playerRow.status,
+          ip,
+          userAgent,
+        });
+        throw new ORPCError('FORBIDDEN', {
+          message: 'This account has been suspended and can no longer be used.',
+          data: { code: 'ACCOUNT_SUSPENDED' },
+        });
       }
 
       this.forwardCookies(authResponse, resHeaders);
@@ -529,7 +555,12 @@ export class IdentityService {
         .update(session)
         .set({ ipAddress: ip, userAgent })
         .where(eq(session.token, body.token));
-      this.events.emit('identity.user.login', { userId: body.user.id, ip, userAgent });
+      this.events.emit('identity.user.login', {
+        userId: body.user.id,
+        playerId: playerRow?.id ?? null,
+        ip,
+        userAgent,
+      });
       const sessionDurationSeconds =
         this.auth.options.session?.expiresIn ?? SESSION_DURATION_IN_SECONDS;
       const expiresAt = body.session?.expiresAt
@@ -779,7 +810,12 @@ export class IdentityService {
     const authResponse = await this.auth.api.signOut({ headers, asResponse: true });
     this.forwardCookies(authResponse, resHeaders);
     if (userId) {
-      this.events.emit('identity.user.logout', { userId, ip, userAgent });
+      this.events.emit('identity.user.logout', {
+        userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
+        ip,
+        userAgent,
+      });
     }
     return SUCCESS;
   }
@@ -827,7 +863,12 @@ export class IdentityService {
     this.forwardCookies(res, resHeaders);
     const userId = await this.currentUserId(headers);
     if (userId) {
-      this.events.emit('identity.2fa.enabled', { userId, ip, userAgent });
+      this.events.emit('identity.2fa.enabled', {
+        userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
+        ip,
+        userAgent,
+      });
     }
     return SUCCESS;
   }
@@ -849,7 +890,12 @@ export class IdentityService {
     await ensureOk(res);
     this.forwardCookies(res, resHeaders);
     if (userId) {
-      this.events.emit('identity.2fa.disabled', { userId, ip, userAgent });
+      this.events.emit('identity.2fa.disabled', {
+        userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
+        ip,
+        userAgent,
+      });
     }
     return SUCCESS;
   }
@@ -962,7 +1008,12 @@ export class IdentityService {
     });
     await ensureOk(res);
     if (userId) {
-      this.events.emit('identity.email.verified', { userId, ip, userAgent });
+      this.events.emit('identity.email.verified', {
+        userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
+        ip,
+        userAgent,
+      });
     }
     return SUCCESS;
   }
@@ -999,7 +1050,12 @@ export class IdentityService {
     const session = await this.auth.api.getSession({ headers });
     const current = session?.user as BetterAuthUser | undefined;
     if (current) {
-      this.events.emit('identity.profile.updated', { userId: current.id, ip, userAgent });
+      this.events.emit('identity.profile.updated', {
+        userId: current.id,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(current.id),
+        ip,
+        userAgent,
+      });
     }
     if (!current) {
       throw new Error('Profile update succeeded but session could not be re-read');

--- a/packages/core/src/pam/identity/service/phone-login.service.ts
+++ b/packages/core/src/pam/identity/service/phone-login.service.ts
@@ -330,10 +330,24 @@ export class PhoneLoginService {
       throw new ORPCError('INTERNAL_SERVER_ERROR', { message: 'Account not found.' });
     }
 
+    // Resolved once, before either gate below, so both the RG-block and the
+    // Backoffice-block events - and the eventual phone-login success event - can all
+    // carry playerId.
+    const [playerRow] = await this.drizzle.db
+      .select({ id: player.id, status: player.status })
+      .from(player)
+      .where(eq(player.userId, account.id))
+      .limit(1);
+
     // RG login block applied only AFTER the OTP verifies so a probe can't distinguish
     // a restricted account from a wrong code.
     if (isRgBlocked(account)) {
-      this.events.emit('rg.exclusion.login_blocked', { userId: account.id, ip, userAgent });
+      this.events.emit('rg.exclusion.login_blocked', {
+        userId: account.id,
+        playerId: playerRow?.id ?? null,
+        ip,
+        userAgent,
+      });
       throw new ORPCError('FORBIDDEN', {
         message: 'Account access is currently restricted (responsible gambling).',
         data: { reason: PhoneLoginErrorReasonSchema.enum.rg_blocked },
@@ -345,14 +359,10 @@ export class PhoneLoginService {
     // the email path there is nothing to revoke here; the OTP is left unconsumed so the
     // gate reads the same as the RG block above. Distinct from RG (self_excluded is out of
     // scope) - a suspended/closed player can never complete phone login.
-    const [playerRow] = await this.drizzle.db
-      .select({ status: player.status })
-      .from(player)
-      .where(eq(player.userId, account.id))
-      .limit(1);
     if (playerRow && (playerRow.status === 'suspended' || playerRow.status === 'closed')) {
       this.events.emit('player.login_blocked', {
         userId: account.id,
+        playerId: playerRow.id,
         status: playerRow.status,
         ip,
         userAgent,
@@ -387,6 +397,7 @@ export class PhoneLoginService {
 
     this.events.emit('identity.user.phone_login', {
       userId: account.id,
+      playerId: playerRow?.id ?? null,
       method: 'phone',
       ip,
       userAgent,

--- a/packages/core/src/pam/identity/service/session.service.ts
+++ b/packages/core/src/pam/identity/service/session.service.ts
@@ -5,7 +5,7 @@ import {
   makeNotFoundError,
 } from '@openora/core/server';
 import { eq, asc, desc, and, gt, count, sql } from 'drizzle-orm';
-import type { ClientMeta, User, PaginationOptions } from '@openora/core/contracts';
+import type { ClientMeta, IdentityReader, User, PaginationOptions } from '@openora/core/contracts';
 import { session } from '../schema/index.js';
 import { type SessionItem, type SessionSortBy } from '../contract/index.js';
 
@@ -14,15 +14,18 @@ export const SessionNotFoundError = makeNotFoundError('Session');
 export type SessionServiceDeps = {
   drizzle: DrizzleService;
   events: EventBus;
+  identityReader: IdentityReader;
 };
 
 export class SessionService {
   private readonly drizzle: DrizzleService;
   private readonly events: EventBus;
+  private readonly identityReader: IdentityReader;
 
-  constructor({ drizzle, events }: SessionServiceDeps) {
+  constructor({ drizzle, events, identityReader }: SessionServiceDeps) {
     this.drizzle = drizzle;
     this.events = events;
+    this.identityReader = identityReader;
   }
 
   async listSessions({
@@ -82,6 +85,7 @@ export class SessionService {
 
     this.events.emit('identity.session.revoked', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       sessionId: id,
       actorId,
       ip: meta?.ip ?? null,
@@ -98,6 +102,7 @@ export class SessionService {
 
     this.events.emit('identity.sessions.revoked_all', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       actorId,
       ip: meta?.ip ?? null,
       userAgent: meta?.userAgent ?? null,

--- a/packages/core/src/pam/player-management/__tests__/kyc-status-writer.int.test.ts
+++ b/packages/core/src/pam/player-management/__tests__/kyc-status-writer.int.test.ts
@@ -43,7 +43,7 @@ beforeEach(async () => {
 describe('PlayerKycStatusWriter.setStatus (real PG)', () => {
   it('writes the new status and emits the change with its previous value', async () => {
     const { writer, events } = makeWriter();
-    const { userId } = await seedPlayer({ kycStatus: 'pending' });
+    const { id: playerId, userId } = await seedPlayer({ kycStatus: 'pending' });
     const actorId = randomUUID();
 
     await writer.setStatus(userId, 'verified', { actorId, source: 'manual' });
@@ -51,6 +51,7 @@ describe('PlayerKycStatusWriter.setStatus (real PG)', () => {
     expect(await statusOf(userId)).toBe('verified');
     expect(events.emit).toHaveBeenCalledWith('compliance.kyc.updated', {
       userId,
+      playerId,
       actorId,
       status: 'verified',
       previousStatus: 'pending',

--- a/packages/core/src/pam/player-management/__tests__/player.service.int.test.ts
+++ b/packages/core/src/pam/player-management/__tests__/player.service.int.test.ts
@@ -412,6 +412,7 @@ describe('PlayerService.update player.level.changed emission (real PG)', () => {
 
     expect(events.emit).toHaveBeenCalledWith('player.level.changed', {
       userId: account.id,
+      playerId: seeded.id,
       previousLevel: 1,
       newLevel: 5,
       actorId: account.id,

--- a/packages/core/src/pam/player-management/service/kyc-status-writer.ts
+++ b/packages/core/src/pam/player-management/service/kyc-status-writer.ts
@@ -5,7 +5,7 @@ import { eq, sql } from 'drizzle-orm';
 import { player } from '@openora/core/pam/schema/profile';
 import { PlayerNotFoundError } from './player.service.js';
 
-type ConditionalUpdateRow = { previous_status: KycStatus };
+type ConditionalUpdateRow = { previous_status: KycStatus; player_id: string };
 
 /**
  * The single writer of `player.kycStatus` (the KYC_STATUS_WRITER seam). Every status
@@ -35,7 +35,7 @@ export class PlayerKycStatusWriter implements KycStatusWriter {
       SET kyc_status = ${status}
       FROM (SELECT kyc_status FROM player WHERE user_id = ${userId} FOR UPDATE) AS prev
       WHERE player.user_id = ${userId} AND prev.kyc_status <> ${status}
-      RETURNING prev.kyc_status AS previous_status
+      RETURNING prev.kyc_status AS previous_status, player.id AS player_id
     `);
     const changed = rows[0];
 
@@ -52,6 +52,7 @@ export class PlayerKycStatusWriter implements KycStatusWriter {
 
     this.events.emit('compliance.kyc.updated', {
       userId,
+      playerId: changed.player_id,
       actorId: opts.actorId,
       status,
       previousStatus: changed.previous_status,

--- a/packages/core/src/pam/player-management/service/player.service.ts
+++ b/packages/core/src/pam/player-management/service/player.service.ts
@@ -242,6 +242,7 @@ export class PlayerService {
     if (data.level !== undefined && data.level !== existing.level) {
       this.events.emit('player.level.changed', {
         userId: existing.userId,
+        playerId,
         previousLevel: existing.level,
         newLevel: data.level,
         actorId,

--- a/packages/core/src/pam/tag/__tests__/tag-evaluation.service.int.test.ts
+++ b/packages/core/src/pam/tag/__tests__/tag-evaluation.service.int.test.ts
@@ -165,6 +165,7 @@ function makeServices(
     getLastLoginAt: vi.fn().mockResolvedValue(null),
     getPlayerIdsInactiveSince: vi.fn().mockResolvedValue([]),
     getPlayerIdByUserId: vi.fn(async (uid: string) => uid),
+    getPlayerIdByUserIdSafe: vi.fn(async (uid: string) => uid),
     getPlayerKycStatusByUserId: vi.fn().mockResolvedValue('pending'),
     getPlayerUserIdsSharingLoginIp: vi.fn().mockResolvedValue([]),
     ...overrides.identityReader,
@@ -184,14 +185,27 @@ function makeServices(
 }
 
 function depositPayload(userId: string, amount: number) {
-  return { userId, amount: String(amount), currency: 'USD', transactionId: randomUUID() };
+  return {
+    userId,
+    playerId: null,
+    amount: String(amount),
+    currency: 'USD',
+    transactionId: randomUUID(),
+  };
 }
 function withdrawalPayload(userId: string, amount: number) {
-  return { userId, amount: String(amount), currency: 'USD', transactionId: randomUUID() };
+  return {
+    userId,
+    playerId: null,
+    amount: String(amount),
+    currency: 'USD',
+    transactionId: randomUUID(),
+  };
 }
 function kycUpdatedPayload(userId: string, status: KycStatus) {
   return {
     userId,
+    playerId: null,
     actorId: SYSTEM_ACTOR_ID,
     status,
     previousStatus: 'pending',
@@ -470,7 +484,7 @@ describe('TagEvaluationService.onUserLogin (real PG)', () => {
     const { inactiveTag } = await seedLoginCleanupTags();
     await seedActiveAssignment(userId, inactiveTag);
 
-    await service.onUserLogin({ userId });
+    await service.onUserLogin({ userId, playerId: null });
 
     expect(await activeTagKeys(userId)).not.toContain('inactive');
     const row = await assignmentRow(userId, inactiveTag);
@@ -483,7 +497,7 @@ describe('TagEvaluationService.onUserLogin (real PG)', () => {
     const { dormantTag } = await seedLoginCleanupTags();
     await seedActiveAssignment(userId, dormantTag);
 
-    await service.onUserLogin({ userId });
+    await service.onUserLogin({ userId, playerId: null });
 
     expect(await activeTagKeys(userId)).not.toContain('dormant_high_roller');
   });
@@ -493,7 +507,7 @@ describe('TagEvaluationService.onUserLogin (real PG)', () => {
     const { service } = makeServices();
     await seedLoginCleanupTags();
 
-    await expect(service.onUserLogin({ userId })).resolves.toBeUndefined();
+    await expect(service.onUserLogin({ userId, playerId: null })).resolves.toBeUndefined();
   });
 
   it('assigns multi_account and bonus_abuser to both player accounts when login IP is shared', async () => {
@@ -506,7 +520,7 @@ describe('TagEvaluationService.onUserLogin (real PG)', () => {
     await seedRule('multi_account');
     await seedRule('bonus_abuser');
 
-    await service.onUserLogin({ userId, ip: '203.0.113.10', userAgent: null });
+    await service.onUserLogin({ userId, playerId: null, ip: '203.0.113.10', userAgent: null });
 
     expect(identityReader.getPlayerUserIdsSharingLoginIp).toHaveBeenCalledWith(
       userId,
@@ -527,7 +541,7 @@ describe('TagEvaluationService.onUserLogin (real PG)', () => {
     await seedRule('multi_account');
     await seedRule('bonus_abuser');
 
-    await service.onUserLogin({ userId });
+    await service.onUserLogin({ userId, playerId: null });
 
     expect(identityReader.getPlayerUserIdsSharingLoginIp).not.toHaveBeenCalled();
   });
@@ -544,6 +558,7 @@ describe('TagEvaluationService.onUserLogin (real PG)', () => {
 
     await service.onUserPhoneLogin({
       userId,
+      playerId: null,
       method: 'phone',
       ip: '203.0.113.11',
       userAgent: null,
@@ -564,7 +579,12 @@ describe('TagEvaluationService.onKycSubmitted (real PG)', () => {
     const { service } = makeServices();
     await seedKycPendingRule();
 
-    await service.onKycSubmitted({ userId, referenceId: 'ref-1', provider: 'sumsub' });
+    await service.onKycSubmitted({
+      userId,
+      playerId: null,
+      referenceId: 'ref-1',
+      provider: 'sumsub',
+    });
 
     expect(await activeTagKeys(userId)).toContain('kyc_pending');
   });
@@ -575,7 +595,12 @@ describe('TagEvaluationService.onKycSubmitted (real PG)', () => {
     const { kycRejectedTag } = await seedKycPendingRule();
     await seedActiveAssignment(userId, kycRejectedTag);
 
-    await service.onKycSubmitted({ userId, referenceId: 'ref-1', provider: 'sumsub' });
+    await service.onKycSubmitted({
+      userId,
+      playerId: null,
+      referenceId: 'ref-1',
+      provider: 'sumsub',
+    });
 
     expect(await activeTagKeys(userId)).toContain('kyc_pending');
     expect(await activeTagKeys(userId)).toContain('kyc_rejected');
@@ -588,7 +613,12 @@ describe('TagEvaluationService.onKycSubmitted (real PG)', () => {
     });
     await seedKycPendingRule();
 
-    await service.onKycSubmitted({ userId, referenceId: 'ref-1', provider: 'sumsub' });
+    await service.onKycSubmitted({
+      userId,
+      playerId: null,
+      referenceId: 'ref-1',
+      provider: 'sumsub',
+    });
 
     expect(await activeTagKeys(userId)).toEqual([]);
   });
@@ -598,7 +628,12 @@ describe('TagEvaluationService.onKycSubmitted (real PG)', () => {
     const { service } = makeServices();
     await seedRule('kyc_pending', { isEnabled: false });
 
-    await service.onKycSubmitted({ userId, referenceId: 'ref-1', provider: 'sumsub' });
+    await service.onKycSubmitted({
+      userId,
+      playerId: null,
+      referenceId: 'ref-1',
+      provider: 'sumsub',
+    });
 
     expect(await activeTagKeys(userId)).toEqual([]);
   });
@@ -610,7 +645,7 @@ describe('TagEvaluationService.onKycSubmitted (real PG)', () => {
     await seedActiveAssignment(userId, kycPendingTag);
 
     await expect(
-      service.onKycSubmitted({ userId, referenceId: 'ref-1', provider: 'sumsub' }),
+      service.onKycSubmitted({ userId, playerId: null, referenceId: 'ref-1', provider: 'sumsub' }),
     ).resolves.toBeUndefined();
 
     const rows = await db.drizzle.db
@@ -1063,6 +1098,7 @@ describe('TagEvaluationService.onSelfExclusionActivated / onSelfExclusionLifted 
 
     await service.onSelfExclusionActivated({
       userId,
+      playerId: null,
       actorId: SYSTEM_ACTOR_ID,
       reason: 'player requested self-exclusion',
       exclusionId: randomUUID(),
@@ -1083,6 +1119,7 @@ describe('TagEvaluationService.onSelfExclusionActivated / onSelfExclusionLifted 
     await expect(
       service.onSelfExclusionActivated({
         userId,
+        playerId: null,
         actorId: SYSTEM_ACTOR_ID,
         reason: 'player requested self-exclusion',
         exclusionId: randomUUID(),
@@ -1101,6 +1138,7 @@ describe('TagEvaluationService.onSelfExclusionActivated / onSelfExclusionLifted 
 
     await service.onSelfExclusionLifted({
       userId,
+      playerId: null,
       actorId: SYSTEM_ACTOR_ID,
       reason: 'exclusion period expired',
       exclusionId: randomUUID(),
@@ -1118,6 +1156,7 @@ describe('TagEvaluationService.onSelfExclusionActivated / onSelfExclusionLifted 
     await expect(
       service.onSelfExclusionLifted({
         userId,
+        playerId: null,
         actorId: SYSTEM_ACTOR_ID,
         reason: 'exclusion period expired',
         exclusionId: randomUUID(),
@@ -1136,6 +1175,7 @@ describe('TagEvaluationService.onPlayerLevelChanged (real PG)', () => {
 
     await service.onPlayerLevelChanged({
       userId,
+      playerId: null,
       previousLevel: 3,
       newLevel: 4,
       actorId: SYSTEM_ACTOR_ID,
@@ -1158,12 +1198,14 @@ describe('TagEvaluationService.onPlayerLevelChanged (real PG)', () => {
       Promise.all([
         service.onPlayerLevelChanged({
           userId,
+          playerId: null,
           previousLevel: 0,
           newLevel: 1,
           actorId: SYSTEM_ACTOR_ID,
         }),
         service.onPlayerLevelChanged({
           userId,
+          playerId: null,
           previousLevel: 0,
           newLevel: 2,
           actorId: SYSTEM_ACTOR_ID,
@@ -1193,6 +1235,7 @@ describe('TagEvaluationService.onPlayerLevelChanged (real PG)', () => {
     await expect(
       service.onPlayerLevelChanged({
         userId,
+        playerId: null,
         previousLevel: 0,
         newLevel: 1,
         actorId: SYSTEM_ACTOR_ID,
@@ -1210,6 +1253,7 @@ describe('TagEvaluationService.onPlayerLevelChanged (real PG)', () => {
     await expect(
       service.onPlayerLevelChanged({
         userId,
+        playerId: null,
         previousLevel: 3,
         newLevel: 4,
         actorId: SYSTEM_ACTOR_ID,
@@ -1240,7 +1284,7 @@ describe('TagEvaluationService idempotency (real PG)', () => {
     const { service } = makeServices();
     await seedLoginCleanupTags();
 
-    await expect(service.onUserLogin({ userId })).resolves.toBeUndefined();
+    await expect(service.onUserLogin({ userId, playerId: null })).resolves.toBeUndefined();
     expect(await activeTagKeys(userId)).toEqual([]);
   });
 });

--- a/packages/core/src/pam/tag/service/tag.service.ts
+++ b/packages/core/src/pam/tag/service/tag.service.ts
@@ -445,7 +445,48 @@ export class TagService implements PlayerTags {
     try {
       const db = this.drizzle.db;
       const { removalReason, ...assignArgs } = args;
+      const [activeAtStart] = await db
+        .select({ id: playerTag.id })
+        .from(playerTag)
+        .innerJoin(tag, eq(tag.id, playerTag.tagId))
+        .where(
+          and(
+            eq(playerTag.playerId, args.playerId),
+            eq(tag.key, args.tagKey),
+            isNull(playerTag.removedAt),
+          ),
+        )
+        .limit(1);
       const result = await db.transaction(async (trx) => {
+        // Serialize replacements for the same player before inspecting/removing the
+        // current assignment. The partial unique index protects the insert, but without
+        // this lock a second transaction can wait for the first to commit, observe its
+        // newly-created active row, remove it, and complete a second successful swap.
+        await trx
+          .select({ id: player.id })
+          .from(player)
+          .where(eq(player.id, args.playerId))
+          .for('update');
+
+        const [activeAfterWait] = await trx
+          .select({ id: playerTag.id })
+          .from(playerTag)
+          .innerJoin(tag, eq(tag.id, playerTag.tagId))
+          .where(
+            and(
+              eq(playerTag.playerId, args.playerId),
+              eq(tag.key, args.tagKey),
+              isNull(playerTag.removedAt),
+            ),
+          )
+          .limit(1);
+        if (
+          activeAfterWait &&
+          (activeAtStart === undefined || activeAfterWait.id !== activeAtStart.id)
+        ) {
+          throw new TagAlreadyInUseError();
+        }
+
         let removed = false;
         try {
           // App-level throw from findOneOrThrow, not a failed SQL statement, so

--- a/packages/core/src/server/auth/admin-guard.ts
+++ b/packages/core/src/server/auth/admin-guard.ts
@@ -5,6 +5,7 @@ import {
   type Token,
   type AdminPermissionResolver,
   type AdminGrant,
+  type IdentityReader,
   type ClientMeta,
 } from '@openora/core/contracts';
 import { DrizzleService } from '../db/index.js';
@@ -12,9 +13,12 @@ import { sql } from 'drizzle-orm';
 import { SessionResolver } from './session-resolver.js';
 import { roles, type ResourceName, type ActionOf } from './permissions.js';
 import type { OssContext, EventBus } from '../kernel/index.js';
+import { createLogger } from '../kernel/logger.js';
 import { extractClientMeta } from '../kernel/router-utils.js';
 
 export const ADMIN_GUARD: Token<AdminGuard> = createToken('ADMIN_GUARD');
+
+const logger = createLogger('admin-guard');
 
 export type AdminCaller = { userId: string; role: string } & ClientMeta;
 
@@ -38,6 +42,10 @@ export class AdminGuard {
     // When bound (iam module loaded), grants come from DB; otherwise falls back to static roles.
     private readonly permissionResolver?: AdminPermissionResolver,
     private readonly events?: EventBus,
+    // When bound (identity module loaded), resolves the PAM player.id for a
+    // player-role denial's audit attribution. This engine-zone file must not import
+    // the player schema directly (ADR-0019/0025), so it goes through this port instead.
+    private readonly identityReader?: IdentityReader,
   ) {}
 
   async assert(context: unknown): Promise<AdminCaller>;
@@ -150,13 +158,24 @@ export class AdminGuard {
     ip: string | null,
     userAgent: string | null,
   ) {
-    this.events?.emit('identity.user.unauthorized_access', {
-      userId,
-      resource,
-      action,
-      ip,
-      userAgent,
-      role,
-    });
+    void (async () => {
+      const playerId =
+        role === 'player'
+          ? ((await this.identityReader?.getPlayerIdByUserIdSafe(userId)) ?? null)
+          : null;
+      try {
+        this.events?.emit('identity.user.unauthorized_access', {
+          userId,
+          playerId,
+          resource,
+          action,
+          ip,
+          userAgent,
+          role,
+        });
+      } catch (err) {
+        logger.error({ err, userId, resource, action }, 'denial audit event failed');
+      }
+    })();
   }
 }

--- a/packages/core/src/server/kernel/__tests__/event-bus.int.test.ts
+++ b/packages/core/src/server/kernel/__tests__/event-bus.int.test.ts
@@ -56,6 +56,7 @@ describe('createEventBus over Redis Streams', () => {
 
     bus.emit('wallet.deposit.completed', {
       userId: 'u1',
+      playerId: null,
       amount: '50',
       currency: 'USD',
       transactionId: 'tx1',
@@ -64,7 +65,7 @@ describe('createEventBus over Redis Streams', () => {
     await vi.waitFor(
       () =>
         expect(received).toEqual([
-          { userId: 'u1', amount: '50', currency: 'USD', transactionId: 'tx1' },
+          { userId: 'u1', playerId: null, amount: '50', currency: 'USD', transactionId: 'tx1' },
         ]),
       DELIVERY,
     );
@@ -83,6 +84,7 @@ describe('createEventBus over Redis Streams', () => {
 
     bus.emit('wallet.deposit.completed', {
       userId: 'u1',
+      playerId: null,
       amount: '10',
       currency: 'USD',
       transactionId: 'tx2',
@@ -112,12 +114,14 @@ describe('createEventBus over Redis Streams', () => {
 
     bus.emit('wallet.deposit.completed', {
       userId: 'u1',
+      playerId: null,
       amount: '1',
       currency: 'USD',
       transactionId: 'a',
     });
     bus.emit('wallet.deposit.completed', {
       userId: 'u1',
+      playerId: null,
       amount: '2',
       currency: 'USD',
       transactionId: 'b',
@@ -143,7 +147,7 @@ describe('createEventBus over Redis Streams', () => {
       group: serviceName,
     });
 
-    bus.emit('identity.user.registered', { userId: 'u1' });
+    bus.emit('identity.user.registered', { userId: 'u1', playerId: null });
 
     await vi.waitFor(() => expect(order).toEqual(['first', 'second']), DELIVERY);
     expect(logger.error).toHaveBeenCalledWith(
@@ -182,7 +186,7 @@ describe('createEventBus over Redis Streams', () => {
     };
     const bus = createEventBus(rejectingBroker, logger);
 
-    bus.emit('gaming.round.ended', { roundId: 'r1', userId: 'u1' });
+    bus.emit('gaming.round.ended', { roundId: 'r1', userId: 'u1', playerId: null });
     await flush();
 
     expect(logger.error).toHaveBeenCalledWith(
@@ -202,11 +206,11 @@ describe('createEventBus over Redis Streams', () => {
     };
     const bus = createEventBus(fakeBroker, fakeLogger());
 
-    bus.emit('gaming.round.ended', { roundId: 'r1', userId: 'u1' });
+    bus.emit('gaming.round.ended', { roundId: 'r1', userId: 'u1', playerId: null });
 
     expect(published).toHaveLength(1);
     expect(published[0]?.topic).toBe('gaming.round.ended');
-    expect(published[0]?.payload).toEqual({ roundId: 'r1', userId: 'u1' });
+    expect(published[0]?.payload).toEqual({ roundId: 'r1', userId: 'u1', playerId: null });
     expect(typeof published[0]?.eventId).toBe('string');
   });
 });

--- a/packages/core/src/server/runtime/create-app.ts
+++ b/packages/core/src/server/runtime/create-app.ts
@@ -29,6 +29,7 @@ import {
   JOB_QUEUE,
   OUTBOX,
   ADMIN_PERMISSION_RESOLVER,
+  IDENTITY_READER,
   RATE_LIMITER,
   CACHE,
   ERROR_TRACKING,
@@ -261,6 +262,8 @@ export async function createApp(
         // has() avoids throwing on an unbound token so boot works without the iam module.
         c.has(ADMIN_PERMISSION_RESOLVER) ? c.get(ADMIN_PERMISSION_RESOLVER) : undefined,
         c.get(EVENT_BUS),
+        // has() avoids throwing on an unbound token so boot works without the identity module.
+        c.has(IDENTITY_READER) ? c.get(IDENTITY_READER) : undefined,
       ),
   );
   if (config.igaming) {

--- a/packages/core/src/testing/mock.ts
+++ b/packages/core/src/testing/mock.ts
@@ -7,7 +7,7 @@ import type {
   EventBus,
   OssContext,
 } from '@openora/core/server';
-import type { AuditWritePort, ClientMeta } from '@openora/core/contracts';
+import type { AuditWritePort, ClientMeta, IdentityReader } from '@openora/core/contracts';
 
 // The one sanctioned home for test-double type assertions. A unit test standing in
 // for a collaborator is inherently partial, so the cast lives here - documented and
@@ -102,6 +102,16 @@ export const makeAuditWriter = (): AuditWritePort & { record: Mock } => ({
   record: vi.fn(async () => undefined),
   recordInTransaction: vi.fn(async () => undefined),
 });
+
+export const makeIdentityReader = (): IdentityReader =>
+  mock<IdentityReader>({
+    getLastLoginAt: vi.fn().mockResolvedValue(null),
+    getPlayerIdsInactiveSince: vi.fn().mockResolvedValue([]),
+    getPlayerIdByUserId: vi.fn().mockResolvedValue(null),
+    getPlayerIdByUserIdSafe: vi.fn().mockResolvedValue(null),
+    getPlayerKycStatusByUserId: vi.fn().mockResolvedValue(null),
+    getPlayerUserIdsSharingLoginIp: vi.fn().mockResolvedValue([]),
+  });
 
 const matches = (refs: readonly string[], resource: string, action: string) =>
   refs.includes(resource) || refs.includes(`${resource}:${action}`);

--- a/packages/core/src/wallet/__tests__/wallet-auto-rule.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-rule.router.int.test.ts
@@ -10,6 +10,7 @@ import {
   testContext,
   makeAuditWriter,
   makeAdminGuard,
+  makeIdentityReader,
 } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { autoWithdrawalRule } from '../schema/index.js';
@@ -49,6 +50,7 @@ function routerWith(adminGuard: AdminGuard) {
     events: makeEventBus(),
     payment: mock<PaymentAdapter>({}),
     audit,
+    identityReader: makeIdentityReader(),
   });
   const router = createWalletRouter(
     service,

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
@@ -11,12 +11,14 @@ import type {
   PlayerTags,
 } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import {
   mock,
   makeEventBus,
   testContext,
   makeAuditWriter,
   makeAdminGuard,
+  makeIdentityReader,
   NO_CLIENT_META,
 } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
@@ -30,7 +32,7 @@ const CALLER_ID = '9a2f7c11-0000-4000-8000-0000000000bb';
 let db: TestDb;
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {
@@ -91,6 +93,7 @@ function routerWith(adminGuard: AdminGuard, platformConfig?: Partial<PlatformCon
       })),
     }),
     audit,
+    identityReader: makeIdentityReader(),
     directory,
     platformConfig: platformConfig ? mock<PlatformConfig>(platformConfig) : undefined,
     riskTags,

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
@@ -14,7 +14,14 @@ import type {
   TagKey,
 } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
-import { mock, makeEventBus, NO_CLIENT_META, makeAuditWriter } from '../../testing/mock.js';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
+import {
+  mock,
+  makeEventBus,
+  makeIdentityReader,
+  NO_CLIENT_META,
+  makeAuditWriter,
+} from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import {
   wallet,
@@ -101,6 +108,7 @@ async function makeService({
     events: events,
     payment: mock<PaymentAdapter>(psp),
     audit: mock<AuditWritePort>(audit),
+    identityReader: makeIdentityReader(),
     directory,
     platformConfig,
     ...(riskTags === 'unbound'
@@ -133,7 +141,7 @@ async function txById(id: string) {
 }
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {
@@ -391,6 +399,7 @@ describe('WalletService.withdraw auto-approval (real PG)', () => {
       events: makeEventBus(),
       payment,
       audit: mock<AuditWritePort>(makeAuditWriter()),
+      identityReader: makeIdentityReader(),
       directory,
       platformConfig,
       riskTags,

--- a/packages/core/src/wallet/__tests__/wallet-kyc-gate.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-kyc-gate.int.test.ts
@@ -9,7 +9,14 @@ import type {
   AdminPlayerSummary,
 } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
-import { mock, makeEventBus, NO_CLIENT_META, makeAuditWriter } from '../../testing/mock.js';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
+import {
+  mock,
+  makeEventBus,
+  makeIdentityReader,
+  NO_CLIENT_META,
+  makeAuditWriter,
+} from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { wallet, walletTransaction } from '../schema/index.js';
 import { WalletService, KycRequiredError } from '../service/wallet.service.js';
@@ -29,6 +36,7 @@ function makeService(kycStatus: KycStatus | null, gateWithdrawals: boolean) {
     events: makeEventBus(),
     payment: mock<PaymentAdapter>({ processWithdrawal: vi.fn() }),
     audit: makeAuditWriter(),
+    identityReader: makeIdentityReader(),
     directory,
     platformConfig: mock<PlatformConfig>({ kyc: { gateWithdrawals } }),
   });
@@ -52,7 +60,7 @@ async function txCount(walletId: string) {
 }
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {

--- a/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
@@ -9,7 +9,14 @@ import type {
   PaymentWebhookVerifier,
 } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
-import { mock, makeEventBus, testContext, makeAuditWriter } from '../../testing/mock.js';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
+import {
+  mock,
+  makeEventBus,
+  makeIdentityReader,
+  testContext,
+  makeAuditWriter,
+} from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { wallet, walletTransaction, walletDepositAddress } from '../schema/index.js';
 import { createWalletRouter } from '../router/index.js';
@@ -21,7 +28,7 @@ const DEPOSIT_ADDRESS = 'bc1qxyz';
 let db: TestDb;
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {
@@ -40,6 +47,7 @@ function routerWith(payment: PaymentAdapter, verifier: PaymentWebhookVerifier) {
     events: makeEventBus(),
     payment,
     audit: makeAuditWriter(),
+    identityReader: makeIdentityReader(),
   });
   return createWalletRouter(
     service,

--- a/packages/core/src/wallet/__tests__/wallet.rate-limit.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.rate-limit.int.test.ts
@@ -3,8 +3,9 @@ import { randomUUID } from 'node:crypto';
 import { sql } from 'drizzle-orm';
 import { RedisRateLimiter } from '@openora/core/server';
 import { createTestDb, createTestRedis, type TestDb, type TestRedis } from '@openora/core/testing';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import type { PaymentAdapter, AuditWritePort } from '@openora/core/contracts';
-import { mock, NO_CLIENT_META, makeEventBus } from '../../testing/mock.js';
+import { mock, NO_CLIENT_META, makeEventBus, makeIdentityReader } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { wallet, walletTransaction } from '../schema/index.js';
 import { WalletService } from '../service/wallet.service.js';
@@ -24,6 +25,7 @@ const makeService = () =>
     events,
     payment,
     audit,
+    identityReader: makeIdentityReader(),
     limiter: new RedisRateLimiter(redis.client),
   });
 
@@ -36,7 +38,7 @@ async function seedWallet() {
 }
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
   redis = await createTestRedis();
 });
 

--- a/packages/core/src/wallet/__tests__/wallet.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.router.int.test.ts
@@ -10,6 +10,7 @@ import {
   testContext,
   makeAuditWriter,
   makeAdminGuard,
+  makeIdentityReader,
 } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { wallet, walletTransaction } from '../schema/index.js';
@@ -40,6 +41,7 @@ function realWalletService() {
     events: makeEventBus(),
     payment: mock<PaymentAdapter>({}),
     audit: makeAuditWriter(),
+    identityReader: makeIdentityReader(),
   });
 }
 

--- a/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
@@ -8,7 +8,14 @@ import type {
   TagEvaluationCommands,
 } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
-import { mock, makeEventBus, NO_CLIENT_META, makeAuditWriter } from '../../testing/mock.js';
+import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
+import {
+  mock,
+  makeEventBus,
+  makeIdentityReader,
+  NO_CLIENT_META,
+  makeAuditWriter,
+} from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
 import { wallet, walletTransaction, walletDepositAddress } from '../schema/index.js';
 import {
@@ -45,6 +52,7 @@ function makeService(overrides: Partial<WalletServiceDeps> = {}) {
     events: events,
     payment: mock<PaymentAdapter>(psp),
     audit,
+    identityReader: makeIdentityReader(),
     ...overrides,
   });
   return { svc, events, psp, audit };
@@ -109,7 +117,7 @@ const emittedTopics = (events: ReturnType<typeof makeEventBus>) =>
   events.emit.mock.calls.map(([topic]) => topic);
 
 beforeAll(async () => {
-  db = await createTestDb([migrate]);
+  db = await createTestDb([migrate, migrateProfile]);
 });
 
 afterAll(async () => {

--- a/packages/core/src/wallet/plugin.ts
+++ b/packages/core/src/wallet/plugin.ts
@@ -3,6 +3,7 @@ import type { CoreTokenCatalog, Plugin } from '@openora/core/server';
 import * as z from 'zod';
 import {
   ADMIN_USER_DIRECTORY,
+  IDENTITY_READER,
   ADMIN_WALLET_REPORTING,
   PAYMENT_ADAPTER,
   PAYMENT_WEBHOOK_VERIFIER,
@@ -58,6 +59,7 @@ export default {
           drizzle: c.get(DRIZZLE),
           events: c.get(EVENT_BUS),
           payment: c.get(PAYMENT_ADAPTER),
+          identityReader: c.get(IDENTITY_READER),
           directory: c.get(ADMIN_USER_DIRECTORY),
           platformConfig: c.has(PLATFORM_CONFIG) ? c.get(PLATFORM_CONFIG) : undefined,
           limiter: c.get(RATE_LIMITER),

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -28,6 +28,7 @@ import {
   type TagEvaluationCommands,
   type TagKey,
   type User,
+  type IdentityReader,
   type ClientMeta,
   type PaginationOptions,
 } from '@openora/core/contracts';
@@ -197,6 +198,7 @@ export type WalletServiceDeps = {
   drizzle: DrizzleService;
   events: EventBus;
   payment: PaymentAdapter;
+  identityReader: IdentityReader;
   directory?: AdminUserDirectory;
   platformConfig?: PlatformConfig;
   limiter?: RateLimiterAdapter<RateLimitKey>;
@@ -223,6 +225,7 @@ export class WalletService {
   private readonly drizzle: DrizzleService;
   private readonly events: EventBus;
   private readonly payment: PaymentAdapter;
+  private readonly identityReader: IdentityReader;
   private readonly directory?: AdminUserDirectory;
   private readonly platformConfig?: PlatformConfig;
   private readonly limiter?: RateLimiterAdapter<RateLimitKey>;
@@ -235,6 +238,7 @@ export class WalletService {
     events,
     payment,
     directory,
+    identityReader,
     platformConfig,
     limiter,
     riskTags,
@@ -245,6 +249,7 @@ export class WalletService {
     this.events = events;
     this.payment = payment;
     this.directory = directory;
+    this.identityReader = identityReader;
     this.platformConfig = platformConfig;
     this.limiter = limiter;
     this.riskTags = riskTags;
@@ -384,6 +389,7 @@ export class WalletService {
     if (!replayed) {
       this.events.emit('wallet.deposit.completed', {
         userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
         amount,
         currency,
         transactionId,
@@ -606,6 +612,7 @@ export class WalletService {
 
     this.events.emit('wallet.withdrawal.requested', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       amount,
       currency,
       transactionId,
@@ -844,6 +851,7 @@ export class WalletService {
       .where(eq(walletTransaction.id, tx.id));
     this.events.emit('wallet.withdrawal.completed', {
       userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
       amount,
       currency: tx.currency,
       transactionId: tx.id,
@@ -918,6 +926,7 @@ export class WalletService {
       }
       this.events.emit('wallet.withdrawal.completed', {
         userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
         amount: tx.amount,
         currency: tx.currency,
         transactionId: tx.id,
@@ -1542,6 +1551,7 @@ export class WalletService {
     if (!replayed) {
       this.events.emit('wallet.deposit.completed', {
         userId: depositAddress.userId,
+        playerId: await this.identityReader.getPlayerIdByUserIdSafe(depositAddress.userId),
         amount: event.amount,
         currency: event.currency,
         transactionId,

--- a/packages/testing/src/__tests__/kyc.e2e.test.ts
+++ b/packages/testing/src/__tests__/kyc.e2e.test.ts
@@ -117,7 +117,7 @@ afterAll(async () => {
 describe('KYC submit (default MockKycAdapter) + admin read + authz', () => {
   it('auto-verifies via the mock vendor, is admin-readable, and is denied to non-admins', async () => {
     const email = `kyc-submit-${randomUUID()}@e2e.test`;
-    const { client, userId } = await registerAndMaterializePlayer(appDefault.app, email);
+    const { client, userId, playerId } = await registerAndMaterializePlayer(appDefault.app, email);
 
     const submitRes = await client.post('/compliance/kyc', {
       documents: [{ type: 'passport', frontUrl: 'https://example.test/front.jpg' }],
@@ -145,7 +145,7 @@ describe('KYC submit (default MockKycAdapter) + admin read + authz', () => {
 
     await vi.waitFor(async () => {
       const res = await admin.get(
-        `/audit/logs?resourceId=${userId}&action=compliance.kyc.submitted`,
+        `/audit/logs?resourceId=${playerId}&action=compliance.kyc.submitted`,
       );
       const body = await readJson(res);
       expect(body.items.length).toBeGreaterThanOrEqual(1);
@@ -154,7 +154,9 @@ describe('KYC submit (default MockKycAdapter) + admin read + authz', () => {
     });
 
     await vi.waitFor(async () => {
-      const res = await admin.get(`/audit/logs?resourceId=${userId}&action=compliance.kyc.updated`);
+      const res = await admin.get(
+        `/audit/logs?resourceId=${playerId}&action=compliance.kyc.updated`,
+      );
       const body = await readJson(res);
       expect(body.items.length).toBeGreaterThanOrEqual(1);
       expect(body.items[0].before).toMatchObject({ kycStatus: 'pending' });
@@ -169,7 +171,7 @@ describe('KYC submit (default MockKycAdapter) + admin read + authz', () => {
 describe('KYC webhook reconcile (gated stack)', () => {
   it('a valid HMAC signature reconciles; a forged/missing one is rejected and changes nothing', async () => {
     const email = `kyc-webhook-${randomUUID()}@e2e.test`;
-    const { client, userId } = await registerAndMaterializePlayer(appGated.app, email);
+    const { client, userId, playerId } = await registerAndMaterializePlayer(appGated.app, email);
     const admin = await asAdmin(appGated.app);
 
     const submitRes = await client.post('/compliance/kyc', {
@@ -216,7 +218,9 @@ describe('KYC webhook reconcile (gated stack)', () => {
     });
 
     await vi.waitFor(async () => {
-      const res = await admin.get(`/audit/logs?resourceId=${userId}&action=compliance.kyc.updated`);
+      const res = await admin.get(
+        `/audit/logs?resourceId=${playerId}&action=compliance.kyc.updated`,
+      );
       const body = await readJson(res);
       expect(body.items.length).toBeGreaterThanOrEqual(1);
       expect(body.items[0].actorType).toBe('system');
@@ -232,7 +236,7 @@ describe('KYC webhook reconcile (gated stack)', () => {
 describe('KYC withdrawal gate (gated stack)', () => {
   it('blocks an unapproved withdrawal, then allows it once an admin marks the player approved', async () => {
     const email = `kyc-withdraw-${randomUUID()}@e2e.test`;
-    const { client, userId } = await registerAndMaterializePlayer(appGated.app, email);
+    const { client, userId, playerId } = await registerAndMaterializePlayer(appGated.app, email);
     const admin = await asAdmin(appGated.app);
 
     const depositRes = await client.post('/wallet/deposit', { amount: '2', currency: 'USD' });
@@ -258,7 +262,9 @@ describe('KYC withdrawal gate (gated stack)', () => {
     expect(allowed.transactionId).toBeTruthy();
 
     await vi.waitFor(async () => {
-      const res = await admin.get(`/audit/logs?resourceId=${userId}&action=compliance.kyc.updated`);
+      const res = await admin.get(
+        `/audit/logs?resourceId=${playerId}&action=compliance.kyc.updated`,
+      );
       const body = await readJson(res);
       expect(body.items.length).toBeGreaterThanOrEqual(1);
       expect(body.items[0].actorType).toBe('admin');
@@ -306,7 +312,7 @@ describe('KYC threshold re-KYC on deposit (gated stack)', () => {
 describe('KYC admin actions: resubmit / override / bulk-approve (default stack)', () => {
   it('requestKycResubmission writes a manual history row, audits it, and notifies the player through the job queue', async () => {
     const email = `kyc-resubmit-${randomUUID()}@e2e.test`;
-    const { client, userId } = await registerAndMaterializePlayer(appDefault.app, email);
+    const { client, userId, playerId } = await registerAndMaterializePlayer(appDefault.app, email);
     const admin = await asAdmin(appDefault.app);
 
     const anonRes = await appDefault.app.request(`/compliance/players/${userId}/kyc/resubmit`, {
@@ -336,7 +342,7 @@ describe('KYC admin actions: resubmit / override / bulk-approve (default stack)'
 
     await vi.waitFor(async () => {
       const auditRes = await admin.get(
-        `/audit/logs?resourceId=${userId}&action=compliance.kyc.updated`,
+        `/audit/logs?resourceId=${playerId}&action=compliance.kyc.updated`,
       );
       const body = await readJson(auditRes);
       expect(body.items.length).toBeGreaterThanOrEqual(1);
@@ -369,7 +375,7 @@ describe('KYC admin actions: resubmit / override / bulk-approve (default stack)'
 
   it('overrideKycStatus writes a rejected choice verbatim (no manually_overridden remap) with reason + actor in the audit log', async () => {
     const email = `kyc-override-reject-${randomUUID()}@e2e.test`;
-    const { userId } = await registerAndMaterializePlayer(appDefault.app, email);
+    const { userId, playerId } = await registerAndMaterializePlayer(appDefault.app, email);
     const admin = await asAdmin(appDefault.app);
 
     const emptyReasonRes = await admin.post(`/compliance/players/${userId}/kyc/override`, {
@@ -387,7 +393,7 @@ describe('KYC admin actions: resubmit / override / bulk-approve (default stack)'
 
     await vi.waitFor(async () => {
       const auditRes = await admin.get(
-        `/audit/logs?resourceId=${userId}&action=compliance.kyc.updated`,
+        `/audit/logs?resourceId=${playerId}&action=compliance.kyc.updated`,
       );
       const body = await readJson(auditRes);
       expect(body.items[0].after).toMatchObject({
@@ -401,8 +407,14 @@ describe('KYC admin actions: resubmit / override / bulk-approve (default stack)'
   it('bulkApproveKyc approves multiple players (one audit entry each) and isolates a not-found id without losing the rest of the batch', async () => {
     const emailA = `kyc-bulk-a-${randomUUID()}@e2e.test`;
     const emailB = `kyc-bulk-b-${randomUUID()}@e2e.test`;
-    const { userId: userA } = await registerAndMaterializePlayer(appDefault.app, emailA);
-    const { userId: userB } = await registerAndMaterializePlayer(appDefault.app, emailB);
+    const { userId: userA, playerId: playerA } = await registerAndMaterializePlayer(
+      appDefault.app,
+      emailA,
+    );
+    const { userId: userB, playerId: playerB } = await registerAndMaterializePlayer(
+      appDefault.app,
+      emailB,
+    );
     const missingUserId = randomUUID();
     const admin = await asAdmin(appDefault.app);
 
@@ -429,9 +441,9 @@ describe('KYC admin actions: resubmit / override / bulk-approve (default stack)'
     }
 
     await vi.waitFor(async () => {
-      for (const userId of [userA, userB]) {
+      for (const playerId of [playerA, playerB]) {
         const auditRes = await admin.get(
-          `/audit/logs?resourceId=${userId}&action=compliance.kyc.updated`,
+          `/audit/logs?resourceId=${playerId}&action=compliance.kyc.updated`,
         );
         const auditBody = await readJson(auditRes);
         expect(auditBody.items.length).toBeGreaterThanOrEqual(1);
@@ -477,7 +489,7 @@ describe('Backoffice player list KYC status filter (legacy verified compatibilit
 describe('KYC status writer concurrency (real Postgres FOR UPDATE)', () => {
   it('two concurrent overrideKycStatus calls to the same target status write exactly one history row and one audit entry', async () => {
     const email = `kyc-concurrent-override-${randomUUID()}@e2e.test`;
-    const { userId } = await registerAndMaterializePlayer(appDefault.app, email);
+    const { userId, playerId } = await registerAndMaterializePlayer(appDefault.app, email);
     const admin = await asAdmin(appDefault.app);
 
     // Two real HTTP requests racing through the full router -> service -> Postgres
@@ -503,7 +515,7 @@ describe('KYC status writer concurrency (real Postgres FOR UPDATE)', () => {
 
     await vi.waitFor(async () => {
       const auditRes = await admin.get(
-        `/audit/logs?resourceId=${userId}&action=compliance.kyc.updated`,
+        `/audit/logs?resourceId=${playerId}&action=compliance.kyc.updated`,
       );
       const auditBody = await readJson(auditRes);
       expect(auditBody.items).toHaveLength(1);

--- a/packages/testing/src/__tests__/kyc.e2e.test.ts
+++ b/packages/testing/src/__tests__/kyc.e2e.test.ts
@@ -150,7 +150,7 @@ describe('KYC submit (default MockKycAdapter) + admin read + authz', () => {
       const body = await readJson(res);
       expect(body.items.length).toBeGreaterThanOrEqual(1);
       expect(body.items[0].actorType).toBe('player');
-      expect(body.items[0].actorId).toBe(userId);
+      expect(body.items[0].actorId).toBe(playerId);
     });
 
     await vi.waitFor(async () => {

--- a/packages/testing/src/__tests__/rg.e2e.test.ts
+++ b/packages/testing/src/__tests__/rg.e2e.test.ts
@@ -57,7 +57,12 @@ async function registerPlayer(email: string) {
   }
   const body = (await readJson(res)) as { user: { id: string } };
   const client = await asPlayer(app.app, { email });
-  return { client, userId: body.user.id };
+  // Materialize the PAM player row (get-or-create) so RG actions taken against this
+  // user resolve to a real player.id for the audit trail - see audit/plugin.ts
+  // mapEventToRecord's resolvePlayerId.
+  const profileRes = await client.get('/profile');
+  const profile = (await profileRes.json()) as { id: string };
+  return { client, userId: body.user.id, playerId: profile.id };
 }
 
 async function attemptLogin(email: string, password: string) {
@@ -372,7 +377,9 @@ describe('RG cooling-off lift', () => {
   });
 
   it('records the lift in the audit trail with actor, reason and subject', async () => {
-    const { userId } = await registerPlayer(`rg-cooloff-lift-audit-${randomUUID()}@e2e.test`);
+    const { userId, playerId } = await registerPlayer(
+      `rg-cooloff-lift-audit-${randomUUID()}@e2e.test`,
+    );
 
     await admin.post(`/compliance/players/${userId}/cooling-off`, {
       durationHours: 24,
@@ -383,7 +390,9 @@ describe('RG cooling-off lift', () => {
     });
 
     await vi.waitFor(async () => {
-      const res = await admin.get(`/audit/logs?resourceId=${userId}&action=rg.cooling_off.lifted`);
+      const res = await admin.get(
+        `/audit/logs?resourceId=${playerId}&action=rg.cooling_off.lifted`,
+      );
       const body = await readJson(res);
       expect(body.items).toHaveLength(1);
       expect(body.items[0].actorType).toBe('admin');
@@ -623,7 +632,7 @@ describe('RG monitoring (queue-based)', () => {
 
 describe('RG audit trail', () => {
   it('every RG mutation leaves an audit row with the right actor + before/after', async () => {
-    const { userId } = await registerPlayer(`rg-audit-${randomUUID()}@e2e.test`);
+    const { userId, playerId } = await registerPlayer(`rg-audit-${randomUUID()}@e2e.test`);
 
     const limitRes = await admin.put(`/compliance/players/${userId}/limits`, {
       type: 'deposit',
@@ -658,7 +667,7 @@ describe('RG audit trail', () => {
     expect(liftRes.status).toBe(200);
 
     await vi.waitFor(async () => {
-      const res = await admin.get(`/audit/logs?resourceId=${userId}&action=rg.limit.set`);
+      const res = await admin.get(`/audit/logs?resourceId=${playerId}&action=rg.limit.set`);
       const body = await readJson(res);
       expect(body.items).toHaveLength(1);
       expect(body.items[0].actorType).toBe('admin');
@@ -667,7 +676,7 @@ describe('RG audit trail', () => {
 
     await vi.waitFor(async () => {
       const res = await admin.get(
-        `/audit/logs?resourceId=${userId}&action=rg.cooling_off.activated`,
+        `/audit/logs?resourceId=${playerId}&action=rg.cooling_off.activated`,
       );
       const body = await readJson(res);
       expect(body.items).toHaveLength(1);
@@ -676,7 +685,7 @@ describe('RG audit trail', () => {
 
     await vi.waitFor(async () => {
       const res = await admin.get(
-        `/audit/logs?resourceId=${userId}&action=rg.self_exclusion.activated`,
+        `/audit/logs?resourceId=${playerId}&action=rg.self_exclusion.activated`,
       );
       const body = await readJson(res);
       expect(body.items).toHaveLength(1);
@@ -693,7 +702,7 @@ describe('RG audit trail', () => {
 
     await vi.waitFor(async () => {
       const res = await admin.get(
-        `/audit/logs?resourceId=${userId}&action=rg.self_exclusion.lifted`,
+        `/audit/logs?resourceId=${playerId}&action=rg.self_exclusion.lifted`,
       );
       const body = await readJson(res);
       expect(body.items).toHaveLength(1);
@@ -704,7 +713,7 @@ describe('RG audit trail', () => {
 
   it('records a system-actor audit row for a blocked login attempt', async () => {
     const email = `rg-audit-login-${randomUUID()}@e2e.test`;
-    const { userId } = await registerPlayer(email);
+    const { userId, playerId } = await registerPlayer(email);
 
     await admin.post(`/compliance/players/${userId}/self-exclusion`, {
       isPermanent: true,
@@ -715,7 +724,7 @@ describe('RG audit trail', () => {
 
     await vi.waitFor(async () => {
       const res = await admin.get(
-        `/audit/logs?resourceId=${userId}&action=rg.exclusion.login_blocked`,
+        `/audit/logs?resourceId=${playerId}&action=rg.exclusion.login_blocked`,
       );
       const body = await readJson(res);
       expect(body.items).toHaveLength(1);
@@ -725,7 +734,7 @@ describe('RG audit trail', () => {
   });
 
   it('exportCsv({actionPrefix: "rg."}) returns only rg.* rows', async () => {
-    const { userId } = await registerPlayer(`rg-audit-export-${randomUUID()}@e2e.test`);
+    const { userId, playerId } = await registerPlayer(`rg-audit-export-${randomUUID()}@e2e.test`);
 
     const limitRes = await admin.put(`/compliance/players/${userId}/limits`, {
       type: 'wager',
@@ -736,11 +745,11 @@ describe('RG audit trail', () => {
     expect(limitRes.status).toBe(200);
 
     await vi.waitFor(async () => {
-      const res = await admin.get(`/audit/logs?resourceId=${userId}&action=rg.limit.set`);
+      const res = await admin.get(`/audit/logs?resourceId=${playerId}&action=rg.limit.set`);
       expect((await readJson(res)).items).toHaveLength(1);
     });
 
-    const exportRes = await admin.get(`/audit/export?actionPrefix=rg.&resourceId=${userId}`);
+    const exportRes = await admin.get(`/audit/export?actionPrefix=rg.&resourceId=${playerId}`);
     expect(exportRes.status).toBe(200);
     const { csv } = await readJson(exportRes);
     expect(csv).toContain('rg.limit.set');

--- a/packages/testing/src/__tests__/tag-bf317.e2e.test.ts
+++ b/packages/testing/src/__tests__/tag-bf317.e2e.test.ts
@@ -178,7 +178,7 @@ describe('level: atomic replace-on-change driven by player.level.changed', () =>
   it('sets level, verifies the tag + reason, changes it again, verifies exactly one active row', async () => {
     const admin = await asAdmin(app.app);
     const email = `level-${randomUUID()}@e2e.test`;
-    const { playerId, userId } = await registerAndMaterializePlayer(app.app, email);
+    const { playerId } = await registerAndMaterializePlayer(app.app, email);
 
     // no level tag before any admin edit
     expect(await activeTagKeys(admin, playerId)).not.toContain('level');
@@ -203,9 +203,10 @@ describe('level: atomic replace-on-change driven by player.level.changed', () =>
       expect(levelTags[0]?.reason).toBe('player level set to 7');
     });
 
-    // player.level.changed's audit resourceId is the identity userId (the subject
-    // player), not the PAM playerId - see audit/plugin.ts mapEventToRecord.
-    await auditHasEntry(admin, userId, 'player.level.changed');
+    // player.level.changed's audit resourceId is the PAM playerId (resolved from the
+    // subject's identity userId), not the raw userId - see audit/plugin.ts
+    // mapEventToRecord / AuditService.resolvePlayerId.
+    await auditHasEntry(admin, playerId, 'player.level.changed');
   });
 
   it('no-op: updating a field other than level does not touch the level tag', async () => {

--- a/packages/testing/src/__tests__/tag.e2e.test.ts
+++ b/packages/testing/src/__tests__/tag.e2e.test.ts
@@ -31,6 +31,7 @@ import {
 
 let db: TestDb;
 let app: TestApp;
+let admin: TestClient;
 
 // oxlint-disable-next-line typescript/no-explicit-any -- ad-hoc JSON shape assertions in tests
 async function readJson(res: Response): Promise<any> {
@@ -131,6 +132,9 @@ beforeAll(async () => {
   const plugins = await loadExtensions();
   app = await bootTestApp({ plugins, databaseUrl: db.url });
   await seedMinimal(app.container, { playerCount: 0 });
+  // Reuse one admin session across the file; the identity login rate limit is
+  // intentionally bounded and this suite performs many admin requests.
+  admin = await asAdmin(app.app);
 }, 60_000);
 
 afterAll(async () => {
@@ -140,7 +144,6 @@ afterAll(async () => {
 
 describe('withdrawal_review: assign on wallet.withdrawal.requested', () => {
   it('assigns the tag when a withdrawal attempt meets the threshold, not below it', async () => {
-    const admin = await asAdmin(app.app);
     await upsertRule(admin, 'withdrawal_review', {
       isEnabled: true,
       threshold: '500',
@@ -182,7 +185,6 @@ describe('withdrawal_review: assign on wallet.withdrawal.requested', () => {
   });
 
   it('is sticky - the withdrawal completing afterwards never removes it (no automated removal path exists)', async () => {
-    const admin = await asAdmin(app.app);
     const email = `wr-sticky-${randomUUID()}@e2e.test`;
     const { client, playerId } = await registerAndMaterializePlayer(app.app, email);
     await client.post('/wallet/deposit', { amount: '1000', currency: 'USD' });
@@ -210,7 +212,6 @@ describe('withdrawal_review: assign on wallet.withdrawal.requested', () => {
 
 describe('dormant_high_roller: co-occurrence sweep + login removal', () => {
   it('assigns only to inactive players who also hold high_roller, then removes on login without touching high_roller', async () => {
-    const admin = await asAdmin(app.app);
     await upsertRule(admin, 'dormant_high_roller', {
       isEnabled: true,
       threshold: null,
@@ -259,7 +260,6 @@ describe('dormant_high_roller: co-occurrence sweep + login removal', () => {
   });
 
   it('rule disabled: sweep takes no action for the tag', async () => {
-    const admin = await asAdmin(app.app);
     await upsertRule(admin, 'dormant_high_roller', {
       isEnabled: false,
       threshold: null,
@@ -288,7 +288,6 @@ describe('dormant_high_roller: co-occurrence sweep + login removal', () => {
 
 describe('high_risk: existing assign path unaffected, frequency-only resweep', () => {
   it('amount-only rule (no thresholdDays/thresholdCount): the daily sweep never resweeps/removes it', async () => {
-    const admin = await asAdmin(app.app);
     await upsertRule(admin, 'high_risk', {
       isEnabled: true,
       threshold: '999999',
@@ -306,7 +305,6 @@ describe('high_risk: existing assign path unaffected, frequency-only resweep', (
   });
 
   it('assigns via withdrawal count breach (existing path), then the resweep removes it once the window ages the withdrawals out', async () => {
-    const admin = await asAdmin(app.app);
     await upsertRule(admin, 'high_risk', {
       isEnabled: true,
       threshold: '999999',
@@ -355,7 +353,6 @@ describe('high_risk: existing assign path unaffected, frequency-only resweep', (
 
 describe('idempotency: at-least-once event delivery does not throw', () => {
   it('re-emitting wallet.withdrawal.requested for an already-tagged player does not throw (literal AC wording)', async () => {
-    const admin = await asAdmin(app.app);
     await upsertRule(admin, 'withdrawal_review', {
       isEnabled: true,
       threshold: '500',
@@ -367,7 +364,13 @@ describe('idempotency: at-least-once event delivery does not throw', () => {
     const { userId, playerId } = await registerAndMaterializePlayer(app.app, email);
 
     const eventBus = app.container.get(EVENT_BUS);
-    const payload = { userId, amount: '600', currency: 'USD', transactionId: randomUUID() };
+    const payload = {
+      userId,
+      playerId: null,
+      amount: '600',
+      currency: 'USD',
+      transactionId: randomUUID(),
+    };
     eventBus.emit('wallet.withdrawal.requested', payload);
     eventBus.emit('wallet.withdrawal.requested', payload);
 
@@ -386,7 +389,6 @@ describe('idempotency: at-least-once event delivery does not throw', () => {
   });
 
   it('exactly one of 5 concurrent assignPlayerTag calls succeeds; the rest are rejected as a conflict (race repro, fixed by the player_tag_active_key unique index)', async () => {
-    const admin = await asAdmin(app.app);
     const email = `race-assign-${randomUUID()}@e2e.test`;
     const { playerId } = await registerAndMaterializePlayer(app.app, email);
 
@@ -424,8 +426,8 @@ describe('idempotency: at-least-once event delivery does not throw', () => {
     const { userId } = await registerAndMaterializePlayer(app.app, email);
 
     const eventBus = app.container.get(EVENT_BUS);
-    eventBus.emit('identity.user.login', { userId });
-    eventBus.emit('identity.user.login', { userId });
+    eventBus.emit('identity.user.login', { userId, playerId: null });
+    eventBus.emit('identity.user.login', { userId, playerId: null });
 
     // No assertion beyond "did not crash the process" - tryRemoveTag swallows
     // TagAssignmentNotFoundError; give the async handlers a beat to run.
@@ -507,7 +509,6 @@ describe('authz: the 6 previously-unguarded tag routes', () => {
 
     // Positive control: a legitimate admin session succeeds on listPlayerTags and
     // listAssignableTags for the same player - proves the guard isn't too broad.
-    const admin = await asAdmin(app.app);
     const adminListRes = await admin.get(`/player/${playerId}/player-tag?page=1&limit=20`);
     expect(adminListRes.status).toBe(200);
     const adminAssignableRes = await admin.get(`/player/${playerId}/assignable-tags`);
@@ -516,7 +517,6 @@ describe('authz: the 6 previously-unguarded tag routes', () => {
 
   it('players never see their own tags: a non-admin player cannot read tags even on their own profile', async () => {
     const email = `authz-selfread-${randomUUID()}@e2e.test`;
-    const admin = await asAdmin(app.app);
     const { client, playerId } = await registerAndMaterializePlayer(app.app, email);
     await assignTagManually(admin, playerId, 'vip');
 


### PR DESCRIPTION
## Summary

Fix audit records so player-scoped events store the PAM player ID as resourceId. Update integration and E2E coverage for KYC, responsible gambling, and player-level audit flows. BF-335.

## Why

Player audit events previously persisted the identity user ID while declaring resourceType as player. Admin log and export filters using the actual player ID therefore missed those records.

## Alternatives considered

Keep using the identity user ID as resourceId, but that conflicts with the declared player resource type and the identifiers used by player-facing consumers.

## Risks

No schema migration. When an event references a user without a materialized player row, resourceId remains null.