### PR TITLE
docs(wallet): document custody pooling, sweeping and reconciliation

### DIFF
--- a/docs/adapters/payment.md
+++ b/docs/adapters/payment.md
@@ -129,3 +129,188 @@ The address-based/async recipe is the same shape regardless of vendor:
    no-ops).
 
 See the wallet contract and service for the exact route behavior.
+
+## Custody: pooling, sweeping and reconciliation
+
+Four vendor shapes this port has to cover, by which optional methods they implement:
+
+| Vendor shape                                | issueDepositAddress | parseWebhook | sweep methods       | listTransactions             |
+| ------------------------------------------- | ------------------- | ------------ | ------------------- | ---------------------------- |
+| Synchronous fiat PSP                        | no                  | no           | no                  | optional (settlement report) |
+| Custody with per-player containers          | yes                 | yes          | yes                 | yes                          |
+| Exchange-style, one address + memo          | yes (tag)           | yes          | no (already pooled) | yes                          |
+| Crypto payment processor that pools for you | yes                 | yes          | no                  | yes                          |
+
+Sweeping is optional, reconciliation is universal - it applies to a fiat PSP settlement
+report exactly as to an on-chain ledger.
+
+### Why deposit-address topology differs by chain
+
+- **UTXO chains** - one shared container can mint unlimited receive addresses, one per
+  player. Attribution is by address alone.
+- **Account/EVM chains** - a container holds one address, so a distinct address per
+  player means one container per player. That single address also serves every token on
+  the chain, which is why a deposit event carries `network` and not just `address` -
+  `address` alone does not identify which chain (or which of several issued rows) it
+  belongs to.
+- **Tag/memo chains** - one shared address plus a per-player tag; attribution is by
+  `(address, tag)`.
+
+### Custody topology
+
+```mermaid
+flowchart LR
+  subgraph core["wallet module (core)"]
+    catalog["wallet_asset<br/>catalog"]
+    addr["wallet_deposit_address"]
+    ledger["ledger<br/>wallet_balance + wallet_transaction"]
+    sweep["sweep job<br/>owns all policy"]
+    recon["reconciliation job"]
+  end
+
+  subgraph overlay["overlay plugin"]
+    psp["PSP adapter"]
+    custody["custody adapter"]
+  end
+
+  subgraph vendorside["vendor side"]
+    perplayer["per-player custody container"]
+    shared["shared container"]
+    pool["pool"]
+    payout["payout source"]
+  end
+
+  catalog --> sweep
+  catalog --> recon
+  sweep -- "listSweepableBalances / sweepToPool" --> custody
+  recon -- "listTransactions / getWithdrawalStatus" --> custody
+  recon -- "listTransactions" --> psp
+  custody -. implemented by .-> perplayer
+  custody -. implemented by .-> shared
+  perplayer -- sweep --> pool
+  shared -- sweep --> pool
+  pool --> payout
+```
+
+### Crediting and sweeping are independent
+
+```mermaid
+sequenceDiagram
+  participant P as Player
+  participant R as Wallet router
+  participant S as WalletService
+  participant V as Vendor
+  participant J as Sweep job (cron)
+
+  P->>R: POST /wallet/deposits/address
+  R->>S: getOrCreateDepositAddress
+  S->>V: issueDepositAddress (once)
+  V-->>S: address (+ network/tag)
+  S-->>S: persist wallet_deposit_address (idempotent)
+  S-->>P: address
+
+  Note over P,V: player sends funds on-chain whenever - no call to this API
+
+  V->>R: POST /wallet/webhook/{provider}
+  R->>R: verify signature
+  R->>S: parseWebhook -> creditDepositByAddress
+  S-->>S: insert wallet_transaction (dedup on providerRefId) + credit balance
+
+  Note over J,V: separate path, its own cron tick - no causal link to the deposit above
+  J->>V: listSweepableBalances / sweepToPool
+```
+
+A deposit never triggers a sweep. Crediting the player and moving the funds into the
+pool are independent code paths - the first happens on every deposit, the second on
+whatever cadence the sweep job runs, and neither waits on the other.
+
+### Sweep cycle
+
+```mermaid
+flowchart TD
+  tick["cron tick"] --> inflight["resolve in-flight sweeps"]
+  inflight --> perprovider["for each provider"]
+  perprovider --> impl{"adapter implements<br/>listSweepableBalances?"}
+  impl -- no --> skip["skip"]
+  impl -- yes --> list["list balances"]
+  list --> perbalance["for each balance"]
+  perbalance --> catalogRow{"catalog row exists?"}
+  catalogRow -- no --> skip
+  catalogRow -- yes --> minDeposit{"amount >= minimum<br/>deposit (dust)?"}
+  minDeposit -- no --> skip
+  minDeposit -- yes --> feeMultiple{"amount >= fee x<br/>fee-multiple?"}
+  feeMultiple -- no --> skip
+  feeMultiple -- yes --> feeCeiling{"fee within ceiling,<br/>unless pool is below<br/>its liquidity floor?"}
+  feeCeiling -- no --> skip
+  feeCeiling -- yes --> noInflight{"no in-flight sweep for<br/>this (user, currency, network)?"}
+  noInflight -- no --> skip
+  noInflight -- yes --> claim["claim a row"]
+  claim --> call["call sweepToPool<br/>(outside the transaction)"]
+  call --> markAudit["mark and audit"]
+```
+
+### Reconciliation
+
+```mermaid
+flowchart TD
+  A["(A) listTransactions<br/>over a window"]
+  B["(B) withdrawals stuck in<br/>processing past an age threshold"]
+  C["(C) live webhook path fails<br/>to attribute a deposit"]
+
+  A --> depositEvent["deposit event"]
+  depositEvent --> hasRow{"matching ledger row?"}
+  hasRow -- no --> findingCredit["finding<br/>(NEVER auto-credit)"]
+  hasRow -- yes --> amountCheck{"amount / currency match?"}
+  amountCheck -- no --> findingMismatch["finding"]
+  amountCheck -- yes --> reconciled["reconciled"]
+
+  A --> withdrawalEvent["withdrawal event"]
+  withdrawalEvent --> idempotentRecon["existing idempotent<br/>status reconciliation"]
+
+  B --> lookup["targeted status lookup<br/>(getWithdrawalStatus)"]
+  lookup -- terminal --> idempotentRecon
+  lookup -- null --> findingStuck["finding"]
+
+  C --> findingCredit
+
+  findingCredit --> threshold{"findings over threshold?"}
+  findingMismatch --> threshold
+  findingStuck --> threshold
+  threshold -- yes --> alert["alert"]
+  threshold --> report["admin report"]
+  report --> manual["manual credit by an admin"]
+```
+
+### Multi-provider routing
+
+```mermaid
+flowchart LR
+  tx["transaction"] --> provider["asset catalog's<br/>provider name"]
+  provider --> registry["provider registry"]
+  registry -- "no name bound" --> default["default single binding<br/>(PAYMENT_ADAPTER / PAYMENT_WEBHOOK_VERIFIER)"]
+  registry -- "named vendor" --> named["named vendor's<br/>adapter + verifier pair"]
+```
+
+### Policy lives in core, topology lives in the overlay
+
+Core learns the _shape_ of custody - per-player containers, pooling, on-chain fees, a
+provider's transaction list - never a vendor's name. Which chains are UTXO, account-based,
+or tag-based is vendor topology, not policy; it belongs in the overlay adapter, not in
+core.
+
+### Planned routes
+
+| Route                                      | Does                                                                                            | Permission                      |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------- |
+| `POST /wallet/webhook/{provider}`          | Routes an inbound webhook to the named provider's adapter instead of the single default binding | none (signature-verified)       |
+| `POST /wallet/custody/sweep/run`           | Triggers one sweep cycle on demand                                                              | `wallet-custody:run`            |
+| `GET /wallet/reconciliation`               | Lists open findings                                                                             | `wallet-reconciliation:view`    |
+| `POST /wallet/reconciliation/{id}/resolve` | Resolves a finding (including a manual credit)                                                  | `wallet-reconciliation:resolve` |
+| `POST /wallet/reconciliation/run`          | Triggers one reconciliation pass on demand                                                      | `wallet-reconciliation:run`     |
+
+### Known limitation
+
+`PAYMENT_ADAPTER` and `PAYMENT_WEBHOOK_VERIFIER` are single DI bindings today - one
+adapter, one verifier, for the whole wallet module. A fiat PSP and a crypto custody
+vendor cannot both be bound at once. The provider registry in the diagram above (asset
+catalog provider name -> named adapter/verifier pair) is what removes that constraint.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ Solid arrows are runtime/build dependencies; dashed arrows are **adapter seams**
 
 **Domains** (`packages/core/src/<domain>/*`) - folded into the single `@openora/core` package and exposed as subpaths (`@openora/core/<domain>`), not as one package per domain. A domain may import the engine zones (`contracts`, `server`, `react`) and a sibling's read-only `/schema` subpath, but **never another domain's internals** - cross-domain communication goes through events, command ports, or shared contracts. Vendor adapter interfaces come from `@openora/core/contracts`. ADR-0025.
 
