### PR TITLE
feat(pam): expose and search by player id on the admin directory

### DIFF
--- a/.changeset/admin-lists-player-id.md
+++ b/.changeset/admin-lists-player-id.md
@@ -1,0 +1,10 @@
+---
+'@openora/core': minor
+---
+
+`AdminPlayerSummary` (the admin/back-office user-directory enrichment port) gains a required `playerId` field alongside `userId`, so back-office consumers can label a row by the real PAM player id instead of the auth-layer user id.
+
+- `AdminPlayerSummary.playerId` is populated by `DrizzleAdminUserDirectory.lookupPlayers` and `.getPlayerByUsername`, selected from the same inner join that already resolves `username`/`kycStatus`.
+- The Transaction Monitor list/detail contract (`AdminTransactionSchema`, inherited by `AdminTransactionDetailSchema`) and the Withdrawal Queue contract (`WithdrawalQueueItemSchema`) both gain a nullable `playerId: UuidSchema.nullable()`, mirroring the existing `playerEmail` nullable pattern - null when the user has no PAM player row.
+- `BackofficeService`'s transaction mappers and `WalletService.listWithdrawals` now surface `playerId` from the enriched directory summary.
+- `findPlayerIds` (the free-text player search on the admin user directory port) now also matches an exact `playerId` or `userId`, not just email/displayName - previously searching by either id returned an empty result.

--- a/packages/core/src/admin-console/__tests__/backoffice.service.int.test.ts
+++ b/packages/core/src/admin-console/__tests__/backoffice.service.int.test.ts
@@ -15,6 +15,7 @@ import { migrate as migrateGaming } from '@openora/core/casino/migrate/gaming';
 import { game, gameRound } from '@openora/core/casino/schema/gaming';
 import { DrizzleAdminGameReporting } from '@openora/core/casino/server';
 import { BackofficeService, TransactionNotFoundError } from '../service/backoffice.service.js';
