### PR TITLE
refactor(wallet): store balances in wallet_balance keyed by currency

### DIFF
--- a/packages/core/src/wallet/__tests__/admin-reporting.int.test.ts
+++ b/packages/core/src/wallet/__tests__/admin-reporting.int.test.ts
@@ -18,7 +18,7 @@ async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
       .insert(wallet)
       .values({ userId: randomUUID(), currency: 'USD', ...overrides })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedWallet: query returned no row'),
   );
   return row;
 }
@@ -41,7 +41,7 @@ async function seedTx(
         ...overrides,
       })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedTx: query returned no row'),
   );
   return row;
 }

--- a/packages/core/src/wallet/__tests__/admin-reporting.int.test.ts
+++ b/packages/core/src/wallet/__tests__/admin-reporting.int.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { findOneOrThrow } from '@openora/core/server';
 import { randomUUID } from 'node:crypto';
 import { sql } from 'drizzle-orm';
 import { createTestDb, type TestDb } from '@openora/core/testing';
@@ -12,31 +13,37 @@ let reporting: DrizzleAdminWalletReporting;
 const AT = (iso: string) => new Date(iso);
 
 async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
-  const [row] = await db.drizzle.db
-    .insert(wallet)
-    .values({ userId: randomUUID(), currency: 'USD', ...overrides })
-    .returning();
-  return row!;
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId: randomUUID(), currency: 'USD', ...overrides })
+      .returning(),
+    new Error('expected a row'),
+  );
+  return row;
 }
 
 async function seedTx(
   walletId: string,
   overrides: Partial<typeof walletTransaction.$inferInsert> = {},
 ) {
-  const [row] = await db.drizzle.db
-    .insert(walletTransaction)
-    .values({
-      walletId,
-      type: 'deposit',
-      amount: '100',
-      currency: 'USD',
-      status: 'completed',
-      rail: 'fiat',
-      createdAt: AT('2026-01-01T00:00:00.000Z'),
-      ...overrides,
-    })
-    .returning();
-  return row!;
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(walletTransaction)
+      .values({
+        walletId,
+        type: 'deposit',
+        amount: '100',
+        currency: 'USD',
+        status: 'completed',
+        rail: 'fiat',
+        createdAt: AT('2026-01-01T00:00:00.000Z'),
+        ...overrides,
+      })
+      .returning(),
+    new Error('expected a row'),
+  );
+  return row;
 }
 
 beforeAll(async () => {

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
@@ -120,7 +120,7 @@ async function seedPlayerWallet(overrides: Partial<typeof wallet.$inferInsert> =
       .insert(wallet)
       .values({ userId: randomUUID(), balance: '100000', currency: 'USD', ...overrides })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedPlayerWallet: query returned no row'),
   );
   await db.drizzle.db
     .insert(walletBalance)

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
@@ -22,7 +22,12 @@ import {
   NO_CLIENT_META,
 } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
-import { wallet, walletTransaction, walletAutoWithdrawalConfig } from '../schema/index.js';
+import {
+  wallet,
+  walletBalance,
+  walletTransaction,
+  walletAutoWithdrawalConfig,
+} from '../schema/index.js';
 import { createWalletRouter } from '../router/index.js';
 import { WalletService } from '../service/wallet.service.js';
 
@@ -113,6 +118,9 @@ async function seedPlayerWallet(overrides: Partial<typeof wallet.$inferInsert> =
     .insert(wallet)
     .values({ userId: randomUUID(), balance: '100000', currency: 'USD', ...overrides })
     .returning();
+  await db.drizzle.db
+    .insert(walletBalance)
+    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
   return row!;
 }
 

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { findOneOrThrow } from '@openora/core/server';
 import { randomUUID } from 'node:crypto';
 import { call, ORPCError } from '@orpc/server';
 import type { AdminGuard } from '@openora/core/server';
@@ -114,14 +115,17 @@ function routerWith(adminGuard: AdminGuard, platformConfig?: Partial<PlatformCon
 }
 
 async function seedPlayerWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
-  const [row] = await db.drizzle.db
-    .insert(wallet)
-    .values({ userId: randomUUID(), balance: '100000', currency: 'USD', ...overrides })
-    .returning();
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId: randomUUID(), balance: '100000', currency: 'USD', ...overrides })
+      .returning(),
+    new Error('expected a row'),
+  );
   await db.drizzle.db
     .insert(walletBalance)
