### PR TITLE
fix(audit): align exportCsv default sort order with list

### DIFF
--- a/packages/core/src/audit/service/audit.service.ts
+++ b/packages/core/src/audit/service/audit.service.ts
@@ -223,7 +223,7 @@ export class AuditService {
     const where = buildWhere(filters);
 
     const sortBy = filters.sortBy ?? 'createdAt';
-    const dir = (filters.sortOrder ?? 'asc') === 'asc' ? asc : desc;
+    const dir = (filters.sortOrder ?? 'desc') === 'asc' ? asc : desc;
 
     const rows = await db
       .select()


### PR DESCRIPTION
exportCsv() defaulted an unset sortOrder to asc while list() defaults to desc, so the CSV export order didn't match the on-screen audit log whenever no explicit sort was applied.