### PR TITLE
fix(audit): don't tag non-player identity actors as player

### DIFF
--- a/packages/core/src/audit/__tests__/audit.service.int.test.ts
+++ b/packages/core/src/audit/__tests__/audit.service.int.test.ts
@@ -654,4 +654,50 @@ describe('mapEventToRecord() player.id resolution (BF-335)', () => {
     expect(row.actorId).toBe(p.id);
     expect(row.actorId).not.toBe(p.userId);
   });
+
+  it('identity.user.login: no player row (admin account) - actorType is admin, actorId is the userId', async () => {
+    const userId = randomUUID();
+
+    const row = await mapAndRecord('identity.user.login', {
+      userId,
+      playerId: null,
+    });
+
+    expect(row.actorType).toBe('admin');
+    expect(row.actorId).toBe(userId);
+  });
+
+  it('identity.user.login: resolved playerId (player account) - actorType is player, actorId is the player.id', async () => {
+    const p = await seedPlayer();
+
+    const row = await mapAndRecord('identity.user.login', {
+      userId: p.userId,
+      playerId: p.id,
+    });
+
+    expect(row.actorType).toBe('player');
+    expect(row.actorId).toBe(p.id);
+  });
+
+  it('identity.user.registered: no player row yet - still actorType player, actorId null (unchanged carve-out)', async () => {
+    const row = await mapAndRecord('identity.user.registered', {
+      userId: randomUUID(),
+      playerId: null,
+    });
+
+    expect(row.actorType).toBe('player');
+    expect(row.actorId).toBeNull();
+  });
+
+  it('identity.profile.updated: no player row (admin account) - actorType is admin, actorId is the userId', async () => {
+    const userId = randomUUID();
+
+    const row = await mapAndRecord('identity.profile.updated', {
+      userId,
+      playerId: null,
+    });
+
+    expect(row.actorType).toBe('admin');
+    expect(row.actorId).toBe(userId);
+  });
 });

--- a/packages/core/src/audit/plugin.ts
+++ b/packages/core/src/audit/plugin.ts
@@ -538,10 +538,34 @@ export async function mapEventToRecord(
     };
   }
 
-  // Generic player-self-action fallback (login/logout/registered/2fa/password
-  // reset/email verified/profile updated, gaming rounds, self-service RG limits,
-  // ...): actorId = the resolved playerId. `identity.user.registered` legitimately
-  // has no player row yet at emit time, so this can be null.
+  // Registration always precedes player-row creation (public sign-up only, no
+  // admin path): actorType stays 'player' even though playerId is legitimately
+  // null at emit time, before the async listener creates the row.
+  if (topic === 'identity.user.registered') {
+    return { ...base, actorId: str(p['playerId']), actorType: 'player' };
+  }
+
+  // Shared identity self-action topics: the same `/identity/*` endpoints serve
+  // both player and admin accounts, so playerId only resolves for a player. A
+  // null playerId means the account has no player row - attribute to the
+  // admin's own userId instead of mislabeling them as a player.
+  if (
+    topic === 'identity.user.login' ||
+    topic === 'identity.user.logout' ||
+    topic === 'identity.2fa.enabled' ||
+    topic === 'identity.2fa.disabled' ||
+    topic === 'identity.password.reset' ||
+    topic === 'identity.email.verified' ||
+    topic === 'identity.profile.updated'
+  ) {
+    const playerId = p['playerId'];
+    return playerId
+      ? { ...base, actorId: str(playerId), actorType: 'player' }
+      : { ...base, actorId: str(p['userId']), actorType: 'admin' };
+  }
+
+  // Generic player-self-action fallback (gaming rounds, chat, self-service RG
+  // limits, ...): actorId = the resolved playerId.
   if (typeof p['userId'] === 'string') {
     return { ...base, actorId: str(p['playerId']), actorType: 'player' };
   }


### PR DESCRIPTION
## Summary

BF-335 follow-up: `identity.user.login` and other shared identity self-action events tagged `actorType: 'player'` even when the authenticating account had no PAM player row (e.g. an admin logging in via the shared `/identity/login` endpoint), leaving `actorId: null` and a mislabeled actor on the audit record.

## Why

`mapEventToRecord`'s generic fallback in `packages/core/src/audit/plugin.ts` set `actorType: 'player'` whenever `p['userId']` was a string, without checking whether `p['playerId']` actually resolved. `identity.service.ts` emits `playerId: null` for any account with no player profile, so every admin action through these shared endpoints (login, logout, 2fa enable/disable, password reset, email verified, profile updated) was recorded as a player with a dangling null actor id.

## Alternatives considered

None.

## Risks

None. Single-file mapper change, no contract/schema/DB impact (`docs/catalog.json` unchanged). `identity.user.registered` keeps its existing unconditional `'player'` behavior via its own carved-out branch (its `playerId` is legitimately null before the async player-row listener runs). `identity.user.login.failed` and `identity.session.revoked`/`sessions.revoked_all` are unaffected - they already have dedicated branches earlier in the mapper. Existing audit rows written before this fix keep their incorrect `actorType` (audit rows are append-only, never corrected retroactively).