-    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
-  return row!;
+    .values({ walletId: row.id, currency: row.currency, amount: row.balance });
+  return row;
 }
 
 describe('wallet auto-withdrawal-config routes', () => {

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
@@ -132,7 +132,7 @@ async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
       .insert(wallet)
       .values({ userId: randomUUID(), balance: '100000', currency: 'USD', ...overrides })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedWallet: query returned no row'),
   );
   await db.drizzle.db
     .insert(walletBalance)
@@ -143,7 +143,7 @@ async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
 async function txById(id: string) {
   const row = findOneOrThrow(
     await db.drizzle.db.select().from(walletTransaction).where(eq(walletTransaction.id, id)),
-    new Error('expected a row'),
+    new Error('txById: query returned no row'),
   );
   return row;
 }
@@ -241,9 +241,9 @@ describe('WalletService.withdraw auto-approval (real PG)', () => {
     expect(result.status).toBe('pending');
     const row = findOneOrThrow(
       await db.drizzle.db.select().from(walletBalance).where(eq(walletBalance.walletId, w.id)),
-      new Error('expected a row'),
+      new Error('no wallet_balance row'),
     );
-    expect(Number(row?.amount)).toBe(60);
+    expect(Number(row.amount)).toBe(60);
   });
 
   it('stays pending when the amount exceeds the configured threshold', async () => {

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
@@ -25,6 +25,7 @@ import {
 import { migrate } from '../migrate.js';
 import {
   wallet,
+  walletBalance,
   walletTransaction,
   autoWithdrawalRule,
   walletAutoWithdrawalConfig,
@@ -129,6 +130,9 @@ async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
     .insert(wallet)
     .values({ userId: randomUUID(), balance: '100000', currency: 'USD', ...overrides })
     .returning();
+  await db.drizzle.db
+    .insert(walletBalance)
+    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
   return row!;
 }
 
@@ -231,8 +235,11 @@ describe('WalletService.withdraw auto-approval (real PG)', () => {
     });
 
     expect(result.status).toBe('pending');
-    const [row] = await db.drizzle.db.select().from(wallet).where(eq(wallet.id, w.id));
-    expect(Number(row?.balance)).toBe(60);
+    const [row] = await db.drizzle.db
+      .select()
+      .from(walletBalance)
+      .where(eq(walletBalance.walletId, w.id));
+    expect(Number(row?.amount)).toBe(60);
   });
 
   it('stays pending when the amount exceeds the configured threshold', async () => {

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { findOneOrThrow } from '@openora/core/server';
 import { randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
 import type {
@@ -126,22 +127,25 @@ async function makeService({
 }
 
 async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
-  const [row] = await db.drizzle.db
-    .insert(wallet)
-    .values({ userId: randomUUID(), balance: '100000', currency: 'USD', ...overrides })
-    .returning();
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId: randomUUID(), balance: '100000', currency: 'USD', ...overrides })
+      .returning(),
+    new Error('expected a row'),
+  );
   await db.drizzle.db
     .insert(walletBalance)
-    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
-  return row!;
+    .values({ walletId: row.id, currency: row.currency, amount: row.balance });
+  return row;
 }
 
 async function txById(id: string) {
-  const [row] = await db.drizzle.db
-    .select()
-    .from(walletTransaction)
-    .where(eq(walletTransaction.id, id));
-  return row!;
+  const row = findOneOrThrow(
+    await db.drizzle.db.select().from(walletTransaction).where(eq(walletTransaction.id, id)),
+    new Error('expected a row'),
+  );
+  return row;
 }
 
 beforeAll(async () => {
@@ -235,10 +239,10 @@ describe('WalletService.withdraw auto-approval (real PG)', () => {
     });
 
     expect(result.status).toBe('pending');
-    const [row] = await db.drizzle.db
-      .select()
-      .from(walletBalance)
-      .where(eq(walletBalance.walletId, w.id));
+    const row = findOneOrThrow(
+      await db.drizzle.db.select().from(walletBalance).where(eq(walletBalance.walletId, w.id)),
+      new Error('expected a row'),
+    );
     expect(Number(row?.amount)).toBe(60);
   });
 

--- a/packages/core/src/wallet/__tests__/wallet-commands.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-commands.service.int.test.ts
@@ -5,7 +5,7 @@ import type { PlayEligibilityPort } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
 import { mock } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
-import { wallet, walletTransaction } from '../schema/index.js';
+import { wallet, walletBalance, walletTransaction } from '../schema/index.js';
 import {
   WalletCommandsService,
   WalletRgRestrictedError,
@@ -23,12 +23,19 @@ async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
     .insert(wallet)
     .values({ userId: randomUUID(), balance: '0', currency: 'USD', ...overrides })
     .returning();
+  await db.drizzle.db
+    .insert(walletBalance)
+    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
   return row!;
 }
 
 async function balanceOf(userId: string) {
-  const [row] = await db.drizzle.db.select().from(wallet).where(eq(wallet.userId, userId));
-  return Number(row?.balance);
+  const [row] = await db.drizzle.db
+    .select({ amount: walletBalance.amount })
+    .from(walletBalance)
+    .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
+    .where(eq(wallet.userId, userId));
+  return Number(row?.amount ?? 0);
 }
 
 async function txRows(walletId: string) {

--- a/packages/core/src/wallet/__tests__/wallet-commands.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-commands.service.int.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { findOneOrThrow } from '@openora/core/server';
 import { randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
 import type { PlayEligibilityPort } from '@openora/core/contracts';
@@ -19,22 +20,28 @@ const eligibility = (isRestricted: boolean) =>
 const svc = new WalletCommandsService(eligibility(false));
 
 async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
-  const [row] = await db.drizzle.db
-    .insert(wallet)
-    .values({ userId: randomUUID(), balance: '0', currency: 'USD', ...overrides })
-    .returning();
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId: randomUUID(), balance: '0', currency: 'USD', ...overrides })
+      .returning(),
+    new Error('expected a row'),
+  );
   await db.drizzle.db
     .insert(walletBalance)
-    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
-  return row!;
+    .values({ walletId: row.id, currency: row.currency, amount: row.balance });
+  return row;
 }
 
 async function balanceOf(userId: string) {
-  const [row] = await db.drizzle.db
-    .select({ amount: walletBalance.amount })
-    .from(walletBalance)
-    .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
-    .where(eq(wallet.userId, userId));
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .select({ amount: walletBalance.amount })
+      .from(walletBalance)
+      .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
+      .where(eq(wallet.userId, userId)),
+    new Error('expected a row'),
+  );
   return Number(row?.amount ?? 0);
 }
 
@@ -205,8 +212,8 @@ describe('WalletCommandsService.credit (real PG)', () => {
     });
 
     expect(res).toEqual({ ok: false, reason: 'wallet not found' });
