### PR TITLE
docs(scaffold): pick the outermost test tier in consumer repos

### DIFF
--- a/tools/templates/consumer/__dot__rulesync/rules/conventions.md
+++ b/tools/templates/consumer/__dot__rulesync/rules/conventions.md
@@ -81,7 +81,10 @@ above) if this repo has no UI apps.
   `mapErrors`.
 - **Pin exact dependency versions** (no `^`/`~`); add a dependency deliberately - std lib or a few
   lines often beat a tree.
-- **Tests co-locate in `__tests__/`**; test behaviour, not implementation; always cover authz
-  negatives. Detail: `docs/standards/testing.md`.
+- **Test at the outermost tier that reaches the behaviour:** a UI journey -> browser E2E; an API
+  route, an overlay, a vendor adapter, anything with SQL -> API E2E against real Postgres with the
+  vendor stubbed at its HTTP boundary; a pure function -> a co-located unit test in `__tests__/`.
+  Never fake a query builder and never let a spy assertion be the point of a test; always cover
+  authz negatives. Detail: `docs/standards/testing.md`.
 - **Green before review:** `pnpm verify` passes. Conventional commits, lowercase subject, one PR
   per concern. Never push without explicit confirmation. Detail: `docs/standards/git-delivery.md`.

--- a/tools/templates/consumer/__dot__rulesync/rules/e2e-conventions.md
+++ b/tools/templates/consumer/__dot__rulesync/rules/e2e-conventions.md
@@ -4,12 +4,19 @@ targets:
   - '*'
 globs:
   - 'apps/e2e/**'
-description: Playwright E2E conventions - dual-mode (USE_MOCKS) specs, fixtures, mocks, page objects.
+description: Playwright E2E conventions - browser specs (dual-mode USE_MOCKS) and the API integration tier.
 ---
 
 # E2E conventions (`apps/e2e`)
 
-Every spec is written ONCE and runs in two modes, switched by `USE_MOCKS`:
+Two kinds of spec live here:
+
+- **Browser specs** (`tests/<app>/**`) - a player or admin journey through the UI. Dual-mode, see below.
+- **API specs** (`tests/api/**`) - the `api` Playwright project: no browser, no `page`. Drives the real API over HTTP against real Postgres, with each external vendor replaced by a stub HTTP server the API is pointed at by env. This is the tier that proves an overlay end to end: request -> route -> service -> rows -> webhook -> resulting state. Never runs under `USE_MOCKS` - an intercepted response would erase the integration the spec exists to check.
+
+## Browser specs
+
+Every browser spec is written ONCE and runs in two modes, switched by `USE_MOCKS`:
 
 - `USE_MOCKS=true` - CI / pull request: requests fulfilled from `mocks/`, no stack needed, blocks merge.
 - unset - scheduled/local run against the real seeded API (`pnpm dev` stack must be up); failures alert, don't block.
@@ -24,3 +31,11 @@ Every spec is written ONCE and runs in two modes, switched by `USE_MOCKS`:
 - Test names are behavioural: "shows masked standings", not "table renders".
 - `cleanup(fn)` reverses any real data a test creates (runs in reverse order; no-op under mocks).
 - Layout: `tests/<app>/<domain>/<scenario>.spec.ts` (one Playwright project per app, sharing fixtures/mocks/pages; run one with `--project=<app>`), `mocks/<domain>.ts`, `pages/<name>.page.ts`.