-**Vendor adapters** - concrete implementations of a module's adapter interfaces (PSP, KYC vendor, igaming aggregator, chat), shipped as separate packages. The interface is the seam; the implementation is swappable.
+**Vendor adapters** - concrete implementations of a module's adapter interfaces (PSP, KYC vendor, igaming aggregator, chat), shipped as separate packages. The interface is the seam; the implementation is swappable. For the pooling/sweeping/reconciliation shape a custody-style payment vendor adds, see [docs/adapters/payment.md](./adapters/payment.md#custody-pooling-sweeping-and-reconciliation).
 
 **Background jobs** - long-running work runs off the request path in a BullMQ worker shipped as an overlay plugin (`/scaffold-plugin <name>-worker`): a module emits an event via the typed `EventBus`, the worker plugin subscribes in `register(ctx)` and processes the job. There is no standalone worker app.
 


### PR DESCRIPTION
## Summary

- Documents the target custody architecture in `docs/adapters/payment.md`: the four vendor shapes the `PaymentAdapter` port covers, why deposit-address topology differs per chain, and five diagrams covering topology, deposit crediting, the sweep cycle, reconciliation, and multi-provider routing.
- Adds the planned route table with the permission each needs, and names the current single-DI-binding limitation.

## Why

Stacked PRs #91 onward build all of this, and reviewing a 5000-line foundation PR without a map first is not a fair ask. This lands the map.

The diagrams also pin down the invariant the rest of the stack depends on: a deposit never triggers a sweep. Crediting the player and moving the funds into the pool are independent code paths, and writing that down now is cheaper than discovering later that someone wired them together.

## Alternatives considered

Folding this into the foundation PR. It would have made a large PR larger, and docs are the one thing a reviewer wants to read *before* the code rather than alongside it.

## Risks

None. Docs only - two files, no code, no schema, no contract. `check:drift` confirms `docs/catalog.json` is untouched.