### PR TITLE
feat(wallet): settle withdrawals on an explicit network

### DIFF
--- a/packages/core/src/wallet/__tests__/settlement-network.test.ts
+++ b/packages/core/src/wallet/__tests__/settlement-network.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveWithdrawalNetwork,
+  assertAboveMinimumWithdrawal,
+  AmbiguousNetworkError,
+  UnsupportedNetworkError,
+  WithdrawalDisabledError,
+  BelowMinimumWithdrawalError,
+} from '../service/wallet.service.js';
+
+const asset = (network: string, minWithdrawal = '0', withdrawalEnabled = true) => ({
+  network,
+  minWithdrawal,
+  withdrawalEnabled,
+});
+
+describe('resolveWithdrawalNetwork', () => {
+  it('passes the caller through when the currency has no catalog rows', () => {
+    expect(resolveWithdrawalNetwork([], 'USD', undefined)).toBeNull();
+    expect(resolveWithdrawalNetwork([], 'USD', 'sepa')).toBe('SEPA');
+  });
+
+  it('implies the only payable network', () => {
+    expect(resolveWithdrawalNetwork([asset('ERC20')], 'USDT')).toBe('ERC20');
+  });
+
+  it('demands a network when several are payable', () => {
+    expect(() => resolveWithdrawalNetwork([asset('ERC20'), asset('TRC20')], 'USDT')).toThrow(
+      AmbiguousNetworkError,
+    );
+  });
+
+  it('implies the only network still payable when the others are disabled', () => {
+    const assets = [asset('ERC20'), asset('TRC20', '0', false)];
+
+    expect(resolveWithdrawalNetwork(assets, 'USDT')).toBe('ERC20');
+  });
+
+  it('accepts an explicitly chosen payable network, normalizing case', () => {
+    const assets = [asset('ERC20'), asset('TRC20')];
+
+    expect(resolveWithdrawalNetwork(assets, 'USDT', 'trc20')).toBe('TRC20');
+  });
+
+  it('rejects a network the currency does not settle on', () => {
+    expect(() => resolveWithdrawalNetwork([asset('ERC20')], 'USDT', 'BEP20')).toThrow(
+      UnsupportedNetworkError,
+    );
+  });
+
+  it('rejects a network configured but disabled for withdrawal', () => {
+    const assets = [asset('ERC20'), asset('TRC20', '0', false)];
+
+    expect(() => resolveWithdrawalNetwork(assets, 'USDT', 'TRC20')).toThrow(
+      UnsupportedNetworkError,
+    );
+  });
+
+  it('fails closed when the currency is configured but payable nowhere', () => {
+    const assets = [asset('ERC20', '0', false), asset('TRC20', '0', false)];
+
+    expect(() => resolveWithdrawalNetwork(assets, 'USDT')).toThrow(WithdrawalDisabledError);
+    expect(() => resolveWithdrawalNetwork(assets, 'USDT', 'ERC20')).toThrow(
+      WithdrawalDisabledError,
+    );
+  });
+});
+
+describe('assertAboveMinimumWithdrawal', () => {
+  const assets = [asset('ERC20', '20'), asset('BEP20', '1')];
+
+  it('enforces the floor of the chosen chain, not the currency', () => {
+    expect(() => assertAboveMinimumWithdrawal(assets, '5', 'USDT', 'ERC20')).toThrow(
+      BelowMinimumWithdrawalError,
+    );
+    expect(() => assertAboveMinimumWithdrawal(assets, '5', 'USDT', 'BEP20')).not.toThrow();
+  });
+
+  it('allows an amount exactly at the floor', () => {
+    expect(() => assertAboveMinimumWithdrawal(assets, '20', 'USDT', 'ERC20')).not.toThrow();
+  });
+
+  it('is a no-op when the network has no catalog row', () => {
+    expect(() => assertAboveMinimumWithdrawal(assets, '0.01', 'USDT', 'TRC20')).not.toThrow();
+    expect(() => assertAboveMinimumWithdrawal([], '0.01', 'USD', null)).not.toThrow();
+  });
+});

--- a/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
@@ -18,7 +18,13 @@ import {
   makeAuditWriter,
 } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