+
+## API specs (`tests/api/**`)
+
+- Use `request` (Playwright's APIRequestContext), never `page`. Assert status, body, and the state a follow-up request reports - not internals.
+- A vendor stub is a plain `node:http` server under `apps/e2e/`, modelled on `mock-identity-server.mjs`: it answers only the vendor endpoints the flow reaches and records the calls a spec asserts on. Point the API at it with the vendor's base-URL env var; every vendor adapter must accept one.
+- Drive the vendor's inbound side the way the vendor does - post the real webhook shape to the real route with a signature the stub's key material produces. Never call the adapter directly.
+- Own your data: create the player the spec needs and reverse it with `cleanup(fn)`. The suite shares one database.
+- Layout: `tests/api/<domain>/<scenario>.spec.ts`.

--- a/tools/templates/consumer/__dot__rulesync/rules/e2e-conventions.md
+++ b/tools/templates/consumer/__dot__rulesync/rules/e2e-conventions.md
@@ -4,32 +4,39 @@ targets:
   - '*'
 globs:
   - 'apps/e2e/**'
-description: Playwright E2E conventions - browser specs (dual-mode USE_MOCKS) and the API integration tier.
+description: Playwright E2E conventions - specs run against the real stack; mocking is a narrow, justified exception.
 ---
 
 # E2E conventions (`apps/e2e`)
 
 Two kinds of spec live here:
 
-- **Browser specs** (`tests/<app>/**`) - a player or admin journey through the UI. Dual-mode, see below.
-- **API specs** (`tests/api/**`) - the `api` Playwright project: no browser, no `page`. Drives the real API over HTTP against real Postgres, with each external vendor replaced by a stub HTTP server the API is pointed at by env. This is the tier that proves an overlay end to end: request -> route -> service -> rows -> webhook -> resulting state. Never runs under `USE_MOCKS` - an intercepted response would erase the integration the spec exists to check.
+- **Browser specs** (`tests/<app>/**`) - a player or admin journey through the UI.
+- **API specs** (`tests/api/**`) - the `api` Playwright project: no browser, no `page`. Drives the real API over HTTP against real Postgres, with each external vendor replaced by a stub HTTP server the API is pointed at by env. This is the tier that proves an overlay end to end: request -> route -> service -> rows -> webhook -> resulting state. `USE_MOCKS` does not apply here at all.
 
-## Browser specs
+## Real stack by default
 
-Every browser spec is written ONCE and runs in two modes, switched by `USE_MOCKS`:
+Every spec runs against the real seeded stack - API, Postgres, and the apps under test - and that
+run is what blocks merge. A test that never executes the backend cannot tell you the backend works.
 
-- `USE_MOCKS=true` - CI / pull request: requests fulfilled from `mocks/`, no stack needed, blocks merge.
-- unset - scheduled/local run against the real seeded API (`pnpm dev` stack must be up); failures alert, don't block.
+`USE_MOCKS=true` intercepts responses in the browser and exists only for a state you cannot produce
+for real: a third-party widget or redirect you are not allowed to run in CI. It is an exception you
+justify per spec, never the mode a suite is written for. Anything reachable by seeding data or by
+scripting a vendor stub is NOT such a state - script the stub instead, and prefer the API tier when
+the behaviour under test is the backend's.
+
+Existing mocked specs are converted as they are touched; delete the fixture with the last spec that
+used it.
 
 ## Rules
 
 - Import `test`/`expect` from `fixtures.ts`, NEVER from `@playwright/test` - fixtures add `cleanup()` and shared setup.
-- `mockApi(page, routes)` (from `lib/mocks.ts`) registers interceptions only under `USE_MOCKS`; in real mode it's a no-op, so the same assertions exercise the live backend. Never branch test logic on the mode.
-- Mocks are typed: fixture shapes in `mocks/<domain>.ts` mirror the response contract - type platform-endpoint fixtures with the `z.infer` contract type from `@openora/*` so a contract change fails typecheck. No loose hand-written JSON.
+- Set up state through the product: seed data or drive the API, so the spec exercises the same path a player would. `mockApi(page, routes)` (from `lib/mocks.ts`) is the escape hatch above - reach for it only after the real setup is genuinely impossible, and never branch test logic on the mode.
+- A mock that stays is typed: fixture shapes in `mocks/<domain>.ts` mirror the response contract - type platform-endpoint fixtures with the `z.infer` contract type from `@openora/*` so a contract change fails typecheck. No loose hand-written JSON.
 - Selectors use `data-testid` - kebab-case, domain-prefixed (`chat-message`, `chat-input`). Never assert on CSS classes or component-library structure; shared UI components spread props so `data-testid` passes through.
 - Page objects in `pages/<name>.page.ts` are functional factories - no classes, no `this`; locators + actions returned as a plain object.
 - Test names are behavioural: "shows masked standings", not "table renders".
-- `cleanup(fn)` reverses any real data a test creates (runs in reverse order; no-op under mocks).
+- `cleanup(fn)` reverses any data a test creates (runs in reverse order) - the suite shares one database, so a spec that leaks rows breaks the next one.
 - Layout: `tests/<app>/<domain>/<scenario>.spec.ts` (one Playwright project per app, sharing fixtures/mocks/pages; run one with `--project=<app>`), `mocks/<domain>.ts`, `pages/<name>.page.ts`.
 
 ## API specs (`tests/api/**`)

--- a/tools/templates/consumer/docs/standards/testing.md
+++ b/tools/templates/consumer/docs/standards/testing.md
@@ -2,12 +2,32 @@
 
 Read this before adding or restructuring a test.
 
-- Co-locate as `src/__tests__/<name>.test.ts` (Vitest); service tests use a vi-mocked Drizzle.
-- Test behavior, not implementation - tests must survive a safe refactor (assert outputs, not
-  private caches).
-- Cover new logic as part of the same change: unit tests for pure functions, authz negatives
-  included.
-- Deterministic and isolated: no shared mutable state, no real network, seedable data.
+## Pick the tier
+
+Pick the OUTERMOST tier that can reach the behaviour - a test earns its keep by running real code,
+not by being cheap.
+
+| What you changed                                              | Tier                                          |
+| ------------------------------------------------------------- | --------------------------------------------- |
+| A screen, a form, a player/admin journey                      | Browser E2E (`apps/e2e/tests/<app>/**`)       |
+| An API route, an overlay, a vendor adapter, anything with SQL | API E2E (`apps/e2e/tests/api/**`)             |
+| A pure function - parser, resolver, mapper, money calculation | Unit (`src/__tests__/<name>.test.ts`, Vitest) |
+
+The API tier drives the real API over HTTP against real Postgres, with each external vendor
+replaced by a stub HTTP server the API is pointed at by env. It is the default tier for
+`apps/api/src/extensions/**`: an overlay is wiring, and wiring is exactly what a unit test skips.
+
+## What is real, what is doubled
+
+- **Anything that touches the database is tested against real Postgres.** Never fake a query
+  builder: a stubbed chain proves a call order, not a result, so it misses the regressions that
+  matter - a unique-index conflict, a wrong `where`, a lost race, a rollback that never happened.
+- **External vendors are stubbed at their HTTP boundary** (a `node:http` stand-in the API's
+  base-URL env var points at), never by mocking our own adapter - a mocked adapter skips exactly
+  the wiring the test exists to check. Every vendor adapter therefore accepts a base-URL override.
+- **A spy assertion is never the point of a test.** `expect(client.x).toHaveBeenCalledWith(...)`
+  only restates the line above it. A spy may stand in for an outbound vendor call, never for the
+  thing under test.
 
 ```ts
 // bad - a mocked builder chain proves a call order, not a result
@@ -16,3 +36,13 @@ expect(db.select).toHaveBeenCalled();
 // good - assert the outcome
 expect(await service.get(id)).toEqual(row);
 ```
+
+## How to write them
+
+- Test behavior, not implementation - tests must survive a safe refactor (assert outputs, not
+  private caches).
+- Cover new logic as part of the same change; always include the authz negatives.
+- Drive a vendor's inbound side the way the vendor does: post the real webhook shape to the real
+  route with a signature the stub's key material produces. Never call the adapter directly.
+- Deterministic and isolated: no shared mutable state, no real outbound network, seedable data.
+  Own the rows a test creates and clean them up - the API suite shares one database.


### PR DESCRIPTION
## Summary

Rewrite the consumer template's testing standard around a tier ladder, and give the E2E rules a second kind of spec: an API tier that drives the real API against real Postgres with vendors stubbed at their HTTP boundary.

## Why

`docs/standards/testing.md` told consumers that "service tests use a vi-mocked Drizzle" - one line above an example explaining why a mocked builder chain proves a call order and not a result. An agent following that line writes a test that passes whether or not the query is correct, and a consumer overlay is mostly wiring, which is exactly what such a test skips.

The consumer scaffold also had nowhere between a unit test and a browser spec. Browser specs run under `USE_MOCKS` in CI, so an overlay's real path (route, service, rows, webhook) never executed in a blocking check.

## Alternatives considered

Making E2E the blanket default. Rejected: it would push a pure resolver or parser into a browser run, and browser specs in mock mode prove nothing about the backend anyway. The tier is chosen by what changed, not by preference.

## Risks

Docs and template only, no runtime code. A consumer generated before this keeps its old wording until it syncs the template; the API tier needs a `tests/api` Playwright project and a Postgres service in that consumer's CI, neither of which this PR creates.