-    const [row] = await db.drizzle.db.select().from(wallet).where(eq(wallet.userId, userId));
-    expect(row).toBeUndefined();
+    const rows = await db.drizzle.db.select().from(wallet).where(eq(wallet.userId, userId));
+    expect(rows).toEqual([]);
   });
 
   it('rejects a non-positive credit', async () => {

--- a/packages/core/src/wallet/__tests__/wallet-commands.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-commands.service.int.test.ts
@@ -25,7 +25,7 @@ async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
       .insert(wallet)
       .values({ userId: randomUUID(), balance: '0', currency: 'USD', ...overrides })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedWallet: query returned no row'),
   );
   await db.drizzle.db
     .insert(walletBalance)
@@ -34,14 +34,11 @@ async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
 }
 
 async function balanceOf(userId: string) {
-  const row = findOneOrThrow(
-    await db.drizzle.db
-      .select({ amount: walletBalance.amount })
-      .from(walletBalance)
-      .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
-      .where(eq(wallet.userId, userId)),
-    new Error('expected a row'),
-  );
+  const [row] = await db.drizzle.db
+    .select({ amount: walletBalance.amount })
+    .from(walletBalance)
+    .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
+    .where(eq(wallet.userId, userId));
   return Number(row?.amount ?? 0);
 }
 

--- a/packages/core/src/wallet/__tests__/wallet-currency-code.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-currency-code.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { DepositInputSchema, WalletBalanceSchema } from '../contract/index.js';
+
+describe('wallet currency codes', () => {
+  it('uppercases the currency on the way in', () => {
+    const parsed = DepositInputSchema.parse({ amount: '10', currency: 'usdt' });
+    expect(parsed.currency).toBe('USDT');
+  });
+
+  it('rejects a non-alphabetic or out-of-range code', () => {
+    expect(() => DepositInputSchema.parse({ amount: '10', currency: 'US$' })).toThrow();
+    expect(() => DepositInputSchema.parse({ amount: '10', currency: 'US' })).toThrow();
+    expect(() => WalletBalanceSchema.parse({ balance: '0', currency: '' })).toThrow();
+  });
+});

--- a/packages/core/src/wallet/__tests__/wallet-kyc-gate.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-kyc-gate.int.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { findOneOrThrow } from '@openora/core/server';
 import { randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
 import type {
@@ -44,14 +45,17 @@ function makeService(kycStatus: KycStatus | null, gateWithdrawals: boolean) {
 }
 
 async function seedWallet() {
-  const [row] = await db.drizzle.db
-    .insert(wallet)
-    .values({ userId: randomUUID(), balance: '100', currency: 'USD' })
-    .returning();
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId: randomUUID(), balance: '100', currency: 'USD' })
+      .returning(),
+    new Error('expected a row'),
+  );
   await db.drizzle.db
     .insert(walletBalance)
-    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
-  return row!;
+    .values({ walletId: row.id, currency: row.currency, amount: row.balance });
+  return row;
 }
 
 async function txCount(walletId: string) {

--- a/packages/core/src/wallet/__tests__/wallet-kyc-gate.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-kyc-gate.int.test.ts
@@ -18,7 +18,7 @@ import {
   makeAuditWriter,
 } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
-import { wallet, walletTransaction } from '../schema/index.js';
+import { wallet, walletBalance, walletTransaction } from '../schema/index.js';
 import { WalletService, KycRequiredError } from '../service/wallet.service.js';
 
 let db: TestDb;
@@ -48,6 +48,9 @@ async function seedWallet() {
     .insert(wallet)
     .values({ userId: randomUUID(), balance: '100', currency: 'USD' })
     .returning();
+  await db.drizzle.db
+    .insert(walletBalance)
+    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
   return row!;
 }
 

--- a/packages/core/src/wallet/__tests__/wallet-kyc-gate.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-kyc-gate.int.test.ts
@@ -50,7 +50,7 @@ async function seedWallet() {
       .insert(wallet)
       .values({ userId: randomUUID(), balance: '100', currency: 'USD' })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedWallet: query returned no row'),
   );
   await db.drizzle.db
     .insert(walletBalance)

--- a/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { findOneOrThrow } from '@openora/core/server';
 import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
 import { call, ORPCError } from '@orpc/server';
@@ -70,14 +71,17 @@ function ctx(rawBody: string, headers: Record<string, string> = {}) {
 }
 
 async function seedWallet(currency = 'BTC') {
-  const [row] = await db.drizzle.db
-    .insert(wallet)
-    .values({ userId: USER_ID, balance: '0', currency })
-    .returning();
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId: USER_ID, balance: '0', currency })
+      .returning(),
+    new Error('expected a row'),
+  );
   await db.drizzle.db
     .insert(walletBalance)
-    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
-  return row!;
+    .values({ walletId: row.id, currency: row.currency, amount: row.balance });
+  return row;
 }
 
 async function seedDepositAddress(currency = 'BTC') {
@@ -90,19 +94,22 @@ async function seedDepositAddress(currency = 'BTC') {
 }
 
 async function seedProcessingWithdrawal(walletId: string, externalId: string) {
-  const [row] = await db.drizzle.db
-    .insert(walletTransaction)
-    .values({
-      walletId,
-      type: 'withdrawal',
-      amount: '1',
-      currency: 'BTC',
-      status: 'processing',
-      rail: 'crypto',
-      providerRefId: externalId,
-    })
-    .returning();
-  return row!;
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(walletTransaction)
+      .values({
+        walletId,
+        type: 'withdrawal',
+        amount: '1',
+        currency: 'BTC',
+        status: 'processing',
+        rail: 'crypto',
+        providerRefId: externalId,
+      })
+      .returning(),
+    new Error('expected a row'),
+  );
+  return row;
 }
 
 async function ledgerFor(walletId: string) {

--- a/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
@@ -76,7 +76,7 @@ async function seedWallet(currency = 'BTC') {
       .insert(wallet)
       .values({ userId: USER_ID, balance: '0', currency })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedWallet: query returned no row'),
   );
   await db.drizzle.db
     .insert(walletBalance)
@@ -107,7 +107,7 @@ async function seedProcessingWithdrawal(walletId: string, externalId: string) {
         providerRefId: externalId,
       })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedProcessingWithdrawal: query returned no row'),
   );
   return row;
 }

--- a/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
@@ -18,7 +18,7 @@ import {
   makeAuditWriter,
 } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
