### PR TITLE
feat(tag): export system actor id from tag contract

### DIFF
--- a/packages/core/src/pam/tag/__tests__/tag-evaluation.service.int.test.ts
+++ b/packages/core/src/pam/tag/__tests__/tag-evaluation.service.int.test.ts
@@ -15,7 +15,7 @@ import { player } from '@openora/core/pam/schema/profile';
 import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import { mock, makeEventBus } from '../../../testing/mock.js';
 import { TagEvaluationService } from '../service/tag-evaluation.service.js';
-import { SYSTEM_ACTOR_ID } from '../service/tag-mappers.js';
+import { SYSTEM_ACTOR_ID } from '../contract/index.js';
 import { TagService } from '../service/tag.service.js';
 import { TagRuleService } from '../service/tag-rule.service.js';
 import { migrate } from '../migrate.js';

--- a/packages/core/src/pam/tag/contract/index.ts
+++ b/packages/core/src/pam/tag/contract/index.ts
@@ -16,6 +16,8 @@ import { HighRiskAssignMetadataSchema } from './player-tag-assign-metadata.js';
 
 export * from './player-tag-assign-metadata.js';
 
+export const SYSTEM_ACTOR_ID = '00000000-0000-0000-0000-000000000000';
+
 export const PLAYER_TAG_SORT_BY_VALUES = ['createdAt', 'assignActor'] as const;
 export const PlayerTagSortBySchema = z.enum(PLAYER_TAG_SORT_BY_VALUES).default('createdAt');
 export type PlayerTagSortBy = z.infer<typeof PlayerTagSortBySchema>;

--- a/packages/core/src/pam/tag/service/tag-evaluation.service.ts
+++ b/packages/core/src/pam/tag/service/tag-evaluation.service.ts
@@ -12,12 +12,12 @@ import {
 import { moneyToNumber, mapConcurrent, type DrizzleTx } from '@openora/core/server';
 import { TagService, TagAlreadyInUseError, TagAssignmentNotFoundError } from './tag.service.js';
 import { TagRuleService, TagRuleNotFoundError } from './tag-rule.service.js';
-import type {
-  PlayerTagAssignMetadata,
-  HighRiskAmountBreachDetail,
-  HighRiskCountBreachDetail,
+import {
+  SYSTEM_ACTOR_ID,
+  type PlayerTagAssignMetadata,
+  type HighRiskAmountBreachDetail,
+  type HighRiskCountBreachDetail,
 } from '@openora/core/pam/contracts/tag';
-import { SYSTEM_ACTOR_ID } from './tag-mappers.js';
 
 const EVAL_CHUNK_SIZE = 100;
 const MULTI_ACCOUNT_REASON = 'identity signal matched another player account';

--- a/packages/core/src/pam/tag/service/tag-mappers.ts
+++ b/packages/core/src/pam/tag/service/tag-mappers.ts
@@ -3,8 +3,6 @@ import { serializeRow } from '@openora/core/server';
 import type { PlayerTagWithTag } from '../contract/index.js';
 import { tag, playerTag, tagRule } from '../schema/index.js';
 
-export const SYSTEM_ACTOR_ID = '00000000-0000-0000-0000-000000000000';
-
 export function toTag(row: typeof tag.$inferSelect) {
   return serializeRow(row, { dateFields: ['createdAt', 'updatedAt'] });
 }

--- a/packages/core/src/pam/tag/service/tag.service.ts
+++ b/packages/core/src/pam/tag/service/tag.service.ts
@@ -23,11 +23,11 @@ import {
   type ClientMeta,
   type PaginationOptions,
 } from '@openora/core/contracts';
-import type { PlayerTagSortBy, PlayerTagWithTag } from '../contract/index.js';
+import { SYSTEM_ACTOR_ID, type PlayerTagSortBy, type PlayerTagWithTag } from '../contract/index.js';
 import { player } from '@openora/core/pam/schema/profile';
 import { playerTag, tag } from '../schema/index.js';
 import { mapDbError } from '@openora/core/common/errors';
-import { toTag, toPlayerTagWithTag, SYSTEM_ACTOR_ID } from './tag-mappers.js';
+import { toTag, toPlayerTagWithTag } from './tag-mappers.js';
 import type { PlayerTagAssignMetadata } from '../contract/player-tag-assign-metadata.js';
 
 // AssignPlayerTagInput is the admin wire-contract type (free-text assignReason only -


### PR DESCRIPTION
## Summary

Exports `SYSTEM_ACTOR_ID` (the sentinel actor id for auto-assigned/system tag actions) from the tag module's public `contract` surface instead of keeping it internal to `service/tag-mappers.ts`.

## Why

A downstream consumer resolving `assignActorUserId`/`removalActorUserId` on `PlayerTagWithTag` needs to detect the system-actor sentinel to render it correctly (e.g. showing "System" instead of a raw admin lookup). The constant wasn't reachable from any published subpath, so the consumer had to hardcode the same UUID literal - a silent-drift risk if this value ever changes.

## Alternatives considered

Leaving the constant private and asking consumers to keep duplicating the literal - rejected, since it's exactly the kind of drift risk `contract/index.ts` exists to prevent.

## Risks

None.