+import { AdminTransactionSchema } from '../contract/index.js';
 
 function makeUsers(over: Partial<AdminUserDirectory> = {}): AdminUserDirectory {
   return mock<AdminUserDirectory>({
@@ -68,14 +69,23 @@ function txRow(over: Partial<AdminTxRow> = {}): AdminTxRow {
 }
 
 describe('BackofficeService.listTransactions', () => {
-  it('resolves a player query to userIds and enriches rows with email', async () => {
-    const findPlayerIds = vi.fn().mockResolvedValue(['u-1']);
-    const listTransactions = vi.fn().mockResolvedValue({ rows: [txRow()], total: 1 });
-    const lookupPlayers = vi
+  it('resolves a player query to userIds and enriches rows with email and playerId', async () => {
+    const txId = randomUUID();
+    const userId = randomUUID();
+    const playerId = randomUUID();
+    const findPlayerIds = vi.fn().mockResolvedValue([userId]);
+    const listTransactions = vi
       .fn()
-      .mockResolvedValue([
-        { userId: 'u-1', username: 'alice', email: 'alice@example.com', kycStatus: 'verified' },
-      ]);
+      .mockResolvedValue({ rows: [txRow({ id: txId, userId })], total: 1 });
+    const lookupPlayers = vi.fn().mockResolvedValue([
+      {
+        playerId,
+        userId,
+        username: 'alice',
+        email: 'alice@example.com',
+        kycStatus: 'verified',
+      },
+    ]);
     const svc = new BackofficeService(
       makeUsers({ findPlayerIds, lookupPlayers }),
       makeReporting({ listTransactions }),
@@ -84,11 +94,13 @@ describe('BackofficeService.listTransactions', () => {
     );
     const res = await svc.listTransactions({ page: 1, limit: 20, player: 'alice' });
     expect(findPlayerIds).toHaveBeenCalledWith('alice');
-    expect(listTransactions).toHaveBeenCalledWith(expect.objectContaining({ userIds: ['u-1'] }));
+    expect(listTransactions).toHaveBeenCalledWith(expect.objectContaining({ userIds: [userId] }));
     expect(res.items[0]).toMatchObject({
       rail: 'fiat',
+      playerId,
       playerEmail: 'alice@example.com',
     });
+    expect(() => AdminTransactionSchema.parse(res.items[0])).not.toThrow();
   });
 
   it('uses an explicit userId directly when no player query is given', async () => {
@@ -155,7 +167,7 @@ describe('BackofficeService.listTransactions', () => {
       makePlayerActivity(),
     );
     const res = await svc.listTransactions({ page: 1, limit: 20 });
-    expect(res.items[0]).toMatchObject({ playerEmail: null });
+    expect(res.items[0]).toMatchObject({ playerId: null, playerEmail: null });
   });
 
   it('converts ISO date filters to Date for the port', async () => {
@@ -202,11 +214,16 @@ describe('BackofficeService.getTransaction', () => {
   });
 
   it('maps the detail incl. ISO reviewedAt and enriched player', async () => {
-    const lookupPlayers = vi
-      .fn()
-      .mockResolvedValue([
-        { userId: 'u-1', username: 'alice', email: 'alice@example.com', kycStatus: 'verified' },
-      ]);
+    const playerId = randomUUID();
+    const lookupPlayers = vi.fn().mockResolvedValue([
+      {
+        playerId,
+        userId: 'u-1',
+        username: 'alice',
+        email: 'alice@example.com',
+        kycStatus: 'verified',
+      },
+    ]);
     const svc = new BackofficeService(
       makeUsers({ lookupPlayers }),
       makeReporting({ getTransaction: vi.fn().mockResolvedValue(detail()) }),
@@ -218,6 +235,7 @@ describe('BackofficeService.getTransaction', () => {
       providerName: 'stripe',
       providerRefId: 'pi_1',
       reviewedAt: '2026-01-02T00:00:00.000Z',
+      playerId,
       playerEmail: 'alice@example.com',
       playerUsername: 'alice',
       playerKycStatus: 'verified',

--- a/packages/core/src/admin-console/contract/index.ts
+++ b/packages/core/src/admin-console/contract/index.ts
@@ -71,8 +71,8 @@ export const TransactionFilterSchema = PageQuerySchema.extend({
   sortOrder: SortOrderSchema.default('desc').optional(),
 });
 
-// The list row carries only the player email as the identifying label; the fuller
-// player info (username, KYC) lives on the detail view fetched on "view".
+// The list row carries the playerId and player email as the identifying labels;
+// the fuller player info (username, KYC) lives on the detail view fetched on "view".
 export const AdminTransactionSchema = z.object({
   id: UuidSchema,
   userId: UuidSchema,
@@ -81,6 +81,7 @@ export const AdminTransactionSchema = z.object({
   currency: CurrencyCodeSchema,
   status: WalletTransactionStatusSchema,
   rail: WalletRailSchema.nullable(),
+  playerId: UuidSchema.nullable(),
   playerEmail: PlayerEmailSchema.nullable(),
   createdAt: TimestampSchema,
 });

--- a/packages/core/src/admin-console/service/backoffice.service.ts
+++ b/packages/core/src/admin-console/service/backoffice.service.ts
@@ -29,6 +29,7 @@ function toAdminUser(r: AdminUserRow) {
 function toAdminTransaction(r: AdminTxRow, player?: AdminPlayerSummary) {
   return {
     ...serializeRow(r, { dateFields: ['createdAt'] }),
+    playerId: player?.playerId ?? null,
     playerEmail: player?.email ?? null,
   };
 }
@@ -36,6 +37,7 @@ function toAdminTransaction(r: AdminTxRow, player?: AdminPlayerSummary) {
 function toAdminTransactionDetail(r: AdminTxDetail, player?: AdminPlayerSummary) {
   return {
     ...serializeRow(r, { dateFields: ['createdAt', 'reviewedAt'] }),
+    playerId: player?.playerId ?? null,
     playerEmail: player?.email ?? null,
     playerUsername: player?.username ?? null,
     playerKycStatus: player?.kycStatus ?? null,

--- a/packages/core/src/contracts/adapters/admin-user-directory.ts
+++ b/packages/core/src/contracts/adapters/admin-user-directory.ts
@@ -1,5 +1,5 @@
 import { createToken, type Token } from './token.js';
-import type { KycStatus } from '../schemas/player.js';
+import type { KycStatus, Player } from '../schemas/player.js';
 import type { UserRole } from '../schemas/iam.js';
 import type { ClientMeta } from '../schemas/common.js';
 import type { SortOrder } from '../kit.js';
@@ -40,11 +40,8 @@ export type AdminUserListOptions = {
   sortOrder?: SortOrder;
 };
 
-/**
- * Player-facing back-office enrichment (username + KYC). Lets a back-office
- * consumer label a player row without reaching into the player/profile tables.
- */
 export type AdminPlayerSummary = {
+  playerId: Player['id'];
   userId: string;
   username: string;
   email: string;

--- a/packages/core/src/contracts/adapters/admin-user-directory.ts
+++ b/packages/core/src/contracts/adapters/admin-user-directory.ts
@@ -40,6 +40,10 @@ export type AdminUserListOptions = {
   sortOrder?: SortOrder;
 };
 
+/**
+ * Player-facing back-office enrichment (username + KYC). Lets a back-office
+ * consumer label a player row without reaching into the player/profile tables.
+ */
 export type AdminPlayerSummary = {
   playerId: Player['id'];
   userId: string;

--- a/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
+++ b/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
@@ -1227,6 +1227,7 @@ describe('ChatService.verifyRoomAccess and listings (real PG)', () => {
     const now = new Date();
     function summary(userId: string, username: string): AdminPlayerSummary {
       return {
+        playerId: randomUUID(),
         userId,
         username,
         email: `${username}@example.test`,

--- a/packages/core/src/engagement/social-transfers/service/__tests__/social-transfers.service.test.ts
+++ b/packages/core/src/engagement/social-transfers/service/__tests__/social-transfers.service.test.ts
@@ -98,6 +98,9 @@ function makeWallet(ok = true): WalletCommands {
 }
 
 const DIRECTORY_CREATED_AT = new Date('2026-01-01T00:00:00.000Z');
+const ACTOR_PLAYER_ID = '00000000-0000-0000-0000-000000000101';
+const CLAIMER_PLAYER_ID = '00000000-0000-0000-0000-000000000102';
+const RECIPIENT_2_PLAYER_ID = '00000000-0000-0000-0000-000000000106';
 
 function makeDirectory(
   senderUsername = 'bob',
@@ -106,6 +109,7 @@ function makeDirectory(
 ): AdminUserDirectory {
   const all = [
     {
+      playerId: ACTOR_PLAYER_ID,
       userId: ACTOR_ID,
       username: senderUsername,
       email: 'bob@example.com',
@@ -117,6 +121,7 @@ function makeDirectory(
       currency: 'USD',
     },
     {
+      playerId: CLAIMER_PLAYER_ID,
       userId: CLAIMER_ID,
       username: claimerUsername,
       email: 'alice@example.com',
@@ -128,6 +133,7 @@ function makeDirectory(
       currency: 'USD',
     },
     {
+      playerId: RECIPIENT_2_PLAYER_ID,
       userId: RECIPIENT_2,
       username: 'charlie',
       email: 'charlie@example.com',
@@ -139,6 +145,7 @@ function makeDirectory(
       currency: 'USD',
     },
     ...extraUserIds.map((userId, index) => ({
+      playerId: `00000000-0000-0000-0000-0000001${String(index).padStart(5, '0')}`,
       userId,
       username: `player${index}`,
       email: `player${index}@example.com`,
@@ -812,6 +819,7 @@ const DONATE_SYSTEM_MSG: CommandChatMessage = {
 function makeRecipientDirectory(): AdminUserDirectory {
   const all = [
     {
+      playerId: ACTOR_PLAYER_ID,
       userId: ACTOR_ID,
       username: 'bob',
       email: 'bob@example.com',
@@ -823,6 +831,7 @@ function makeRecipientDirectory(): AdminUserDirectory {
       currency: 'USD',
     },
     {
+      playerId: CLAIMER_PLAYER_ID,
       userId: CLAIMER_ID,
       username: 'alice',
       email: 'alice@example.com',

--- a/packages/core/src/pam/identity/__tests__/admin-user-directory.int.test.ts
+++ b/packages/core/src/pam/identity/__tests__/admin-user-directory.int.test.ts
@@ -175,11 +175,15 @@ describe('DrizzleAdminUserDirectory.lookupPlayers (real PG)', () => {
   it('joins the email from the user table onto the player summary', async () => {
     const { dir } = makeDirectory();
     const account = await seedUser({ email: 'alice@example.com' });
-    await seedPlayer(account.id, { displayName: 'alice', kycStatus: 'verified' });
+    const seededPlayer = await seedPlayer(account.id, {
+      displayName: 'alice',
+      kycStatus: 'verified',
+    });
 
     const [summary] = await dir.lookupPlayers([account.id]);
 
     expect(summary).toEqual({
+      playerId: seededPlayer.id,
       userId: account.id,
       username: 'alice',
       email: 'alice@example.com',
@@ -190,6 +194,8 @@ describe('DrizzleAdminUserDirectory.lookupPlayers (real PG)', () => {
       level: 1,
       currency: 'USD',
     });
+    expect(summary?.playerId).toBe(seededPlayer.id);
+    expect(summary?.playerId).not.toBe(summary?.userId);
   });
 
   it('skips a user id that has no player profile', async () => {
@@ -204,11 +210,17 @@ describe('DrizzleAdminUserDirectory.getPlayerByUsername (real PG)', () => {
   it('returns an exact case-insensitive match', async () => {
     const { dir } = makeDirectory();
     const account = await seedUser({ email: 'anna@example.com' });
-    await seedPlayer(account.id, { displayName: 'AnnaBell' });
+    const seededPlayer = await seedPlayer(account.id, { displayName: 'AnnaBell' });
 
     const summary = await dir.getPlayerByUsername('annabell');
 
-    expect(summary).toMatchObject({ userId: account.id, username: 'AnnaBell' });
+    expect(summary).toMatchObject({
+      playerId: seededPlayer.id,
+      userId: account.id,
+      username: 'AnnaBell',
+    });
+    expect(summary?.playerId).toBe(seededPlayer.id);
+    expect(summary?.playerId).not.toBe(summary?.userId);
   });
 
   it('returns null when no player matches', async () => {
@@ -246,5 +258,29 @@ describe('DrizzleAdminUserDirectory.findPlayerIds (real PG)', () => {
     await seedUser({ email: 'alice@example.com' });
 
     expect(await dir.findPlayerIds('zzzz')).toEqual([]);
+  });
+
+  it('matches an exact playerId', async () => {
+    const { dir } = makeDirectory();
+    const account = await seedUser({ email: 'carlos@example.com' });
+    const seededPlayer = await seedPlayer(account.id, { displayName: 'carlos' });
+
+    expect(await dir.findPlayerIds(seededPlayer.id)).toEqual([account.id]);
+  });
+
+  it('matches an exact identity userId', async () => {
+    const { dir } = makeDirectory();
+    const account = await seedUser({ email: 'dana@example.com' });
+    await seedPlayer(account.id, { displayName: 'dana' });
+
+    expect(await dir.findPlayerIds(account.id)).toEqual([account.id]);
+  });
+
+  it('does not substring-match a playerId, unlike email/displayName', async () => {
+    const { dir } = makeDirectory();
+    const account = await seedUser({ email: 'erin@example.com' });
+    const seededPlayer = await seedPlayer(account.id, { displayName: 'erin' });
+
+    expect(await dir.findPlayerIds(seededPlayer.id.slice(0, 8))).toEqual([]);
   });
 });

--- a/packages/core/src/pam/identity/admin-user-directory.ts
+++ b/packages/core/src/pam/identity/admin-user-directory.ts
@@ -2,7 +2,7 @@ import type { AdminUserDirectory, AdminUserListOptions, ClientMeta } from '@open
 import { KycStatusSchema, normalizeKycStatus } from '@openora/core/contracts';
 import { DrizzleService, pageToOffset } from '@openora/core/server';
 import type { EventBus } from '@openora/core/server';
-import { asc, count, desc, eq, ilike, inArray, sql } from 'drizzle-orm';
+import { asc, count, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm';
 import { user } from './schema/index.js';
 // Read-only cross-domain read of the player/profile table via the public /schema
 // subpath (allowed per ADR-0020) so back-office lists can label players by
@@ -174,45 +174,24 @@ export class DrizzleAdminUserDirectory implements AdminUserDirectory {
   }
 
   // Substring search is index-backed by the pg_trgm GIN indexes on user.email and
-  // player.display_name; the 1000 cap is a safety bound on the id set, not a perf
-  // crutch - it is effectively unreachable for a real admin search term.
+  // player.display_name; the id branches are exact matches on the ::text cast, not
+  // substring, so a UUID fragment can't coincidentally match. One query, deduped and
+  // capped by Postgres via DISTINCT + LIMIT, rather than four round trips merged in JS.
   async findPlayerIds(query: string, limit = 1000) {
     const term = `%${query}%`;
-    const [byEmail, byName, byPlayerId, byUserId] = await Promise.all([
-      this.drizzle.db
-        .select({ id: user.id })
-        .from(user)
-        .where(ilike(user.email, term))
-        .limit(limit),
-      this.drizzle.db
-        .select({ userId: player.userId })
-        .from(player)
-        .where(ilike(player.displayName, term))
-        .limit(limit),
-      this.drizzle.db
-        .select({ userId: player.userId })
-        .from(player)
-        .where(ilike(sql`${player.id}::text`, query))
-        .limit(limit),
-      this.drizzle.db
-        .select({ userId: player.userId })
-        .from(player)
-        .where(ilike(sql`${player.userId}::text`, query))
-        .limit(limit),
-    ]);
-    const ids = new Set<string>();
-    for (const r of byEmail) {
-      ids.add(r.id);
-    }
-    for (const r of byName) {
-      ids.add(r.userId);
-    }
-    for (const r of byPlayerId) {
-      ids.add(r.userId);
-    }
-    for (const r of byUserId) {
-      ids.add(r.userId);
-    }
-    return [...ids].slice(0, limit);
+    const rows = await this.drizzle.db
+      .selectDistinct({ id: user.id })
+      .from(user)
+      .leftJoin(player, eq(player.userId, user.id))
+      .where(
+        or(
+          ilike(user.email, term),
+          ilike(player.displayName, term),
+          ilike(sql`${player.id}::text`, query),
+          ilike(sql`${player.userId}::text`, query),
+        ),
+      )
+      .limit(limit);
+    return rows.map((r) => r.id);
   }
 }

--- a/packages/core/src/pam/identity/admin-user-directory.ts
+++ b/packages/core/src/pam/identity/admin-user-directory.ts
@@ -1,5 +1,5 @@
 import type { AdminUserDirectory, AdminUserListOptions, ClientMeta } from '@openora/core/contracts';
-import { KycStatusSchema, normalizeKycStatus } from '@openora/core/contracts';
+import { KycStatusSchema, normalizeKycStatus, UuidSchema } from '@openora/core/contracts';
 import { DrizzleService, pageToOffset } from '@openora/core/server';
 import type { EventBus } from '@openora/core/server';
 import { asc, count, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm';
@@ -173,24 +173,17 @@ export class DrizzleAdminUserDirectory implements AdminUserDirectory {
     return { ...row, kycStatus: kyc.success ? normalizeKycStatus(kyc.data) : null };
   }
 
-  // Substring search is index-backed by the pg_trgm GIN indexes on user.email and
-  // player.display_name; the id branches are exact matches on the ::text cast, not
-  // substring, so a UUID fragment can't coincidentally match. One query, deduped and
-  // capped by Postgres via DISTINCT + LIMIT, rather than four round trips merged in JS.
   async findPlayerIds(query: string, limit = 1000) {
     const term = `%${query}%`;
+    const conditions = [ilike(user.email, term), ilike(player.displayName, term)];
+    if (UuidSchema.safeParse(query).success) {
+      conditions.push(eq(player.id, query), eq(player.userId, query));
+    }
     const rows = await this.drizzle.db
       .selectDistinct({ id: user.id })
       .from(user)
       .leftJoin(player, eq(player.userId, user.id))
-      .where(
-        or(
-          ilike(user.email, term),
-          ilike(player.displayName, term),
-          ilike(sql`${player.id}::text`, query),
-          ilike(sql`${player.userId}::text`, query),
-        ),
-      )
+      .where(or(...conditions))
       .limit(limit);
     return rows.map((r) => r.id);
   }

--- a/packages/core/src/pam/identity/admin-user-directory.ts
+++ b/packages/core/src/pam/identity/admin-user-directory.ts
@@ -117,6 +117,7 @@ export class DrizzleAdminUserDirectory implements AdminUserDirectory {
     }
     const rows = await this.drizzle.db
       .select({
+        playerId: player.id,
         userId: player.userId,
         username: player.displayName,
         kycStatus: player.kycStatus,
@@ -147,6 +148,7 @@ export class DrizzleAdminUserDirectory implements AdminUserDirectory {
   async getPlayerByUsername(username: string) {
     const rows = await this.drizzle.db
       .select({
+        playerId: player.id,
         userId: player.userId,
         username: player.displayName,
         kycStatus: player.kycStatus,
@@ -176,7 +178,7 @@ export class DrizzleAdminUserDirectory implements AdminUserDirectory {
   // crutch - it is effectively unreachable for a real admin search term.
   async findPlayerIds(query: string, limit = 1000) {
     const term = `%${query}%`;
-    const [byEmail, byName] = await Promise.all([
+    const [byEmail, byName, byPlayerId, byUserId] = await Promise.all([
       this.drizzle.db
         .select({ id: user.id })
         .from(user)
@@ -187,12 +189,28 @@ export class DrizzleAdminUserDirectory implements AdminUserDirectory {
         .from(player)
         .where(ilike(player.displayName, term))
         .limit(limit),
+      this.drizzle.db
+        .select({ userId: player.userId })
+        .from(player)
+        .where(ilike(sql`${player.id}::text`, query))
+        .limit(limit),
+      this.drizzle.db
+        .select({ userId: player.userId })
+        .from(player)
+        .where(ilike(sql`${player.userId}::text`, query))
+        .limit(limit),
     ]);
     const ids = new Set<string>();
     for (const r of byEmail) {
       ids.add(r.id);
     }
     for (const r of byName) {
+      ids.add(r.userId);
+    }
+    for (const r of byPlayerId) {
+      ids.add(r.userId);
+    }
+    for (const r of byUserId) {
       ids.add(r.userId);
     }
     return [...ids].slice(0, limit);

--- a/packages/core/src/pam/player-management/__tests__/player.service.int.test.ts
+++ b/packages/core/src/pam/player-management/__tests__/player.service.int.test.ts
@@ -57,9 +57,13 @@ const SEARCH_VIEWER_ID = '00000000-0000-0000-0000-0000000000a1';
 const SEARCH_OTHER_ID = '00000000-0000-0000-0000-0000000000a2';
 const SEARCH_CREATED_AT = new Date('2026-01-01T00:00:00.000Z');
 
+const SEARCH_VIEWER_PLAYER_ID = '00000000-0000-0000-0000-0000000000b1';
+const SEARCH_OTHER_PLAYER_ID = '00000000-0000-0000-0000-0000000000b2';
+
 function makeUserDirectory(): AdminUserDirectory {
   const all = [
     {
+      playerId: SEARCH_VIEWER_PLAYER_ID,
       userId: SEARCH_VIEWER_ID,
       username: 'bob',
       email: 'bob@example.com',
@@ -71,6 +75,7 @@ function makeUserDirectory(): AdminUserDirectory {
       currency: 'USD',
     },
     {
+      playerId: SEARCH_OTHER_PLAYER_ID,
       userId: SEARCH_OTHER_ID,
       username: 'alice',
       email: 'alice@example.com',

--- a/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
@@ -30,6 +30,7 @@ import {
   DepositAddressUnsupportedError,
   DestinationAddressRequiredError,
 } from '../service/wallet.service.js';
+import { WithdrawalQueueItemSchema } from '../contract/index.js';
 
 let db: TestDb;
 
@@ -701,10 +702,16 @@ describe('WalletService.rejectWithdrawal (real PG)', () => {
 });
 
 describe('WalletService.listWithdrawals (real PG)', () => {
-  it('enriches rows with username and kycStatus from the directory port', async () => {
+  it('enriches rows with username, kycStatus, and playerId from the directory port', async () => {
     const w = await seedWallet();
+    const playerId = randomUUID();
     const directory = makeDirectory([
-      { userId: w.userId, username: 'player1', kycStatus: 'verified' } as AdminPlayerSummary,
+      {
+        playerId,
+        userId: w.userId,
+        username: 'player1',
+        kycStatus: 'verified',
+      } as AdminPlayerSummary,
     ]);
     const { svc } = makeService({ directory });
     await seedTx(w.id, { amount: '10' });
@@ -714,10 +721,23 @@ describe('WalletService.listWithdrawals (real PG)', () => {
     expect(total).toBe(1);
     expect(items[0]).toMatchObject({
       userId: w.userId,
+      playerId,
       username: 'player1',
       kycStatus: 'verified',
       riskTags: [],
     });
+    expect(() => WithdrawalQueueItemSchema.parse(items[0])).not.toThrow();
+  });
+
+  it('yields playerId: null when the user has no player summary', async () => {
+    const w = await seedWallet();
+    const directory = makeDirectory([]);
+    const { svc } = makeService({ directory });
+    await seedTx(w.id, { amount: '10' });
+
+    const { items } = await svc.listWithdrawals({ page: 1, limit: 20 });
+
+    expect(items[0]).toMatchObject({ userId: w.userId, playerId: null, username: '' });
   });
 
   it('returns rows of every status when no status filter is given', async () => {

--- a/packages/core/src/wallet/contract/index.ts
+++ b/packages/core/src/wallet/contract/index.ts
@@ -88,6 +88,7 @@ export const ListPlayerTransactionsArgs = PageQuerySchema.extend({
 export const WithdrawalQueueItemSchema = z.object({
   transactionId: UuidSchema,
   userId: UuidSchema,
+  playerId: UuidSchema.nullable(),
   username: z.string(),
   amount: MoneyAmountSchema,
   currency: WalletCurrencyCodeSchema,

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -716,6 +716,7 @@ export class WalletService {
       return {
         transactionId: r.tx.id,
         userId: r.userId,
+        playerId: summary?.playerId ?? null,
         username: summary?.username ?? '',
         amount: r.tx.amount,
         currency: r.tx.currency,


### PR DESCRIPTION
## Summary

Adds `playerId` to the admin user-directory port and to the Transaction Monitor / Withdrawal Queue admin list contracts, and fixes the player search (`findPlayerIds`) to also match an exact `playerId`/`userId`, not just email/displayName.

## Why

PAM is playerId-native while wallet and admin-console are userId-native, so the same person shows a different UUID depending on which admin list is open, and pasting a UUID into the player search box previously returned nothing because `findPlayerIds` only matched `user.email` and `player.displayName` substrings.

## Alternatives considered

Bolting an id-resolution overlay onto the downstream consumer instead of fixing the port here - rejected because both list endpoints already join through the same `AdminUserDirectory.lookupPlayers`/`findPlayerIds` port, so extending the port adds zero new queries and keeps every consumer playerId-consistent at the source rather than duplicating resolution logic per app.

Substring (`ILIKE '%term%'`) matching for the new id search branches, mirroring the existing email/displayName behaviour - rejected because a UUID substring match is not meaningful (a fragment of one UUID can coincidentally appear in another) and would force a sequential text-cast scan; used exact match instead, consistent with the existing precedent in `PlayerService.list`.

## Risks

`AdminPlayerSummary.playerId` is a required field on a port type (`AdminUserDirectory`) that downstream repos can implement, so any external implementation missing it will fail to typecheck until updated - shipped as a `minor` changeset rather than `patch` to signal this.

No schema or migration changes (the column already existed; this only adds it to existing select projections). No change to existing email/displayName search behaviour - the two new id branches are additive.