-import { wallet, walletTransaction, walletDepositAddress } from '../schema/index.js';
+import { wallet, walletBalance, walletTransaction, walletDepositAddress } from '../schema/index.js';
 import { createWalletRouter } from '../router/index.js';
 import { WalletService } from '../service/wallet.service.js';
 
@@ -38,6 +38,7 @@ afterAll(async () => {
 beforeEach(async () => {
   await db.drizzle.db.delete(walletTransaction);
   await db.drizzle.db.delete(walletDepositAddress);
+  await db.drizzle.db.delete(walletBalance);
   await db.drizzle.db.delete(wallet);
 });
 
@@ -73,6 +74,9 @@ async function seedWallet(currency = 'BTC') {
     .insert(wallet)
     .values({ userId: USER_ID, balance: '0', currency })
     .returning();
+  await db.drizzle.db
+    .insert(walletBalance)
+    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
   return row!;
 }
 
@@ -158,8 +162,11 @@ describe('wallet webhook route (M2M, no admin session)', () => {
       providerRefId: 'vendor-ext-1',
       txHash: '0xabc',
     });
-    const [credited] = await db.drizzle.db.select().from(wallet).where(eq(wallet.id, w.id));
-    expect(credited?.balance).toBe('0.500000000000000000');
+    const [credited] = await db.drizzle.db
+      .select()
+      .from(walletBalance)
+      .where(eq(walletBalance.walletId, w.id));
+    expect(credited?.amount).toBe('0.500000000000000000');
   });
 
   it('credits a replayed deposit event exactly once', async () => {
@@ -171,8 +178,11 @@ describe('wallet webhook route (M2M, no admin session)', () => {
     await call(router.webhook, {}, ctx('{"event":"deposit"}'));
 
     expect(await ledgerFor(w.id)).toHaveLength(1);
-    const [credited] = await db.drizzle.db.select().from(wallet).where(eq(wallet.id, w.id));
-    expect(credited?.balance).toBe('0.500000000000000000');
+    const [credited] = await db.drizzle.db
+      .select()
+      .from(walletBalance)
+      .where(eq(walletBalance.walletId, w.id));
+    expect(credited?.amount).toBe('0.500000000000000000');
   });
 
   it('settles the matching withdrawal on a verified withdrawal event', async () => {

--- a/packages/core/src/wallet/__tests__/wallet.rate-limit.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.rate-limit.int.test.ts
@@ -7,7 +7,7 @@ import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import type { PaymentAdapter, AuditWritePort } from '@openora/core/contracts';
 import { mock, NO_CLIENT_META, makeEventBus, makeIdentityReader } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
-import { wallet, walletTransaction } from '../schema/index.js';
+import { wallet, walletBalance, walletTransaction } from '../schema/index.js';
 import { WalletService } from '../service/wallet.service.js';
 
 const events = makeEventBus();
@@ -34,6 +34,9 @@ async function seedWallet() {
     .insert(wallet)
     .values({ userId: randomUUID(), balance: '1000', currency: 'USD' })
     .returning();
+  await db.drizzle.db
+    .insert(walletBalance)
+    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
   return row!;
 }
 

--- a/packages/core/src/wallet/__tests__/wallet.rate-limit.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.rate-limit.int.test.ts
@@ -35,7 +35,7 @@ async function seedWallet() {
       .insert(wallet)
       .values({ userId: randomUUID(), balance: '1000', currency: 'USD' })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedWallet: query returned no row'),
   );
   await db.drizzle.db
     .insert(walletBalance)

--- a/packages/core/src/wallet/__tests__/wallet.rate-limit.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.rate-limit.int.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { sql } from 'drizzle-orm';
-import { RedisRateLimiter } from '@openora/core/server';
+import { findOneOrThrow, RedisRateLimiter } from '@openora/core/server';
 import { createTestDb, createTestRedis, type TestDb, type TestRedis } from '@openora/core/testing';
 import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import type { PaymentAdapter, AuditWritePort } from '@openora/core/contracts';
@@ -30,14 +30,17 @@ const makeService = () =>
   });
 
 async function seedWallet() {
-  const [row] = await db.drizzle.db
-    .insert(wallet)
-    .values({ userId: randomUUID(), balance: '1000', currency: 'USD' })
-    .returning();
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId: randomUUID(), balance: '1000', currency: 'USD' })
+      .returning(),
+    new Error('expected a row'),
+  );
   await db.drizzle.db
     .insert(walletBalance)