-import { wallet, walletBalance, walletTransaction, walletDepositAddress } from '../schema/index.js';
+import {
+  wallet,
+  walletBalance,
+  walletTransaction,
+  walletDepositAddress,
+  walletAsset,
+} from '../schema/index.js';
 import {
   WalletService,
   type WalletServiceDeps,
@@ -31,6 +37,9 @@ import {
   IdempotencyKeyReuseError,
   DepositAddressUnsupportedError,
   DestinationAddressRequiredError,
+  AmbiguousNetworkError,
+  BelowMinimumWithdrawalError,
+  WithdrawalDisabledError,
 } from '../service/wallet.service.js';
 import { WithdrawalQueueItemSchema } from '../contract/index.js';
 
@@ -152,7 +161,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await db.drizzle.db.execute(
-    sql`TRUNCATE ${walletTransaction}, ${walletDepositAddress}, ${wallet} RESTART IDENTITY CASCADE`,
+    sql`TRUNCATE ${walletTransaction}, ${walletDepositAddress}, ${walletAsset}, ${wallet} RESTART IDENTITY CASCADE`,
   );
 });
 
@@ -315,6 +324,117 @@ describe('WalletService.withdraw (real PG)', () => {
       rail: 'crypto',
       destinationAddress: 'bc1qexample',
     });