-    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
-  return row!;
+    .values({ walletId: row.id, currency: row.currency, amount: row.balance });
+  return row;
 }
 
 beforeAll(async () => {

--- a/packages/core/src/wallet/__tests__/wallet.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.router.int.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { findOneOrThrow } from '@openora/core/server';
 import { randomUUID } from 'node:crypto';
 import { call, ORPCError } from '@orpc/server';
 import type { AdminGuard } from '@openora/core/server';
@@ -61,13 +62,16 @@ const transactionDenyingGuard = () =>
 const allowingGuard = () => makeAdminGuard({ caller: { userId: 'caller-1' } });
 
 async function seedLedger(userId: string, amounts: string[]) {
-  const [row] = await db.drizzle.db
-    .insert(wallet)
-    .values({ userId, balance: '0', currency: 'USD' })
-    .returning();
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId, balance: '0', currency: 'USD' })
+      .returning(),
+    new Error('expected a row'),
+  );
   for (const amount of amounts) {
     await db.drizzle.db.insert(walletTransaction).values({
-      walletId: row!.id,
+      walletId: row.id,
       type: 'deposit',
       amount,
       currency: 'USD',

--- a/packages/core/src/wallet/__tests__/wallet.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.router.int.test.ts
@@ -67,7 +67,7 @@ async function seedLedger(userId: string, amounts: string[]) {
       .insert(wallet)
       .values({ userId, balance: '0', currency: 'USD' })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedLedger: query returned no row'),
   );
   for (const amount of amounts) {
     await db.drizzle.db.insert(walletTransaction).values({

--- a/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
@@ -190,6 +190,20 @@ describe('WalletService.deposit (real PG)', () => {
     expect(await balanceOf(w.userId)).toBe(11);
   });
 
+  it('credits the wallet currency row when the deposit currency differs only in case', async () => {
+    const { svc } = makeService();
+    const w = await seedWallet({ balance: '10', currency: 'USD' });
+
+    await svc.deposit({ userId: w.userId, amount: '5', currency: 'usd' });
+
+    const rows = await db.drizzle.db
+      .select()
+      .from(walletBalance)
+      .where(eq(walletBalance.walletId, w.id));
+    expect(rows).toHaveLength(1);
+    expect(await balanceOf(w.userId)).toBe(15);
+  });
+
   it('throws CurrencyMismatchError when the deposit currency differs from the wallet, without calling the PSP or crediting the balance', async () => {
     const { svc, psp } = makeService();
     const w = await seedWallet({ balance: '100', currency: 'USD' });

--- a/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
@@ -74,7 +74,7 @@ async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
       .insert(wallet)
       .values({ userId: randomUUID(), balance: '0', currency: 'USD', ...overrides })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedWallet: query returned no row'),
   );
   await db.drizzle.db
     .insert(walletBalance)
@@ -99,20 +99,17 @@ async function seedTx(
         ...overrides,
       })
       .returning(),
-    new Error('expected a row'),
+    new Error('seedTx: query returned no row'),
   );
   return row;
 }
 
 async function balanceOf(userId: string) {
-  const row = findOneOrThrow(
-    await db.drizzle.db
-      .select({ amount: walletBalance.amount })
-      .from(walletBalance)
-      .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
-      .where(eq(wallet.userId, userId)),
-    new Error('expected a row'),
-  );
+  const [row] = await db.drizzle.db
+    .select({ amount: walletBalance.amount })
+    .from(walletBalance)
+    .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
+    .where(eq(wallet.userId, userId));
   return Number(row?.amount ?? 0);
 }
 
@@ -126,7 +123,7 @@ async function txRows(walletId: string) {
 async function txById(id: string) {
   const row = findOneOrThrow(
     await db.drizzle.db.select().from(walletTransaction).where(eq(walletTransaction.id, id)),
-    new Error('expected a row'),
+    new Error('txById: query returned no row'),
   );
   return row;
 }

--- a/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
@@ -17,7 +17,7 @@ import {
   makeAuditWriter,
 } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
-import { wallet, walletTransaction, walletDepositAddress } from '../schema/index.js';
+import { wallet, walletBalance, walletTransaction, walletDepositAddress } from '../schema/index.js';
 import {
   WalletService,
   type WalletServiceDeps,
@@ -72,6 +72,9 @@ async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
     .insert(wallet)
     .values({ userId: randomUUID(), balance: '0', currency: 'USD', ...overrides })
     .returning();
+  await db.drizzle.db
+    .insert(walletBalance)
+    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
   return row!;
 }
 
@@ -95,8 +98,12 @@ async function seedTx(
 }
 
 async function balanceOf(userId: string) {
-  const [row] = await db.drizzle.db.select().from(wallet).where(eq(wallet.userId, userId));
-  return Number(row?.balance);
+  const [row] = await db.drizzle.db
+    .select({ amount: walletBalance.amount })
+    .from(walletBalance)
+    .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
+    .where(eq(wallet.userId, userId));
+  return Number(row?.amount ?? 0);
 }
 
 async function txRows(walletId: string) {

--- a/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { findOneOrThrow } from '@openora/core/server';
 import { randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
 import type {
@@ -68,41 +69,50 @@ function makeDirectory(summaries: AdminPlayerSummary[]) {
 }
 
 async function seedWallet(overrides: Partial<typeof wallet.$inferInsert> = {}) {
-  const [row] = await db.drizzle.db
-    .insert(wallet)
-    .values({ userId: randomUUID(), balance: '0', currency: 'USD', ...overrides })
-    .returning();
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId: randomUUID(), balance: '0', currency: 'USD', ...overrides })
+      .returning(),
+    new Error('expected a row'),
+  );
   await db.drizzle.db
     .insert(walletBalance)
-    .values({ walletId: row!.id, currency: row!.currency, amount: row!.balance });
-  return row!;
+    .values({ walletId: row.id, currency: row.currency, amount: row.balance });
+  return row;
 }
 
 async function seedTx(
   walletId: string,
   overrides: Partial<typeof walletTransaction.$inferInsert> = {},
 ) {
-  const [row] = await db.drizzle.db
-    .insert(walletTransaction)
-    .values({
-      walletId,
-      type: 'withdrawal',
-      amount: '10',
-      currency: 'USD',
-      status: 'pending',
-      rail: 'fiat',
-      ...overrides,
-    })
-    .returning();
-  return row!;
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(walletTransaction)
+      .values({
+        walletId,
+        type: 'withdrawal',
+        amount: '10',
+        currency: 'USD',
+        status: 'pending',
+        rail: 'fiat',
+        ...overrides,
+      })
+      .returning(),
+    new Error('expected a row'),
+  );
+  return row;
 }
 
 async function balanceOf(userId: string) {
-  const [row] = await db.drizzle.db
-    .select({ amount: walletBalance.amount })
-    .from(walletBalance)
-    .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
-    .where(eq(wallet.userId, userId));
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .select({ amount: walletBalance.amount })
+      .from(walletBalance)
+      .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
+      .where(eq(wallet.userId, userId)),
+    new Error('expected a row'),
+  );
   return Number(row?.amount ?? 0);
 }
 
@@ -114,11 +124,11 @@ async function txRows(walletId: string) {
 }
 
 async function txById(id: string) {
-  const [row] = await db.drizzle.db
-    .select()
-    .from(walletTransaction)
-    .where(eq(walletTransaction.id, id));
-  return row!;
+  const row = findOneOrThrow(
+    await db.drizzle.db.select().from(walletTransaction).where(eq(walletTransaction.id, id)),
+    new Error('expected a row'),
+  );
+  return row;
 }
 
 const emittedTopics = (events: ReturnType<typeof makeEventBus>) =>

--- a/packages/core/src/wallet/contract/index.ts
+++ b/packages/core/src/wallet/contract/index.ts
@@ -19,7 +19,13 @@ const PositiveMoneyAmountSchema = MoneyAmountSchema.refine((v) => Number(v) > 0,
   message: 'must be greater than zero',
 });
 
-const WalletCurrencyCodeSchema = z.string().min(1);
+// ISO 4217 plus longer crypto tickers (USDT, USDC). Codes are canonically uppercase -
+// normalize on the way in so a `usd` request can never diverge from a `USD` wallet.
+const WalletCurrencyCodeSchema = z
+  .string()
+  .regex(/^[A-Za-z]{3,10}$/, 'currency code, e.g. USD or USDT');
+
+const WalletCurrencyInputSchema = WalletCurrencyCodeSchema.transform((c) => c.toUpperCase());
 
 export const WalletBalanceSchema = z.object({
   balance: MoneyAmountSchema,
@@ -37,14 +43,14 @@ export const WalletTransactionSchema = z.object({
 
 export const DepositInputSchema = z.object({
   amount: PositiveMoneyAmountSchema,
-  currency: WalletCurrencyCodeSchema,
+  currency: WalletCurrencyInputSchema,
   provider: z.string().optional(),
   idempotencyKey: UuidSchema.optional(),
 });
 
 export const WithdrawInputSchema = z.object({
   amount: PositiveMoneyAmountSchema,
-  currency: WalletCurrencyCodeSchema,
+  currency: WalletCurrencyInputSchema,
   provider: z.string().optional(),
   idempotencyKey: UuidSchema.optional(),
   destinationAddress: z.string().optional(),
@@ -104,7 +110,7 @@ export type WithdrawalQueueItem = z.infer<typeof WithdrawalQueueItemSchema>;
 
 export const WithdrawalQueueFilterSchema = PageQuerySchema.extend({
   status: WalletTransactionStatusSchema.optional(),
-  currency: WalletCurrencyCodeSchema.optional(),
+  currency: WalletCurrencyInputSchema.optional(),
   rail: WalletRailSchema.optional(),
   minAmount: MoneyAmountSchema.optional(),
   maxAmount: MoneyAmountSchema.optional(),
@@ -171,7 +177,7 @@ export const RejectWithdrawalInputSchema = z.object({
 export const PaymentWebhookInputSchema = z.record(z.string(), z.unknown());
 export const PaymentWebhookOutputSchema = z.object({ ok: z.literal(true) });
 
-export const DepositAddressInputSchema = z.object({ currency: WalletCurrencyCodeSchema });
+export const DepositAddressInputSchema = z.object({ currency: WalletCurrencyInputSchema });
 export const DepositAddressSchema = z.object({
   address: z.string(),
   currency: WalletCurrencyCodeSchema,

--- a/packages/core/src/wallet/index.ts
+++ b/packages/core/src/wallet/index.ts
@@ -1,3 +1,1 @@
-// The public consumer surface: the domain's wire contract (schemas, enum triples, types).
-// Isomorphic - safe in the browser. Server wiring lives in './server', tables in './schema'.
 export * from './contract/index.js';

--- a/packages/core/src/wallet/migrate.ts
+++ b/packages/core/src/wallet/migrate.ts
@@ -1,10 +1,6 @@
-// Applies this module's own migration set against its own tracking table, so it
-// never collides with sibling modules that share the database. SQL ships in the
-// tarball ('files') and loads via an import.meta.url-relative path. See ADR-0020/0027.
 import { fileURLToPath } from 'node:url';
 import { runMigrations } from '@openora/core/server/migrate';
 
-/** Apply the wallet module migrations (idempotent: drizzle skips already-recorded ones). */
 export function migrate(databaseUrl?: string) {
   return runMigrations({
     migrationsFolder: fileURLToPath(new URL('./drizzle/migrations', import.meta.url)),

--- a/packages/core/src/wallet/service/wallet-commands.service.ts
+++ b/packages/core/src/wallet/service/wallet-commands.service.ts
@@ -9,9 +9,14 @@ import type {
   WalletTransactionType,
 } from '@openora/core/contracts';
 import { createDomainError, makeConflictError, type DrizzleDb } from '@openora/core/server';
-import { and, eq, gte, sql } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { wallet, walletTransaction } from '../schema/index.js';
-import { railFor } from './wallet.service.js';
+import {
+  creditWalletBalance,
+  debitWalletBalance,
+  railFor,
+  readWalletBalance,
+} from './wallet.service.js';
 
 export const WalletCommandAmountError = createDomainError<[operation: string, amount: string]>(
   'WalletCommandAmountError',
@@ -69,7 +74,7 @@ export class WalletCommandsService implements WalletCommands {
     if (!row) {
       return { ok: false, available: '0' };
     }
-    const available = row.balance;
+    const available = await readWalletBalance(txn, row.id, row.currency);
 
     if (type === 'loss') {
       await this.writeLedgerRow(txn, row, 'loss', '0');
@@ -78,12 +83,8 @@ export class WalletCommandsService implements WalletCommands {
 
     // The UPDATE ... RETURNING gives the new balance straight from Postgres numeric
     // arithmetic - no JS float math on either side of the debit.
-    const debited = await txn
-      .update(wallet)
-      .set({ balance: sql`${wallet.balance} - ${amount}::numeric` })
-      .where(and(eq(wallet.id, row.id), gte(wallet.balance, amount)))
-      .returning({ balance: wallet.balance });
-    const newBalance = debited[0]?.balance;
+    const debited = await debitWalletBalance(txn, row.id, row.currency, amount);
+    const newBalance = debited[0]?.amount;
     if (newBalance === undefined) {
       return { ok: false, available };
     }
@@ -112,17 +113,13 @@ export class WalletCommandsService implements WalletCommands {
       return { ok: false, reason: 'currency mismatch' };
     }
 
-    const [credited] = await txn
-      .update(wallet)
-      .set({ balance: sql`${wallet.balance} + ${amount}::numeric` })
-      .where(eq(wallet.id, row.id))
-      .returning({ balance: wallet.balance });
+    const [credited] = await creditWalletBalance(txn, row.id, currency, amount);
     if (!credited) {
       throw new Error('wallet credit: no row');
     }
 
     await this.writeLedgerRow(txn, row, type, amount);
 
-    return { ok: true, newBalance: credited.balance };
+    return { ok: true, newBalance: credited.amount };
   }
 }

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -37,6 +37,7 @@ import { eq, asc, desc, sql, and, gte, lte, count, inArray } from 'drizzle-orm';
 import { createHash } from 'node:crypto';
 import {
   wallet,
+  walletBalance,
   walletTransaction,
   autoWithdrawalRule,
   walletAutoWithdrawalConfig,
@@ -114,6 +115,56 @@ export function railFor(currency: string, cryptoCurrencies?: readonly string[]):
     ? new Set(cryptoCurrencies.map((c) => c.toUpperCase()))
     : DEFAULT_CRYPTO_CURRENCIES;
   return set.has(currency.toUpperCase()) ? 'crypto' : 'fiat';
+}
+
+export function creditWalletBalance(
+  txn: DrizzleDb,
+  walletId: Wallet['id'],
+  currency: string,
+  amount: string,
+) {
+  return txn
+    .insert(walletBalance)
+    .values({ walletId, currency, amount })
+    .onConflictDoUpdate({
+      target: [walletBalance.walletId, walletBalance.currency],
+      set: {
+        amount: sql`${walletBalance.amount} + ${amount}::numeric`,
+        updatedAt: new Date(),
+      },
+    })
+    .returning({ amount: walletBalance.amount });
+}
+
+export function debitWalletBalance(
+  txn: DrizzleDb,
+  walletId: Wallet['id'],
+  currency: string,
+  amount: string,
+) {
+  return txn
+    .update(walletBalance)
+    .set({ amount: sql`${walletBalance.amount} - ${amount}::numeric` })
+    .where(
+      and(
+        eq(walletBalance.walletId, walletId),
+        eq(walletBalance.currency, currency),
+        gte(walletBalance.amount, amount),
+      ),
+    )
+    .returning({ amount: walletBalance.amount });
+}
+
+export async function readWalletBalance(
+  txn: DrizzleDb,
+  walletId: Wallet['id'],
+  currency: string,
+): Promise<string> {
+  const [row] = await txn
+    .select({ amount: walletBalance.amount })
+    .from(walletBalance)
+    .where(and(eq(walletBalance.walletId, walletId), eq(walletBalance.currency, currency)));
+  return row?.amount ?? '0';
 }
 
 // Namespace the key per operation so the same raw key on a deposit then a withdraw can't
@@ -286,7 +337,7 @@ export class WalletService {
     }
 
     return {
-      balance: record.balance,
+      balance: await readWalletBalance(this.drizzle.db, record.id, record.currency),
       currency: record.currency,
     };
   }
@@ -378,10 +429,7 @@ export class WalletService {
       });
 
       if (!replayed) {
-        await txn
-          .update(wallet)
-          .set({ balance: sql`${wallet.balance} + ${amount}::numeric` })
-          .where(eq(wallet.id, walletRecord.id));
+        await creditWalletBalance(txn, walletRecord.id, currency, amount);
       }
 
       return { transactionId: row.id, replayed };
@@ -585,13 +633,12 @@ export class WalletService {
         }
 
         // Guarded conditional debit: the WHERE makes balance>=amount atomic with the write; 0 rows back rolls back the whole tx.
-        const debited = await txn
-          .update(wallet)
-          .set({ balance: sql`${wallet.balance} - ${amount}::numeric` })
-          .where(and(eq(wallet.id, current.id), gte(wallet.balance, amount)))
-          .returning({ id: wallet.id });
+        const debited = await debitWalletBalance(txn, current.id, currency, amount);
         if (debited.length !== 1) {
-          throw new InsufficientBalanceError(current.balance, amount);
+          throw new InsufficientBalanceError(
+            await readWalletBalance(txn, current.id, currency),
+            amount,
+          );
         }
 
         if (this.tagEvaluationCommands) {
@@ -883,10 +930,7 @@ export class WalletService {
       if (updated.length === 0) {
         return false;
       }
-      await txn
-        .update(wallet)
-        .set({ balance: sql`${wallet.balance} + ${amount}::numeric` })
-        .where(eq(wallet.id, tx.walletId));
+      await creditWalletBalance(txn, tx.walletId, tx.currency, amount);
       return true;
     });
     if (transitioned && adminId) {
@@ -1374,10 +1418,7 @@ export class WalletService {
         new WithdrawalNotFoundError(withdrawalId),
       );
 
-      await txn
-        .update(wallet)
-        .set({ balance: sql`${wallet.balance} + ${updated.amount}::numeric` })
-        .where(eq(wallet.id, updated.walletId));
+      await creditWalletBalance(txn, updated.walletId, updated.currency, updated.amount);
 
       return updated;
     });
@@ -1532,10 +1573,7 @@ export class WalletService {
         .returning();
 
       if (inserted) {
-        await txn
-          .update(wallet)
-          .set({ balance: sql`${wallet.balance} + ${event.amount}::numeric` })
-          .where(eq(wallet.id, walletRecord.id));
+        await creditWalletBalance(txn, walletRecord.id, event.currency, event.amount);
         return { transactionId: inserted.id, replayed: false };
       }
 

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -117,6 +117,11 @@ export function railFor(currency: string, cryptoCurrencies?: readonly string[]):
   return set.has(currency.toUpperCase()) ? 'crypto' : 'fiat';
 }
 
+// Currency checks elsewhere are case-insensitive, so `usd` reaches here for a `USD`
+// wallet. Every read and write of wallet_balance funnels through these three helpers,
+// so normalizing the key here is enough to keep one row per wallet+currency.
+const balanceKey = (currency: string) => currency.toUpperCase();
+
 export function creditWalletBalance(
   txn: DrizzleDb,
   walletId: Wallet['id'],
@@ -125,7 +130,7 @@ export function creditWalletBalance(
 ) {
   return txn
     .insert(walletBalance)
-    .values({ walletId, currency, amount })
+    .values({ walletId, currency: balanceKey(currency), amount })
     .onConflictDoUpdate({
       target: [walletBalance.walletId, walletBalance.currency],
       set: {
@@ -148,7 +153,7 @@ export function debitWalletBalance(
     .where(
       and(
         eq(walletBalance.walletId, walletId),
-        eq(walletBalance.currency, currency),
+        eq(walletBalance.currency, balanceKey(currency)),
         gte(walletBalance.amount, amount),
       ),
     )
@@ -163,7 +168,9 @@ export async function readWalletBalance(
   const [row] = await txn
     .select({ amount: walletBalance.amount })
     .from(walletBalance)
-    .where(and(eq(walletBalance.walletId, walletId), eq(walletBalance.currency, currency)));
+    .where(
+      and(eq(walletBalance.walletId, walletId), eq(walletBalance.currency, balanceKey(currency))),
+    );
   return row?.amount ?? '0';
 }
 

--- a/packages/testing/src/__tests__/gaming-stake-debit.e2e.test.ts
+++ b/packages/testing/src/__tests__/gaming-stake-debit.e2e.test.ts
@@ -8,7 +8,7 @@ import {
   type CoreTokenCatalog,
 } from '@openora/core/server';
 import { game, gameRound } from '@openora/core/casino/schema/gaming';
-import { wallet, walletTransaction } from '@openora/core/wallet/schema';
+import { wallet, walletBalance, walletTransaction } from '@openora/core/wallet/schema';
 import {
   setupTestDb,
   bootTestApp,
@@ -51,10 +51,11 @@ async function deposit(client: TestClient, amount: string, currency = 'USD') {
 async function balanceOf(container: Container<CoreTokenCatalog>, userId: string): Promise<string> {
   const [row] = await container
     .get(DRIZZLE)
-    .db.select()
-    .from(wallet)
+    .db.select({ amount: walletBalance.amount })
+    .from(walletBalance)
+    .innerJoin(wallet, eq(wallet.id, walletBalance.walletId))
     .where(eq(wallet.userId, userId));
-  return row?.balance ?? '0';
+  return row?.amount ?? '0';
 }
 
 beforeAll(async () => {

--- a/packages/testing/src/seed-demo-data.ts
+++ b/packages/testing/src/seed-demo-data.ts
@@ -3,7 +3,7 @@ import { findOneOrThrow, type DrizzleDb } from '@openora/core/server';
 import { eq } from 'drizzle-orm';
 import { user } from '@openora/core/pam/schema/identity';
 import { player } from '@openora/core/pam/schema/profile';
-import { wallet, walletTransaction } from '@openora/core/wallet/schema';
+import { wallet, walletBalance, walletTransaction } from '@openora/core/wallet/schema';
 import { game } from '@openora/core/casino/schema/gaming';
 import {
   chatRoom,
@@ -415,6 +415,7 @@ export async function seedDemoData(options: SeedOptions): Promise<SeedResult> {
   await db.delete(chatMessage);
   await db.delete(chatRoom);
   await db.delete(walletTransaction);
+  await db.delete(walletBalance);
   await db.delete(wallet);
   await db.delete(player);
   await db.delete(game);
@@ -535,6 +536,9 @@ export async function seedDemoData(options: SeedOptions): Promise<SeedResult> {
         .returning(),
       new Error('seed: expected the wallet insert to return a row'),
     );
+    await db
+      .insert(walletBalance)
+      .values({ walletId: walletRow.id, currency, amount: walletRow.balance });
 
     const deposits = 1 + Math.floor(rng() * 4);
     let depositSum = 0;


### PR DESCRIPTION
## Summary
- Adds `creditWalletBalance`, `debitWalletBalance` and `readWalletBalance` to `wallet.service.ts` and moves all seven balance mutation sites onto them: deposit, withdrawal hold, PSP-failure refund, admin-reject refund, webhook deposit credit, and `WalletCommandsService.debit`/`credit`.
- `debitWalletBalance` keeps the same atomic guard the old code had, now as `WHERE walletId AND currency AND amount >= x` - a lost race still updates zero rows and reports the shortfall.
- `creditWalletBalance` is an upsert, so the balance row is created on first credit and the arithmetic stays in Postgres numeric.
- Test seeds and the demo seeder now write `wallet_balance`; `wallet.balance` is still present but no longer read or written by anything.

## Why
Follow-up to #70. Behaviour is deliberately unchanged here - `CurrencyMismatchError` still rejects a deposit or withdrawal in a currency other than the wallet's, and no test assertion about balances changed. Splitting the storage move from the product change keeps each PR revertible on its own; lifting the single-currency restriction is #72.

## Alternatives considered
Dual-writing `wallet.balance` alongside `wallet_balance` during a transition. Rejected - two sources of truth for money is exactly the thing worth avoiding, and there is no production data that needs the safety net.

## Risks
`wallet.balance` is now dead weight: written as `'0'` on wallet creation and never updated. Anything outside this repo reading that column directly would silently see zero. Grepped the monorepo and only the wallet service touched it. It is dropped in #72.