+  });
+
+  it('pins the only payable network on the transaction', async () => {
+    const { svc } = makeService();
+    const w = await seedWallet({ balance: '2', currency: 'BTC' });
+    await db.drizzle.db.insert(walletAsset).values({
+      currency: 'BTC',
+      network: 'BITCOIN',
+      providerAssetId: 'BTC',
+      minDeposit: '0',
+      minWithdrawal: '0',
+      withdrawalFee: '0',
+    });
+
+    const result = await svc.withdraw({
+      userId: w.userId,
+      amount: '1',
+      currency: 'BTC',
+      destinationAddress: 'bc1qexample',
+      ...NO_CLIENT_META,
+    });
+
+    expect(await txById(result.transactionId)).toMatchObject({ network: 'BITCOIN' });
+  });
+
+  it('demands a network when the currency is payable on several, holding no funds', async () => {
+    const { svc } = makeService();
+    const w = await seedWallet({ balance: '100', currency: 'USDT' });
+    await db.drizzle.db.insert(walletAsset).values(
+      ['ERC20', 'TRC20'].map((network) => ({
+        currency: 'USDT',
+        network,
+        providerAssetId: `USDT_${network}`,
+        minDeposit: '0',
+        minWithdrawal: '0',
+        withdrawalFee: '0',
+      })),
+    );
+
+    await expect(
+      svc.withdraw({
+        userId: w.userId,
+        amount: '10',
+        currency: 'USDT',
+        destinationAddress: '0xexample',
+        ...NO_CLIENT_META,
+      }),
+    ).rejects.toBeInstanceOf(AmbiguousNetworkError);
+    expect(await balanceOf(w.userId)).toBe(100);
+  });
+
+  it('enforces the minimum of the chosen chain, not the currency', async () => {
+    const { svc } = makeService();
+    const w = await seedWallet({ balance: '100', currency: 'USDT' });
+    await db.drizzle.db.insert(walletAsset).values([
+      {
+        currency: 'USDT',
+        network: 'ERC20',
+        providerAssetId: 'USDT_ERC20',
+        minDeposit: '0',
+        minWithdrawal: '20',
+        withdrawalFee: '0',
+      },
+      {
+        currency: 'USDT',
+        network: 'BEP20',
+        providerAssetId: 'USDT_BSC',
+        minDeposit: '0',
+        minWithdrawal: '1',
+        withdrawalFee: '0',
+      },
+    ]);
+    const args = {
+      userId: w.userId,
+      amount: '5',
+      currency: 'USDT',
+      destinationAddress: '0xexample',
+      ...NO_CLIENT_META,
+    };
+
+    await expect(svc.withdraw({ ...args, network: 'ERC20' })).rejects.toBeInstanceOf(
+      BelowMinimumWithdrawalError,
+    );
+    const ok = await svc.withdraw({ ...args, network: 'BEP20' });
+
+    expect(await txById(ok.transactionId)).toMatchObject({ network: 'BEP20' });
+  });
+
+  it('fails closed when the currency is configured but payable nowhere', async () => {
+    const { svc } = makeService();
+    const w = await seedWallet({ balance: '100', currency: 'USDT' });
+    await db.drizzle.db.insert(walletAsset).values({
+      currency: 'USDT',
+      network: 'ERC20',
+      providerAssetId: 'USDT_ERC20',
+      minDeposit: '0',
+      minWithdrawal: '0',
+      withdrawalFee: '0',
+      withdrawalEnabled: false,
+    });
+
+    await expect(
+      svc.withdraw({
+        userId: w.userId,
+        amount: '10',
+        currency: 'USDT',
+        destinationAddress: '0xexample',
+        ...NO_CLIENT_META,
+      }),
+    ).rejects.toBeInstanceOf(WithdrawalDisabledError);
+    expect(await balanceOf(w.userId)).toBe(100);
   });
 
   it('throws DestinationAddressRequiredError for a crypto withdrawal with no address', async () => {

--- a/packages/core/src/wallet/contract/index.ts
+++ b/packages/core/src/wallet/contract/index.ts
@@ -29,6 +29,13 @@ const WalletCurrencyCodeSchema = z
 
 const WalletCurrencyInputSchema = WalletCurrencyCodeSchema.transform((c) => c.toUpperCase());
 
+// A currency does not identify a chain: USDT settles on ERC20, TRC20 and BEP20 with
+// different addresses, fees and minimums. Free-form rather than an enum because each
+// vendor spells chains its own way (ERC20 vs ETHEREUM vs eth-mainnet).
+const WalletNetworkSchema = z.string().trim().min(1).max(32);
+
+const WalletNetworkInputSchema = WalletNetworkSchema.transform((n) => n.toUpperCase());
+
 export const WalletBalanceSchema = z.object({
   balance: MoneyAmountSchema,
   currency: WalletCurrencyCodeSchema,
@@ -48,6 +55,7 @@ export const WalletTransactionSchema = z.object({
   type: WalletTransactionTypeSchema,
   amount: MoneyAmountSchema,
   currency: WalletCurrencyCodeSchema,
+  network: WalletNetworkSchema.nullable(),
   status: WalletTransactionStatusSchema,
   createdAt: TimestampSchema,
 });
@@ -62,6 +70,9 @@ export const DepositInputSchema = z.object({
 export const WithdrawInputSchema = z.object({
   amount: PositiveMoneyAmountSchema,
   currency: WalletCurrencyInputSchema,
+  // Required for any currency the operator settles on more than one chain - a payout is
+  // rejected as ambiguous rather than guessing which chain the player meant.
+  network: WalletNetworkInputSchema.optional(),
   provider: z.string().optional(),
   idempotencyKey: UuidSchema.optional(),
   destinationAddress: z.string().optional(),
@@ -109,6 +120,7 @@ export const WithdrawalQueueItemSchema = z.object({
   username: z.string(),
   amount: MoneyAmountSchema,
   currency: WalletCurrencyCodeSchema,
+  network: WalletNetworkSchema.nullable(),
   rail: WalletRailSchema.nullable(),
   status: WalletTransactionStatusSchema,
   kycStatus: KycStatusSchema.nullable(),
@@ -190,23 +202,14 @@ export const PaymentWebhookOutputSchema = z.object({ ok: z.literal(true) });
 
 export const DepositAddressInputSchema = z.object({
   currency: WalletCurrencyInputSchema,
-  network: z.string().min(1).optional(),
+  network: WalletNetworkInputSchema.optional(),
 });
 export const DepositAddressSchema = z.object({
   address: z.string(),
   currency: WalletCurrencyCodeSchema,
-  network: z.string().optional(),
+  network: WalletNetworkSchema.optional(),
   tag: z.string().optional(),
 });
-
-// Free-form, not an enum: each payment vendor spells chains its own way (ERC20 vs
-// ETHEREUM vs eth-mainnet). Uppercased so casing alone can't duplicate a row.
-const WalletNetworkInputSchema = z
-  .string()
-  .trim()
-  .min(1)
-  .max(32)
-  .transform((n) => n.toUpperCase());
 
 // Bounded to the column's integer-digit budget so an oversized value is a 4xx at the
 // contract boundary instead of a DB overflow 500.
@@ -217,7 +220,7 @@ const WalletAssetAmountSchema = MoneyAmountSchema.refine(
 
 export const PublicWalletAssetSchema = z.object({
   currency: WalletCurrencyCodeSchema,
-  network: z.string(),
+  network: WalletNetworkSchema,
   minDeposit: MoneyAmountSchema,
   minWithdrawal: MoneyAmountSchema,
   withdrawalFee: MoneyAmountSchema,

--- a/packages/core/src/wallet/drizzle/migrations/0011_third_steve_rogers.sql
+++ b/packages/core/src/wallet/drizzle/migrations/0011_third_steve_rogers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "wallet_transaction" ADD COLUMN "network" text;--> statement-breakpoint
+CREATE INDEX "wallet_transaction_currency_network_idx" ON "wallet_transaction" USING btree ("currency","network");

--- a/packages/core/src/wallet/drizzle/migrations/meta/0011_snapshot.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1028 @@
+{
+  "id": "94559e52-682d-489c-a5c6-7cfba3dab7d7",
+  "prevId": "48b38945-d272-4fe6-baf9-6e604577d5a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auto_withdrawal_rule": {
+      "name": "auto_withdrawal_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auto_withdrawal_rule_user_id_unique": {
+          "name": "auto_withdrawal_rule_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_user_id_unique": {
+          "name": "wallet_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_asset": {
+      "name": "wallet_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_asset_id": {
+          "name": "provider_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_deposit": {
+          "name": "min_deposit",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_withdrawal": {
+          "name": "min_withdrawal",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawal_fee": {
+          "name": "withdrawal_fee",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deposit_enabled": {
+          "name": "deposit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "withdrawal_enabled": {
+          "name": "withdrawal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_asset_currency_network_idx": {
+          "name": "wallet_asset_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_auto_withdrawal_config": {
+      "name": "wallet_auto_withdrawal_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "fiat_threshold": {
+          "name": "fiat_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crypto_threshold": {
+          "name": "crypto_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_risk_flags": {
+          "name": "exclude_risk_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['high_risk','bonus_abuser','kyc_rejected','withdrawal_review','multi_account']::text[]"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_auto_withdrawal_config_singletonKey_unique": {
+          "name": "wallet_auto_withdrawal_config_singletonKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_balance": {
+      "name": "wallet_balance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_balance_wallet_id_currency_idx": {
+          "name": "wallet_balance_wallet_id_currency_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_balance_wallet_id_wallet_id_fk": {
+          "name": "wallet_balance_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_balance",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_deposit_address": {
+      "name": "wallet_deposit_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_deposit_address_user_id_currency_network_idx": {
+          "name": "wallet_deposit_address_user_id_currency_network_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_user_id_currency_idx": {
+          "name": "wallet_deposit_address_user_id_currency_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_tag_idx": {
+          "name": "wallet_deposit_address_address_tag_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_network_currency_idx": {
+          "name": "wallet_deposit_address_address_network_currency_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NULL AND \"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_idx": {
+          "name": "wallet_deposit_address_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_provider_vault": {
+      "name": "wallet_provider_vault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_account_id": {
+          "name": "vault_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_provider_vault_user_id_provider_name_idx": {
+          "name": "wallet_provider_vault_user_id_provider_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_provider_vault_provider_name_vault_account_id_idx": {
+          "name": "wallet_provider_vault_provider_name_vault_account_id_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vault_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transaction": {
+      "name": "wallet_transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "wallet_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rail": {
+          "name": "rail",
+          "type": "wallet_rail",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref_id": {
+          "name": "provider_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_address": {
+          "name": "destination_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transaction_wallet_id_idx": {
+          "name": "wallet_transaction_wallet_id_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_created_at_idx": {
+          "name": "wallet_transaction_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_type_idx": {
+          "name": "wallet_transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_idx": {
+          "name": "wallet_transaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_rail_idx": {
+          "name": "wallet_transaction_rail_idx",
+          "columns": [
+            {
+              "expression": "rail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_idx": {
+          "name": "wallet_transaction_currency_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_network_idx": {
+          "name": "wallet_transaction_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_tx_hash_idx": {
+          "name": "wallet_transaction_tx_hash_idx",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_type_created_at_idx": {
+          "name": "wallet_transaction_status_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_type_status_idx": {
+          "name": "wallet_transaction_wallet_id_type_status_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_provider_ref_id_idx": {
+          "name": "wallet_transaction_provider_ref_id_idx",
+          "columns": [
+            {
+              "expression": "provider_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"provider_ref_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_idempotency_key_idx": {
+          "name": "wallet_transaction_wallet_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transaction_wallet_id_wallet_id_fk": {
+          "name": "wallet_transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.wallet_rail": {
+      "name": "wallet_rail",
+      "schema": "public",
+      "values": ["crypto", "fiat"]
+    },
+    "public.wallet_transaction_status": {
+      "name": "wallet_transaction_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "rejected", "on_hold", "cancelled"]
+    },
+    "public.wallet_transaction_type": {
+      "name": "wallet_transaction_type",
+      "schema": "public",
+      "values": ["deposit", "withdrawal", "bet", "win", "loss", "bonus", "tip", "gift", "rain"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1787257749911,
       "tag": "0010_mixed_mongu",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1787259524346,
+      "tag": "0011_third_steve_rogers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/wallet/router/index.ts
+++ b/packages/core/src/wallet/router/index.ts
@@ -22,6 +22,10 @@ import {
   WalletAssetAlreadyExistsError,
   WalletAssetUnsupportedError,
   WalletAssetInUseError,
+  AmbiguousNetworkError,
+  UnsupportedNetworkError,
+  WithdrawalDisabledError,
+  BelowMinimumWithdrawalError,
 } from '../service/wallet.service.js';
 
 export function createWalletRouter(
@@ -60,14 +64,26 @@ export function createWalletRouter(
       return mapErrors(
         {
           NOT_FOUND: WalletNotFoundError,
-          BAD_REQUEST: [InsufficientBalanceError, CurrencyMismatchError],
-          CONFLICT: [KycRequiredError, IdempotencyKeyReuseError, DestinationAddressRequiredError],
+          BAD_REQUEST: [
+            InsufficientBalanceError,
+            CurrencyMismatchError,
+            AmbiguousNetworkError,
+            UnsupportedNetworkError,
+            BelowMinimumWithdrawalError,
+          ],
+          CONFLICT: [
+            KycRequiredError,
+            IdempotencyKeyReuseError,
+            DestinationAddressRequiredError,
+            WithdrawalDisabledError,
+          ],
         },
         () =>
           wallet.withdraw({
             userId: getUserId(context),
             amount: input.amount,
             currency: input.currency,
+            network: input.network,
             idempotencyKey: input.idempotencyKey,
             destinationAddress: input.destinationAddress,
             ...context.clientMeta,

--- a/packages/core/src/wallet/schema/index.ts
+++ b/packages/core/src/wallet/schema/index.ts
@@ -72,6 +72,10 @@ export const walletTransaction = pgTable(
     type: walletTransactionTypeEnum().notNull(),
     amount: decimal({ precision: MONEY_PRECISION, scale: MONEY_SCALE }).notNull(),
     currency: text().notNull(),
+    // The chain this moved on. A currency does not identify one, so reconciliation and
+    // reporting are per (currency, network). Null on a fiat rail and on any internal
+    // transaction type (bet/win/bonus) that never touches a chain.
+    network: text(),
     status: walletTransactionStatusEnum()
       .$type<WalletTransactionStatus>()
       .notNull()
@@ -104,6 +108,7 @@ export const walletTransaction = pgTable(
     index('wallet_transaction_status_idx').on(t.status),
     index('wallet_transaction_rail_idx').on(t.rail),
     index('wallet_transaction_currency_idx').on(t.currency),
+    index('wallet_transaction_currency_network_idx').on(t.currency, t.network),
     index('wallet_transaction_tx_hash_idx').on(t.txHash),
     index('wallet_transaction_status_type_created_at_idx').on(t.status, t.type, t.createdAt),
     index('wallet_transaction_wallet_id_type_status_idx').on(t.walletId, t.type, t.status),

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -117,6 +117,28 @@ export const WalletAssetInUseError = makeConflictError(
   'Players still hold a balance in this currency',
 );
 
+export const AmbiguousNetworkError = createDomainError(
+  'AmbiguousNetworkError',
+  (currency, networks) =>
+    `Currency ${currency} settles on several networks (${networks}) - a network is required`,
+);
+
+export const UnsupportedNetworkError = createDomainError(
+  'UnsupportedNetworkError',
+  (currency, network) => `Currency ${currency} is not settled on network ${network}`,
+);
+
+export const WithdrawalDisabledError = createDomainError(
+  'WithdrawalDisabledError',
+  (currency) => `Withdrawals are disabled for ${currency} on every configured network`,
+);
+
+export const BelowMinimumWithdrawalError = createDomainError(
+  'BelowMinimumWithdrawalError',
+  (amount, minimum, currency, network) =>
+    `Withdrawal of ${amount} ${currency} on ${network} is below the ${minimum} ${currency} minimum`,
+);
+
 const KYC_PASS_STATUSES: ReadonlySet<KycStatus> = new Set(['approved', 'manually_overridden']);
 
 export const CurrencyMismatchError = createDomainError(
@@ -144,6 +166,69 @@ const DEFAULT_WALLET_CURRENCY = 'USD';
 // fraud (idempotency + the ledger guard cover correctness). An overlay rebinds
 // RATE_LIMITER to change the backend, not this policy.
 const WALLET_MUTATION_RATE_LIMIT = { limit: 30, windowMs: 60 * 1000 };
+
+/** The catalog fields a payout decision needs - a structural subset of a wallet_asset row. */
+type WithdrawalAsset = {
+  network: string;
+  minWithdrawal: string;
+  withdrawalEnabled: boolean;
+};
+
+/**
+ * Pins the chain a payout settles on. With one payable network the choice is implied; with
+ * several an explicit network is mandatory, because picking one silently would send a
+ * player's USDT over a chain their receiving wallet may not support.
+ *
+ * `assets` is every catalog row for the currency, enabled or not, so the two empty cases
+ * stay distinguishable: no rows at all means the operator never configured this currency
+ * (a fiat PSP), and the caller's choice passes through unchecked; rows that are all
+ * withdrawal-disabled is a deliberate operator decision and fails closed.
+ */
+export function resolveWithdrawalNetwork(
+  assets: readonly WithdrawalAsset[],
+  currency: string,
+  network?: string,
+): string | null {
+  if (assets.length === 0) {
+    return network?.toUpperCase() ?? null;
+  }
+  const payable = assets.filter((asset) => asset.withdrawalEnabled);
+  const [only, ...rest] = payable;
+  if (!only) {
+    throw new WithdrawalDisabledError(currency);
+  }
+  if (network === undefined) {
+    if (rest.length > 0) {
+      throw new AmbiguousNetworkError(currency, payable.map((asset) => asset.network).join(', '));
+    }
+    return only.network.toUpperCase();
+  }
+  const wanted = network.toUpperCase();
+  if (!payable.some((asset) => asset.network.toUpperCase() === wanted)) {
+    throw new UnsupportedNetworkError(currency, wanted);
+  }
+  return wanted;
+}
+
+/**
+ * Rejects a payout worth less than the operator's per-network floor. The floor is per chain,
+ * not per currency: moving USDT costs cents on BEP20 and dollars on ERC20, so one
+ * currency-wide minimum is either too high for the cheap chain or below the fee on the
+ * expensive one.
+ */
+export function assertAboveMinimumWithdrawal(
+  assets: readonly WithdrawalAsset[],
+  amount: string,
+  currency: string,
+  network: string | null,
+): void {
+  const asset = assets.find(
+    (candidate) => candidate.withdrawalEnabled && candidate.network.toUpperCase() === network,
+  );
+  if (asset && moneyToNumber(amount) < moneyToNumber(asset.minWithdrawal)) {
+    throw new BelowMinimumWithdrawalError(amount, asset.minWithdrawal, currency, asset.network);
+  }
+}
 
 export function railFor(currency: string, cryptoCurrencies?: readonly string[]): WalletRail {
   const set = cryptoCurrencies
@@ -379,6 +464,19 @@ export class WalletService {
     this.riskTags = riskTags;
     this.tagEvaluationCommands = tagEvaluationCommands;
     this.audit = audit;
+  }
+
+  // Every catalog row for the currency, enabled or not - resolveWithdrawalNetwork needs
+  // both to tell "never configured" from "deliberately disabled".
+  private assetsForCurrency(currency: string) {
+    return this.drizzle.db
+      .select({
+        network: walletAsset.network,
+        minWithdrawal: walletAsset.minWithdrawal,
+        withdrawalEnabled: walletAsset.withdrawalEnabled,
+      })
+      .from(walletAsset)
+      .where(eq(walletAsset.currency, currency.toUpperCase()));
   }
 
   private resolveRail(currency: string): WalletRail {
@@ -649,6 +747,7 @@ export class WalletService {
     userId,
     amount,
     currency,
+    network,
     idempotencyKey,
     destinationAddress,
     ip,
@@ -657,6 +756,7 @@ export class WalletService {
     userId: User['id'];
     amount: string;
     currency: string;
+    network?: string;
     idempotencyKey?: string;
     destinationAddress?: string;
   } & ClientMeta): Promise<TransactionResult> {
@@ -665,6 +765,9 @@ export class WalletService {
     if (this.resolveRail(currency) === 'crypto' && !destinationAddress) {
       throw new DestinationAddressRequiredError();
     }
+    const assets = await this.assetsForCurrency(currency);
+    const settlementNetwork = resolveWithdrawalNetwork(assets, currency, network);
+    assertAboveMinimumWithdrawal(assets, amount, currency, settlementNetwork);
 
     const { transactionId, status, replayed, walletId, rail } = await this.drizzle.db.transaction(
       async (txn) => {
@@ -705,6 +808,7 @@ export class WalletService {
             currency,
             status: 'pending',
             rail: this.resolveRail(currency),
+            network: settlementNetwork,
             destinationAddress: destinationAddress ?? null,
           },
         });
@@ -856,6 +960,7 @@ export class WalletService {
         username: summary?.username ?? '',
         amount: r.tx.amount,
         currency: r.tx.currency,
+        network: r.tx.network,
         rail: r.tx.rail ?? null,
         status: r.tx.status,
         kycStatus: summary?.kycStatus ?? null,
@@ -958,6 +1063,8 @@ export class WalletService {
         rail: tx.rail,
         adminId,
         destinationAddress: tx.destinationAddress,
+        // Pinned at request time; without it an adapter cannot tell ERC20 USDT from TRC20.
+        network: tx.network,
       });
     } catch (err) {
       // Payout did not happen - mark failed and return the held funds in one transaction.
@@ -1703,6 +1810,7 @@ export class WalletService {
         type: tx.type,
         amount: tx.amount,
         currency: tx.currency,
+        network: tx.network,
         status: tx.status,
         createdAt: tx.createdAt.toISOString(),
       })),
@@ -1792,6 +1900,9 @@ export class WalletService {
           currency: event.currency,
           status: 'completed',
           rail: this.resolveRail(event.currency),
+          // Prefer the chain the vendor reported; fall back to the one the address was
+          // issued on, which is the only network an address-only webhook can imply.
+          network: event.network ?? depositAddress.network,
           providerName: depositAddress.providerName,
           providerRefId: event.externalId,
           destinationAddress: event.address,


### PR DESCRIPTION
## Summary

- `wallet_transaction` gains a `network` column and a `(currency, network)` index, so reconciliation and reporting are per chain rather than per currency.
- A withdrawal now resolves its settlement network from the asset catalog before any funds are held, and pins it on the row. `POST /wallet/withdraw` takes an optional `network`.
- The per-chain `minWithdrawal` from the catalog is enforced on that resolved network.
- `approveWithdrawal` passes the pinned `network` to the adapter, and a webhook deposit records the chain the vendor reported, falling back to the one the address was issued on.

## Why

Stacked on #88, which added the catalog but left nothing reading it. This is the half that makes the config do something.

A currency does not identify a chain. USDT settles on ERC20, TRC20 and BEP20 with different addresses, fees and minimums, so a payout that carries only a currency is ambiguous, and an adapter receiving it has to guess. Guessing wrong sends a player's funds over a chain their receiving wallet may not support. Storing only the currency on the transaction has the same problem after the fact: two USDT withdrawals on different chains are indistinguishable in the ledger.

## Alternatives considered

Inferring the network from the destination address. That works for chains with distinctive address formats and fails exactly where it matters most, since ERC20 and BEP20 share the EVM address format - the two chains a USDT payout is most likely to be confused between.

Defaulting to a "primary" network per currency instead of rejecting an ambiguous request. A silent default is the failure mode this is meant to prevent, and it would be indistinguishable from a correct payout until the player reports missing funds.

## Risks

The column is nullable and backfills as `NULL`, so existing rows keep working. `NULL` stays correct for the fiat rail and for internal types like bet, win and bonus that never touch a chain.

Behaviour only changes for a currency that has catalog rows. A currency with none passes through unchecked, which keeps a fiat-only operator working exactly as before. A currency whose rows are all withdrawal-disabled now fails closed, which is a deliberate reversal of the previous silent-allow.

An operator who populates the catalog with several networks for one currency turns previously-accepted `POST /wallet/withdraw` calls that omit `network` into a 4xx. That is the intended behaviour, but it is a client-visible change for anyone who configures a multi-chain currency.

Minimum deposit is stored but still unenforced. A deposit arrives by webhook after the funds have already moved, so rejecting one is not possible; deciding what to do with a below-minimum deposit is its own piece of work.
