### PR TITLE
feat(wallet): destination tags, ledger direction and a realtime balance stream

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -427,6 +427,7 @@
         "wallet.set",
         "wallet.set",
         "wallet.setActiveCurrency",
+        "wallet.streamBalance",
         "wallet.update",
         "wallet.webhook",
         "wallet.webhookForProvider",
@@ -808,7 +809,8 @@
       "status": "wired",
       "boundIn": [
         "packages/core/src/compliance/plugin.ts",
-        "packages/core/src/engagement/chat/plugin.ts"
+        "packages/core/src/engagement/chat/plugin.ts",
+        "packages/core/src/wallet/plugin.ts"
       ]
     },
     {
@@ -2184,11 +2186,19 @@
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
+      "name": "WalletBalanceChangeReasonSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
       "name": "WalletBalanceSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
       "name": "WalletBalancesSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "WalletBalanceUpdateSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1346,6 +1346,10 @@
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
+      "name": "DestinationTagInputSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
       "name": "Disable2faInputSchema",
       "file": "packages/core/src/contracts/schemas/identity.ts"
     },

--- a/packages/core/src/contracts/adapters/payment.ts
+++ b/packages/core/src/contracts/adapters/payment.ts
@@ -123,15 +123,20 @@ export type PaymentAdapter = {
    *
    * Called on the address-book write path rather than at payout time on purpose: approval can
    * need a human quorum, which must not sit inside a withdrawal that is already holding a
-   * player's funds. Implementations must be idempotent on (userId, currency, network, address) -
-   * a retried registration has to return the original id instead of creating a second
-   * destination that then needs its own approval.
+   * player's funds. Implementations must be idempotent on
+   * (userId, currency, network, address, destinationTag) - a retried registration has to return
+   * the original id instead of creating a second destination that then needs its own approval.
+   *
+   * `destinationTag` is part of the destination, not a detail of it: on a tag/memo chain one
+   * address serves many accounts and the tag picks which, so two tags on the same address are
+   * two different beneficiaries and must whitelist as two different destinations.
    */
   whitelistWithdrawalAddress?(input: {
     userId: string;
     currency: string;
     network: string;
     address: string;
+    destinationTag?: string;
   }): Promise<{ providerWalletId: string }>;
 
   /**

--- a/packages/core/src/server/runtime/__tests__/create-app.test.ts
+++ b/packages/core/src/server/runtime/__tests__/create-app.test.ts
@@ -51,6 +51,35 @@ describe('createApp - distributed-only durable seams (ADR-0030)', () => {
   });
 });
 
+describe('createApp - streaming responses opt out of transformation', () => {
+  it('marks an SSE response no-transform so an intermediary cannot batch its frames', async () => {
+    const saved = process.env['REDIS_URL'];
+    process.env['REDIS_URL'] = redisUrlForWorker();
+    try {
+      const created = await createApp({ plugins: [], databaseUrl: DUMMY_DATABASE_URL });
+      created.app.get('/sse-probe', (c) =>
+        c.body(new ReadableStream(), { headers: { 'content-type': 'text/event-stream' } }),
+      );
+
+      const stream = await created.app.request('/sse-probe');
+      expect(stream.headers.get('cache-control')).toBe('no-store, no-transform');
+      expect(stream.headers.get('x-accel-buffering')).toBe('no');
+
+      const json = await created.app.request('/health');
+      expect(json.headers.get('cache-control')).toBe('no-store');
+      expect(json.headers.get('x-accel-buffering')).toBeNull();
+
+      await created.close();
+    } finally {
+      if (saved === undefined) {
+        delete process.env['REDIS_URL'];
+      } else {
+        process.env['REDIS_URL'] = saved;
+      }
+    }
+  });
+});
+
 describe('createApp - service name for the Redis Streams consumer group', () => {
   const saved = { redis: process.env['REDIS_URL'], manifest: process.env['SERVICE_MANIFEST'] };
 

--- a/packages/core/src/server/runtime/create-app.ts
+++ b/packages/core/src/server/runtime/create-app.ts
@@ -396,11 +396,23 @@ export async function createApp(
       } else {
         await next();
       }
+      // An SSE body is a sequence of small frames that only mean anything on arrival, so any
+      // intermediary that compresses or buffers it holds every event until its own flush
+      // threshold. That is not hypothetical: Next's built-in gzip (and nginx's, and a CDN's)
+      // turned a sub-100ms balance push into an 11-second one, with the events arriving in
+      // batches. `no-transform` is the standards-defined opt-out every one of them honours,
+      // and `X-Accel-Buffering` covers nginx's separate proxy-buffering stage.
+      const isEventStream = (c.res.headers.get('content-type') ?? '').includes('text/event-stream');
+      if (isEventStream) {
+        c.res.headers.set('X-Accel-Buffering', 'no');
+      }
       c.res.headers.set(
         'Cache-Control',
         isCacheable
           ? `public, max-age=${maxAgeSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`
-          : 'no-store',
+          : isEventStream
+            ? 'no-store, no-transform'
+            : 'no-store',
       );
     });
   }

--- a/packages/core/src/wallet/__tests__/wallet-asset.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-asset.router.int.test.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { call, ORPCError } from '@orpc/server';
 import type { AdminGuard } from '@openora/core/server';
 import { queue, type PaymentAdapter } from '@openora/core/contracts';
-import { createTestDb, type TestDb } from '@openora/core/testing';
+import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
 import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import {
   mock,
@@ -91,6 +91,7 @@ function routerWith(
     reconciliation: mock<ReconciliationService>({}),
     jobQueue: makeJobQueue(),
     reconciliationQueue: RECONCILIATION_QUEUE,
+    realtime: new InProcessRealtimeTransport(),
   });
   return { router, audit, service };
 }

--- a/packages/core/src/wallet/__tests__/wallet-auto-rule.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-rule.router.int.test.ts
@@ -3,7 +3,7 @@ import { eq } from 'drizzle-orm';
 import { call, ORPCError } from '@orpc/server';
 import type { AdminGuard } from '@openora/core/server';
 import { queue, type PaymentAdapter } from '@openora/core/contracts';
-import { createTestDb, type TestDb } from '@openora/core/testing';
+import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
 import {
   mock,
   makeEventBus,
@@ -67,6 +67,7 @@ function routerWith(adminGuard: AdminGuard) {
     reconciliation: mock<ReconciliationService>({}),
     jobQueue: makeJobQueue(),
     reconciliationQueue: RECONCILIATION_QUEUE,
+    realtime: new InProcessRealtimeTransport(),
   });
   return { router, audit };
 }

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal-config.router.int.test.ts
@@ -11,7 +11,7 @@ import type {
   PlayerTags,
 } from '@openora/core/contracts';
 import { queue } from '@openora/core/contracts';
-import { createTestDb, type TestDb } from '@openora/core/testing';
+import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
 import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import {
   mock,
@@ -119,6 +119,7 @@ function routerWith(adminGuard: AdminGuard, platformConfig?: Partial<PlatformCon
     reconciliation: mock<ReconciliationService>({}),
     jobQueue: makeJobQueue(),
     reconciliationQueue: RECONCILIATION_QUEUE,
+    realtime: new InProcessRealtimeTransport(),
   });
   return { router, audit, service };
 }

--- a/packages/core/src/wallet/__tests__/wallet-balance-stream.router.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-balance-stream.router.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { InProcessRealtimeTransport } from '@openora/core/testing';
+import { createWalletBalanceStream, walletBalanceChannel } from '../router/index.js';
+
+describe('wallet streamBalance router', () => {
+  it('streams only the caller-scoped channel, never another player`s balance updates', async () => {
+    const realtime = new InProcessRealtimeTransport();
+    const iterator = createWalletBalanceStream(realtime, 'user-1', undefined)[
+      Symbol.asyncIterator
+    ]();
+    const next = iterator.next();
+    await Promise.resolve();
+
+    realtime.publish(walletBalanceChannel('other-user'), {
+      eventId: '11111111-1111-4111-8111-111111111111',
+      currency: 'USD',
+      reason: 'deposit',
+    });
+    realtime.publish(walletBalanceChannel('user-1'), {
+      eventId: '22222222-2222-4222-8222-222222222222',
+      currency: 'USD',
+      reason: 'withdrawal',
+    });
+
+    await expect(next).resolves.toEqual({
+      done: false,
+      value: {
+        eventId: '22222222-2222-4222-8222-222222222222',
+        currency: 'USD',
+        reason: 'withdrawal',
+      },
+    });
+    await iterator.return?.(undefined);
+  });
+});

--- a/packages/core/src/wallet/__tests__/wallet-bonus-rollover-config.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-bonus-rollover-config.router.int.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { call, ORPCError } from '@orpc/server';
 import type { AdminGuard } from '@openora/core/server';
 import { queue, type PaymentAdapter } from '@openora/core/contracts';
-import { createTestDb, type TestDb } from '@openora/core/testing';
+import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
 import {
   mock,
   makeEventBus,
@@ -74,6 +74,7 @@ function routerWith(adminGuard: AdminGuard) {
     reconciliation: mock<ReconciliationService>({}),
     jobQueue: makeJobQueue(),
     reconciliationQueue: RECONCILIATION_QUEUE,
+    realtime: new InProcessRealtimeTransport(),
   });
   return { router, audit, service };
 }

--- a/packages/core/src/wallet/__tests__/wallet-commands.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-commands.service.int.test.ts
@@ -231,6 +231,28 @@ describe('WalletCommandsService.credit (real PG)', () => {
   });
 });
 
+describe('WalletCommandsService ledger direction (real PG)', () => {
+  // gift/rain/tip write the SAME `type` for both legs of a transfer - direction is the
+  // only column that tells the sender's debit apart from the recipient's credit.
+  it('records opposite directions for the sender debit and recipient credit legs of a tip', async () => {
+    const sender = await seedWallet({ balance: '100' });
+    const recipient = await seedWallet({ balance: '0' });
+
+    await svc.debit(db.drizzle.db, { userId: sender.userId, amount: '10', type: 'tip' });
+    await svc.credit(db.drizzle.db, {
+      userId: recipient.userId,
+      amount: '10',
+      currency: 'USD',
+      type: 'tip',
+    });
+
+    const senderRows = await txRows(sender.id);
+    const recipientRows = await txRows(recipient.id);
+    expect(senderRows[0]).toMatchObject({ type: 'tip', direction: 'debit' });
+    expect(recipientRows[0]).toMatchObject({ type: 'tip', direction: 'credit' });
+  });
+});
+
 describe('WalletCommandsService ledger sequence (real PG)', () => {
   it('nets a deposit-like credit, a bet debit, and a win credit into one running balance', async () => {
     const w = await seedWallet({ balance: '0' });

--- a/packages/core/src/wallet/__tests__/wallet-custody-routes.router.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-custody-routes.router.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { call, ORPCError } from '@orpc/server';
 import type { AdminGuard } from '@openora/core/server';
-import { queue, type JobQueueAdapter, type PaymentAdapter } from '@openora/core/contracts';
+import {
+  queue,
+  type JobQueueAdapter,
+  type PaymentAdapter,
+  type RealtimeTransport,
+} from '@openora/core/contracts';
 import {
   mock,
   makeDrizzle,
@@ -45,6 +50,7 @@ function routerWith(
     reconciliation: overrides.reconciliation ?? mock<ReconciliationService>({}),
     jobQueue: overrides.jobQueue ?? makeJobQueue(),
     reconciliationQueue: RECONCILIATION_QUEUE,
+    realtime: mock<RealtimeTransport>({}),
   });
 }
 

--- a/packages/core/src/wallet/__tests__/wallet-transaction-direction-backfill.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-transaction-direction-backfill.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { WALLET_TRANSACTION_TYPES, type WalletTransactionType } from '@openora/core/contracts';
+
+// Mirrors the CASE mapping hand-appended to
+// drizzle/migrations/0014_abandoned_madripoor.sql. Kept in lockstep here so a future type
+// added to WALLET_TRANSACTION_TYPES fails this test instead of silently backfilling as
+// NULL (or, worse, someone guessing a direction for it).
+const BACKFILL_CREDIT_TYPES: WalletTransactionType[] = ['deposit', 'win', 'bonus', 'manual_credit'];
+const BACKFILL_DEBIT_TYPES: WalletTransactionType[] = ['withdrawal', 'bet', 'loss', 'manual_debit'];
+
+// The only types where the same value is written for both legs of a transfer (see
+// engagement/social-transfers/service/social-transfers.service.ts), so a historical row
+// has no recoverable direction and the migration deliberately leaves it NULL.
+const KNOWN_AMBIGUOUS_TYPES: WalletTransactionType[] = ['gift', 'rain', 'tip'];
+
+describe('wallet_transaction direction backfill vocabulary', () => {
+  it('accounts for every WALLET_TRANSACTION_TYPES value exactly once', () => {
+    const partitioned = [
+      ...BACKFILL_CREDIT_TYPES,
+      ...BACKFILL_DEBIT_TYPES,
+      ...KNOWN_AMBIGUOUS_TYPES,
+    ];
+
+    expect(new Set(partitioned).size).toBe(partitioned.length);
+    expect([...partitioned].sort()).toEqual([...WALLET_TRANSACTION_TYPES].sort());
+  });
+});

--- a/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-webhook.router.int.test.ts
@@ -13,7 +13,7 @@ import {
   type RateLimiterAdapter,
   type RateLimitKey,
 } from '@openora/core/contracts';
-import { createTestDb, type TestDb } from '@openora/core/testing';
+import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
 import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import {
   mock,
@@ -91,6 +91,7 @@ function routerWithProviders(
     reconciliation: mock<ReconciliationService>({}),
     jobQueue: makeJobQueue(),
     reconciliationQueue: RECONCILIATION_QUEUE,
+    realtime: new InProcessRealtimeTransport(),
     limiter,
   });
 }

--- a/packages/core/src/wallet/__tests__/wallet-withdrawal-address.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-withdrawal-address.router.int.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { call, ORPCError } from '@orpc/server';
 import { queue, type PaymentAdapter } from '@openora/core/contracts';
-import { createTestDb, type TestDb } from '@openora/core/testing';
+import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
 import type { CreateWithdrawalAddressInput } from '../contract/index.js';
 import {
   mock,
@@ -66,6 +66,7 @@ function routerWith(payment: Partial<PaymentAdapter> = {}) {
     reconciliation: mock<ReconciliationService>({}),
     jobQueue: makeJobQueue(),
     reconciliationQueue: RECONCILIATION_QUEUE,
+    realtime: new InProcessRealtimeTransport(),
   });
   return { router, audit, service };
 }

--- a/packages/core/src/wallet/__tests__/wallet.router.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.router.int.test.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { call, ORPCError } from '@orpc/server';
 import type { AdminGuard } from '@openora/core/server';
 import { queue, type PaymentAdapter } from '@openora/core/contracts';
-import { createTestDb, type TestDb } from '@openora/core/testing';
+import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
 import {
   mock,
   makeEventBus,
@@ -61,6 +61,7 @@ function routerWith(adminGuard: AdminGuard) {
     reconciliation: mock<ReconciliationService>({}),
     jobQueue: makeJobQueue(),
     reconciliationQueue: RECONCILIATION_QUEUE,
+    realtime: new InProcessRealtimeTransport(),
   });
 }
 

--- a/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
@@ -935,6 +935,61 @@ describe('WalletService.withdraw destination whitelisting (real PG)', () => {
     expect(result.transactionId).toBeDefined();
   });
 
+  it('refuses a tag the player never whitelisted on an address they did', async () => {
+    const psp = whitelistingPsp();
+    const { svc } = makeService({ payment: mock<PaymentAdapter>(psp) });
+    const w = await seedWallet({ currency: 'XRP', balance: '5' });
+    await db.drizzle.db.insert(walletWithdrawalAddress).values({
+      userId: w.userId,
+      label: 'my exchange account',
+      currency: 'XRP',
+      network: 'XRPL',
+      address: 'rSharedExchangeAddress',
+      destinationTag: '1000',
+      providerName: DEFAULT_PAYMENT_PROVIDER,
+      providerWalletId: 'fb-wallet-1',
+    });
+
+    // Same shared exchange address, someone else's account behind it.
+    await expect(
+      svc.withdraw({
+        userId: w.userId,
+        amount: '1',
+        currency: 'XRP',
+        network: 'XRPL',
+        destinationAddress: 'rSharedExchangeAddress',
+        destinationTag: '2000',
+        ...NO_CLIENT_META,
+      }),
+    ).rejects.toBeInstanceOf(DestinationAddressNotWhitelistedError);
+
+    // Dropping the tag must not fall back to the address-only match either.
+    await expect(
+      svc.withdraw({
+        userId: w.userId,
+        amount: '1',
+        currency: 'XRP',
+        network: 'XRPL',
+        destinationAddress: 'rSharedExchangeAddress',
+        ...NO_CLIENT_META,
+      }),
+    ).rejects.toBeInstanceOf(DestinationAddressNotWhitelistedError);
+
+    expect(await balanceOf(w.userId)).toBe(5);
+    expect(psp.processWithdrawal).not.toHaveBeenCalled();
+
+    const allowed = await svc.withdraw({
+      userId: w.userId,
+      amount: '1',
+      currency: 'XRP',
+      network: 'XRPL',
+      destinationAddress: 'rSharedExchangeAddress',
+      destinationTag: '1000',
+      ...NO_CLIENT_META,
+    });
+    expect(allowed.transactionId).toBeDefined();
+  });
+
   it('carries the destination tag through to the payout adapter', async () => {
     const { svc, psp } = makeService();
     const w = await seedWallet({ currency: 'BTC', balance: '5' });

--- a/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet.service.int.test.ts
@@ -935,6 +935,49 @@ describe('WalletService.withdraw destination whitelisting (real PG)', () => {
     expect(result.transactionId).toBeDefined();
   });
 
+  it('carries the destination tag through to the payout adapter', async () => {
+    const { svc, psp } = makeService();
+    const w = await seedWallet({ currency: 'BTC', balance: '5' });
+
+    const requested = await svc.withdraw({
+      userId: w.userId,
+      amount: '1',
+      currency: 'BTC',
+      network: 'BITCOIN',
+      destinationAddress: 'bc1qexample',
+      destinationTag: '4138454749',
+      ...NO_CLIENT_META,
+    });
+    await svc.approveWithdrawal(randomUUID(), requested.transactionId, NO_CLIENT_META);
+
+    expect(psp.processWithdrawal).toHaveBeenCalledWith(
+      expect.any(String),
+      'BTC',
+      expect.objectContaining({ destinationTag: '4138454749' }),
+    );
+  });
+
+  it('leaves the tag null for a payout that carries none', async () => {
+    const { svc, psp } = makeService();
+    const w = await seedWallet({ currency: 'BTC', balance: '5' });
+
+    const requested = await svc.withdraw({
+      userId: w.userId,
+      amount: '1',
+      currency: 'BTC',
+      network: 'BITCOIN',
+      destinationAddress: 'bc1qexample',
+      ...NO_CLIENT_META,
+    });
+    await svc.approveWithdrawal(randomUUID(), requested.transactionId, NO_CLIENT_META);
+
+    expect(psp.processWithdrawal).toHaveBeenCalledWith(
+      expect.any(String),
+      'BTC',
+      expect.objectContaining({ destinationTag: null }),
+    );
+  });
+
   it('leaves a non-whitelisting adapter alone', async () => {
     const { svc } = makeService();
     const w = await seedWallet({ currency: 'BTC', balance: '5' });

--- a/packages/core/src/wallet/contract/index.ts
+++ b/packages/core/src/wallet/contract/index.ts
@@ -97,6 +97,12 @@ export const WithdrawInputSchema = z.object({
   provider: z.string().optional(),
   idempotencyKey: UuidSchema.optional(),
   destinationAddress: WalletAddressInputSchema.optional(),
+  // Tag/memo networks (XRP, XLM, EOS, and the exchange deposit addresses on them) carry the
+  // beneficiary in a separate field rather than in the address: one address serves every
+  // account behind it. A payout sent without the tag the player was given arrives
+  // unattributed and has to be recovered by hand, so it is carried end to end instead of
+  // being dropped between the request and the custodian.
+  destinationTag: z.string().trim().min(1).max(64).optional(),
 });
 
 export const MANUAL_ADJUSTMENT_DIRECTIONS = ['credit', 'debit'] as const;

--- a/packages/core/src/wallet/contract/index.ts
+++ b/packages/core/src/wallet/contract/index.ts
@@ -1,4 +1,4 @@
-import { oc } from '@orpc/contract';
+import { eventIterator, oc } from '@orpc/contract';
 import * as z from 'zod';
 import {
   KycStatusSchema,
@@ -60,9 +60,30 @@ export const WalletBalancesSchema = z.object({
   balances: z.array(WalletBalanceSchema),
 });
 
+// A change *signal*, never the balance itself: carrying `{ currency, balance }` on the
+// stream would make the stream a money surface - a dropped or reordered event leaves a
+// stale number on screen with no self-correction. This shape only tells the client WHAT
+// changed; the client re-fetches getBalance(s)/listTransactions, which is cheap and
+// always internally consistent.
+export const WalletBalanceChangeReasonSchema = z.enum(['deposit', 'withdrawal', 'adjustment']);
+export type WalletBalanceChangeReason = z.infer<typeof WalletBalanceChangeReasonSchema>;
+
+export const WalletBalanceUpdateSchema = z.object({
+  eventId: UuidSchema,
+  currency: WalletCurrencyCodeSchema,
+  reason: WalletBalanceChangeReasonSchema,
+});
+export type WalletBalanceUpdate = z.infer<typeof WalletBalanceUpdateSchema>;
+
 export const SetActiveCurrencyInputSchema = z.object({ currency: WalletCurrencyCodeSchema });
 
 export const ActiveCurrencySchema = z.object({ activeCurrency: WalletCurrencyCodeSchema });
+
+// Shared by a manual adjustment's input direction and a transaction row's recorded
+// direction - a wallet move only ever goes one of these two ways.
+export const MANUAL_ADJUSTMENT_DIRECTIONS = ['credit', 'debit'] as const;
+export const ManualAdjustmentDirectionSchema = z.enum(MANUAL_ADJUSTMENT_DIRECTIONS);
+export type ManualAdjustmentDirection = z.infer<typeof ManualAdjustmentDirectionSchema>;
 
 export const WalletTransactionSchema = z.object({
   id: UuidSchema,
@@ -71,6 +92,11 @@ export const WalletTransactionSchema = z.object({
   currency: WalletCurrencyCodeSchema,
   network: WalletNetworkSchema.nullable(),
   status: WalletTransactionStatusSchema,
+  // Which way this leg moved money - derived server-side from what the operation IS,
+  // never a caller input. Nullable: rows written before this column existed (and any
+  // row whose `type` never carried a recoverable direction, eg a pre-migration gift/
+  // rain/tip leg) have no direction on record.
+  direction: ManualAdjustmentDirectionSchema.nullable(),
   createdAt: TimestampSchema,
 });
 
@@ -104,10 +130,6 @@ export const WithdrawInputSchema = z.object({
   // being dropped between the request and the custodian.
   destinationTag: z.string().trim().min(1).max(64).optional(),
 });
-
-export const MANUAL_ADJUSTMENT_DIRECTIONS = ['credit', 'debit'] as const;
-export const ManualAdjustmentDirectionSchema = z.enum(MANUAL_ADJUSTMENT_DIRECTIONS);
-export type ManualAdjustmentDirection = z.infer<typeof ManualAdjustmentDirectionSchema>;
 
 export const ManualWalletAdjustmentInputSchema = z.object({
   userId: UuidSchema,
@@ -479,6 +501,10 @@ export const walletContract = {
   getBalance: oc.route({ method: 'GET', path: '/wallet/balance' }).output(WalletBalanceSchema),
 
   getBalances: oc.route({ method: 'GET', path: '/wallet/balances' }).output(WalletBalancesSchema),
+
+  streamBalance: oc
+    .route({ method: 'GET', path: '/wallet/balance/stream' })
+    .output(eventIterator(WalletBalanceUpdateSchema)),
 
   setActiveCurrency: oc
     .route({ method: 'PUT', path: '/wallet/active-currency' })

--- a/packages/core/src/wallet/contract/index.ts
+++ b/packages/core/src/wallet/contract/index.ts
@@ -168,6 +168,9 @@ export const WithdrawalQueueItemSchema = z.object({
   riskTags: z.array(z.string()),
   requestedAt: TimestampSchema,
   destinationAddress: z.string().nullable(),
+  // An approver on a tag chain is releasing funds to an address shared by many accounts, so
+  // the tag is part of what they are approving, not a detail behind it.
+  destinationTag: z.string().nullable(),
   txHash: z.string().nullable(),
 });
 export type WithdrawalQueueItem = z.infer<typeof WithdrawalQueueItemSchema>;

--- a/packages/core/src/wallet/contract/index.ts
+++ b/packages/core/src/wallet/contract/index.ts
@@ -114,6 +114,12 @@ export const DepositInputSchema = z.object({
   idempotencyKey: UuidSchema.optional(),
 });
 
+// Bounded but otherwise unvalidated, like the address: each tag chain has its own format (an
+// XRP tag is a uint32, an XLM memo can be text or a hash), and the bound adapter is the only
+// thing that knows which. Tightening this here would break every chain but the one it was
+// tightened for; the adapter rejects a malformed tag at payout time.
+export const DestinationTagInputSchema = z.string().trim().min(1).max(64);
+
 export const WithdrawInputSchema = z.object({
   amount: PositiveMoneyAmountSchema,
   currency: WalletCurrencyInputSchema,
@@ -127,8 +133,9 @@ export const WithdrawInputSchema = z.object({
   // beneficiary in a separate field rather than in the address: one address serves every
   // account behind it. A payout sent without the tag the player was given arrives
   // unattributed and has to be recovered by hand, so it is carried end to end instead of
-  // being dropped between the request and the custodian.
-  destinationTag: z.string().trim().min(1).max(64).optional(),
+  // being dropped between the request and the custodian. It must match the tag saved on the
+  // whitelisted destination - see `requireWhitelistedWalletId`.
+  destinationTag: DestinationTagInputSchema.optional(),
 });
 
 export const ManualWalletAdjustmentInputSchema = z.object({
@@ -476,6 +483,7 @@ export const WithdrawalAddressSchema = z.object({
   currency: WalletCurrencyCodeSchema,
   network: WalletNetworkSchema,
   address: z.string(),
+  destinationTag: z.string().nullable(),
   createdAt: TimestampSchema,
 });
 export type WithdrawalAddress = z.infer<typeof WithdrawalAddressSchema>;
@@ -488,6 +496,10 @@ export const CreateWithdrawalAddressInputSchema = z.object({
   currency: WalletCurrencyInputSchema,
   network: WalletNetworkInputSchema,
   address: WalletAddressInputSchema,
+  // Part of the saved destination, for the same reason the address is: on a tag chain the pair
+  // names the beneficiary and the address alone does not. A withdrawal must present the tag it
+  // was saved with, so this is what the payout is checked against.
+  destinationTag: DestinationTagInputSchema.optional(),
 });
 export type CreateWithdrawalAddressInput = z.infer<typeof CreateWithdrawalAddressInputSchema>;
 

--- a/packages/core/src/wallet/drizzle/migrations/0013_polite_peter_parker.sql
+++ b/packages/core/src/wallet/drizzle/migrations/0013_polite_peter_parker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wallet_transaction" ADD COLUMN "destination_tag" text;

--- a/packages/core/src/wallet/drizzle/migrations/0014_abandoned_madripoor.sql
+++ b/packages/core/src/wallet/drizzle/migrations/0014_abandoned_madripoor.sql
@@ -1,0 +1,20 @@
+CREATE TYPE "public"."wallet_transaction_direction" AS ENUM('credit', 'debit');--> statement-breakpoint
+ALTER TABLE "wallet_transaction" ADD COLUMN "direction" "wallet_transaction_direction";--> statement-breakpoint
+-- Backfill direction from `type` only where it is unambiguous. gift/rain/tip write the
+-- SAME type for both the sender's debit leg and the recipient's credit leg (see
+-- engagement/social-transfers/service/social-transfers.service.ts), so a historical row
+-- of one of those three types has no recoverable direction and is left NULL on purpose -
+-- guessing would fabricate money-direction data that was never recorded.
+UPDATE "wallet_transaction"
+SET "direction" = CASE "type"
+  WHEN 'deposit' THEN 'credit'
+  WHEN 'win' THEN 'credit'
+  WHEN 'bonus' THEN 'credit'
+  WHEN 'manual_credit' THEN 'credit'
+  WHEN 'withdrawal' THEN 'debit'
+  WHEN 'bet' THEN 'debit'
+  WHEN 'loss' THEN 'debit'
+  WHEN 'manual_debit' THEN 'debit'
+  ELSE NULL
+END::"wallet_transaction_direction"
+WHERE "direction" IS NULL;

--- a/packages/core/src/wallet/drizzle/migrations/0015_right_oracle.sql
+++ b/packages/core/src/wallet/drizzle/migrations/0015_right_oracle.sql
@@ -1,0 +1,3 @@
+DROP INDEX "wallet_withdrawal_address_user_id_currency_network_address_idx";--> statement-breakpoint
+ALTER TABLE "wallet_withdrawal_address" ADD COLUMN "destination_tag" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "wallet_withdrawal_address_user_id_currency_network_address_idx" ON "wallet_withdrawal_address" USING btree ("user_id","currency","network","address",coalesce("destination_tag", ''));

--- a/packages/core/src/wallet/drizzle/migrations/meta/0013_snapshot.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1913 @@
+{
+  "id": "76bc6c80-2b98-44be-a045-2cf9b9721916",
+  "prevId": "2e55806e-da5d-4a8e-a74e-705495594c36",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auto_withdrawal_rule": {
+      "name": "auto_withdrawal_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auto_withdrawal_rule_user_id_unique": {
+          "name": "auto_withdrawal_rule_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_user_id_unique": {
+          "name": "wallet_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_asset": {
+      "name": "wallet_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_asset_id": {
+          "name": "provider_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_deposit": {
+          "name": "min_deposit",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_withdrawal": {
+          "name": "min_withdrawal",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawal_fee": {
+          "name": "withdrawal_fee",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deposit_enabled": {
+          "name": "deposit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "withdrawal_enabled": {
+          "name": "withdrawal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sweep_fee_ceiling": {
+          "name": "sweep_fee_ceiling",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool_liquidity_floor": {
+          "name": "pool_liquidity_floor",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_asset_currency_network_idx": {
+          "name": "wallet_asset_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_auto_withdrawal_config": {
+      "name": "wallet_auto_withdrawal_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "fiat_threshold": {
+          "name": "fiat_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crypto_threshold": {
+          "name": "crypto_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_risk_flags": {
+          "name": "exclude_risk_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['high_risk','bonus_abuser','kyc_rejected','withdrawal_review','multi_account']::text[]"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_auto_withdrawal_config_singletonKey_unique": {
+          "name": "wallet_auto_withdrawal_config_singletonKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_balance": {
+      "name": "wallet_balance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_balance_wallet_id_currency_idx": {
+          "name": "wallet_balance_wallet_id_currency_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_balance_wallet_id_wallet_id_fk": {
+          "name": "wallet_balance_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_balance",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_bonus_credit": {
+      "name": "wallet_bonus_credit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "wallet_bonus_credit_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credited_amount": {
+          "name": "credited_amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_multiplier": {
+          "name": "rollover_multiplier",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_required": {
+          "name": "rollover_required",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_progress": {
+          "name": "rollover_progress",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_bonus_credit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wallet_bonus_credit_user_id_currency_status_idx": {
+          "name": "wallet_bonus_credit_user_id_currency_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_bonus_credit_wallet_id_idx": {
+          "name": "wallet_bonus_credit_wallet_id_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_bonus_credit_wallet_id_wallet_id_fk": {
+          "name": "wallet_bonus_credit_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_bonus_credit",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_bonus_rollover_config": {
+      "name": "wallet_bonus_rollover_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_bonus_rollover_config_singletonKey_unique": {
+          "name": "wallet_bonus_rollover_config_singletonKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_custody_sweep": {
+      "name": "wallet_custody_sweep",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_fee": {
+          "name": "estimated_fee",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool_ref": {
+          "name": "pool_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_custody_sweep_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_custody_sweep_user_id_currency_network_idx": {
+          "name": "wallet_custody_sweep_user_id_currency_network_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending','processing','unknown')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_external_id_idx": {
+          "name": "wallet_custody_sweep_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_custody_sweep\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_status_created_at_idx": {
+          "name": "wallet_custody_sweep_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_provider_name_created_at_idx": {
+          "name": "wallet_custody_sweep_provider_name_created_at_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_deposit_address": {
+      "name": "wallet_deposit_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_deposit_address_user_id_currency_network_idx": {
+          "name": "wallet_deposit_address_user_id_currency_network_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_user_id_currency_idx": {
+          "name": "wallet_deposit_address_user_id_currency_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_tag_idx": {
+          "name": "wallet_deposit_address_address_tag_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_network_currency_idx": {
+          "name": "wallet_deposit_address_address_network_currency_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NULL AND \"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_idx": {
+          "name": "wallet_deposit_address_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_job_run": {
+      "name": "wallet_job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_job_run_job_name_idx": {
+          "name": "wallet_job_run_job_name_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_job_run\".\"finished_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_job_run_job_name_started_at_idx": {
+          "name": "wallet_job_run_job_name_started_at_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_provider_vault": {
+      "name": "wallet_provider_vault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_account_id": {
+          "name": "vault_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_provider_vault_user_id_provider_name_idx": {
+          "name": "wallet_provider_vault_user_id_provider_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_provider_vault_provider_name_vault_account_id_idx": {
+          "name": "wallet_provider_vault_provider_name_vault_account_id_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vault_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_reconciliation_finding": {
+      "name": "wallet_reconciliation_finding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "wallet_reconciliation_finding_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_reconciliation_finding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_reconciliation_finding_kind_external_id_idx": {
+          "name": "wallet_reconciliation_finding_kind_external_id_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_reconciliation_finding\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_reconciliation_finding_status_created_at_idx": {
+          "name": "wallet_reconciliation_finding_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_reconciliation_finding_run_id_idx": {
+          "name": "wallet_reconciliation_finding_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transaction": {
+      "name": "wallet_transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "wallet_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rail": {
+          "name": "rail",
+          "type": "wallet_rail",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref_id": {
+          "name": "provider_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_address": {
+          "name": "destination_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_tag": {
+          "name": "destination_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_wallet_id": {
+          "name": "destination_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transaction_wallet_id_idx": {
+          "name": "wallet_transaction_wallet_id_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_created_at_idx": {
+          "name": "wallet_transaction_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_type_idx": {
+          "name": "wallet_transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_idx": {
+          "name": "wallet_transaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_rail_idx": {
+          "name": "wallet_transaction_rail_idx",
+          "columns": [
+            {
+              "expression": "rail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_idx": {
+          "name": "wallet_transaction_currency_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_network_idx": {
+          "name": "wallet_transaction_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_tx_hash_idx": {
+          "name": "wallet_transaction_tx_hash_idx",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_type_created_at_idx": {
+          "name": "wallet_transaction_status_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_type_status_idx": {
+          "name": "wallet_transaction_wallet_id_type_status_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_provider_ref_id_idx": {
+          "name": "wallet_transaction_provider_ref_id_idx",
+          "columns": [
+            {
+              "expression": "provider_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"provider_ref_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_idempotency_key_idx": {
+          "name": "wallet_transaction_wallet_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transaction_wallet_id_wallet_id_fk": {
+          "name": "wallet_transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_withdrawal_address": {
+      "name": "wallet_withdrawal_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_wallet_id": {
+          "name": "provider_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_withdrawal_address_user_id_currency_network_address_idx": {
+          "name": "wallet_withdrawal_address_user_id_currency_network_address_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_withdrawal_address_user_id_created_at_idx": {
+          "name": "wallet_withdrawal_address_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.wallet_bonus_credit_source_type": {
+      "name": "wallet_bonus_credit_source_type",
+      "schema": "public",
+      "values": ["gift", "rain"]
+    },
+    "public.wallet_bonus_credit_status": {
+      "name": "wallet_bonus_credit_status",
+      "schema": "public",
+      "values": ["active", "completed"]
+    },
+    "public.wallet_custody_sweep_status": {
+      "name": "wallet_custody_sweep_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "unknown"]
+    },
+    "public.wallet_job_run_status": {
+      "name": "wallet_job_run_status",
+      "schema": "public",
+      "values": ["running", "completed", "failed", "abandoned"]
+    },
+    "public.wallet_rail": {
+      "name": "wallet_rail",
+      "schema": "public",
+      "values": ["crypto", "fiat"]
+    },
+    "public.wallet_reconciliation_finding_kind": {
+      "name": "wallet_reconciliation_finding_kind",
+      "schema": "public",
+      "values": [
+        "missing_deposit",
+        "unattributed_deposit",
+        "amount_mismatch",
+        "currency_mismatch",
+        "status_mismatch",
+        "unknown_at_provider",
+        "unconfigured_asset",
+        "stuck_sweep"
+      ]
+    },
+    "public.wallet_reconciliation_finding_status": {
+      "name": "wallet_reconciliation_finding_status",
+      "schema": "public",
+      "values": ["open", "resolved"]
+    },
+    "public.wallet_transaction_status": {
+      "name": "wallet_transaction_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "rejected", "on_hold", "cancelled"]
+    },
+    "public.wallet_transaction_type": {
+      "name": "wallet_transaction_type",
+      "schema": "public",
+      "values": [
+        "deposit",
+        "withdrawal",
+        "bet",
+        "win",
+        "loss",
+        "bonus",
+        "tip",
+        "gift",
+        "rain",
+        "manual_credit",
+        "manual_debit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/wallet/drizzle/migrations/meta/0014_snapshot.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/0014_snapshot.json
@@ -1,0 +1,1925 @@
+{
+  "id": "9cb907e0-23be-4124-bd49-3d3191a186c4",
+  "prevId": "76bc6c80-2b98-44be-a045-2cf9b9721916",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auto_withdrawal_rule": {
+      "name": "auto_withdrawal_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auto_withdrawal_rule_user_id_unique": {
+          "name": "auto_withdrawal_rule_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_user_id_unique": {
+          "name": "wallet_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_asset": {
+      "name": "wallet_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_asset_id": {
+          "name": "provider_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_deposit": {
+          "name": "min_deposit",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_withdrawal": {
+          "name": "min_withdrawal",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawal_fee": {
+          "name": "withdrawal_fee",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deposit_enabled": {
+          "name": "deposit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "withdrawal_enabled": {
+          "name": "withdrawal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sweep_fee_ceiling": {
+          "name": "sweep_fee_ceiling",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool_liquidity_floor": {
+          "name": "pool_liquidity_floor",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_asset_currency_network_idx": {
+          "name": "wallet_asset_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_auto_withdrawal_config": {
+      "name": "wallet_auto_withdrawal_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "fiat_threshold": {
+          "name": "fiat_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crypto_threshold": {
+          "name": "crypto_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_risk_flags": {
+          "name": "exclude_risk_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['high_risk','bonus_abuser','kyc_rejected','withdrawal_review','multi_account']::text[]"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_auto_withdrawal_config_singletonKey_unique": {
+          "name": "wallet_auto_withdrawal_config_singletonKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_balance": {
+      "name": "wallet_balance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_balance_wallet_id_currency_idx": {
+          "name": "wallet_balance_wallet_id_currency_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_balance_wallet_id_wallet_id_fk": {
+          "name": "wallet_balance_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_balance",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_bonus_credit": {
+      "name": "wallet_bonus_credit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "wallet_bonus_credit_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credited_amount": {
+          "name": "credited_amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_multiplier": {
+          "name": "rollover_multiplier",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_required": {
+          "name": "rollover_required",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_progress": {
+          "name": "rollover_progress",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_bonus_credit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wallet_bonus_credit_user_id_currency_status_idx": {
+          "name": "wallet_bonus_credit_user_id_currency_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_bonus_credit_wallet_id_idx": {
+          "name": "wallet_bonus_credit_wallet_id_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_bonus_credit_wallet_id_wallet_id_fk": {
+          "name": "wallet_bonus_credit_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_bonus_credit",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_bonus_rollover_config": {
+      "name": "wallet_bonus_rollover_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_bonus_rollover_config_singletonKey_unique": {
+          "name": "wallet_bonus_rollover_config_singletonKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_custody_sweep": {
+      "name": "wallet_custody_sweep",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_fee": {
+          "name": "estimated_fee",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool_ref": {
+          "name": "pool_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_custody_sweep_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_custody_sweep_user_id_currency_network_idx": {
+          "name": "wallet_custody_sweep_user_id_currency_network_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending','processing','unknown')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_external_id_idx": {
+          "name": "wallet_custody_sweep_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_custody_sweep\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_status_created_at_idx": {
+          "name": "wallet_custody_sweep_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_provider_name_created_at_idx": {
+          "name": "wallet_custody_sweep_provider_name_created_at_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_deposit_address": {
+      "name": "wallet_deposit_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_deposit_address_user_id_currency_network_idx": {
+          "name": "wallet_deposit_address_user_id_currency_network_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_user_id_currency_idx": {
+          "name": "wallet_deposit_address_user_id_currency_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_tag_idx": {
+          "name": "wallet_deposit_address_address_tag_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_network_currency_idx": {
+          "name": "wallet_deposit_address_address_network_currency_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NULL AND \"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_idx": {
+          "name": "wallet_deposit_address_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_job_run": {
+      "name": "wallet_job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_job_run_job_name_idx": {
+          "name": "wallet_job_run_job_name_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_job_run\".\"finished_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_job_run_job_name_started_at_idx": {
+          "name": "wallet_job_run_job_name_started_at_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_provider_vault": {
+      "name": "wallet_provider_vault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_account_id": {
+          "name": "vault_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_provider_vault_user_id_provider_name_idx": {
+          "name": "wallet_provider_vault_user_id_provider_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_provider_vault_provider_name_vault_account_id_idx": {
+          "name": "wallet_provider_vault_provider_name_vault_account_id_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vault_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_reconciliation_finding": {
+      "name": "wallet_reconciliation_finding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "wallet_reconciliation_finding_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_reconciliation_finding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_reconciliation_finding_kind_external_id_idx": {
+          "name": "wallet_reconciliation_finding_kind_external_id_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_reconciliation_finding\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_reconciliation_finding_status_created_at_idx": {
+          "name": "wallet_reconciliation_finding_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_reconciliation_finding_run_id_idx": {
+          "name": "wallet_reconciliation_finding_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transaction": {
+      "name": "wallet_transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "wallet_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rail": {
+          "name": "rail",
+          "type": "wallet_rail",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "wallet_transaction_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref_id": {
+          "name": "provider_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_address": {
+          "name": "destination_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_tag": {
+          "name": "destination_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_wallet_id": {
+          "name": "destination_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transaction_wallet_id_idx": {
+          "name": "wallet_transaction_wallet_id_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_created_at_idx": {
+          "name": "wallet_transaction_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_type_idx": {
+          "name": "wallet_transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_idx": {
+          "name": "wallet_transaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_rail_idx": {
+          "name": "wallet_transaction_rail_idx",
+          "columns": [
+            {
+              "expression": "rail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_idx": {
+          "name": "wallet_transaction_currency_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_network_idx": {
+          "name": "wallet_transaction_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_tx_hash_idx": {
+          "name": "wallet_transaction_tx_hash_idx",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_type_created_at_idx": {
+          "name": "wallet_transaction_status_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_type_status_idx": {
+          "name": "wallet_transaction_wallet_id_type_status_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_provider_ref_id_idx": {
+          "name": "wallet_transaction_provider_ref_id_idx",
+          "columns": [
+            {
+              "expression": "provider_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"provider_ref_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_idempotency_key_idx": {
+          "name": "wallet_transaction_wallet_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transaction_wallet_id_wallet_id_fk": {
+          "name": "wallet_transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_withdrawal_address": {
+      "name": "wallet_withdrawal_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_wallet_id": {
+          "name": "provider_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_withdrawal_address_user_id_currency_network_address_idx": {
+          "name": "wallet_withdrawal_address_user_id_currency_network_address_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_withdrawal_address_user_id_created_at_idx": {
+          "name": "wallet_withdrawal_address_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.wallet_bonus_credit_source_type": {
+      "name": "wallet_bonus_credit_source_type",
+      "schema": "public",
+      "values": ["gift", "rain"]
+    },
+    "public.wallet_bonus_credit_status": {
+      "name": "wallet_bonus_credit_status",
+      "schema": "public",
+      "values": ["active", "completed"]
+    },
+    "public.wallet_custody_sweep_status": {
+      "name": "wallet_custody_sweep_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "unknown"]
+    },
+    "public.wallet_job_run_status": {
+      "name": "wallet_job_run_status",
+      "schema": "public",
+      "values": ["running", "completed", "failed", "abandoned"]
+    },
+    "public.wallet_rail": {
+      "name": "wallet_rail",
+      "schema": "public",
+      "values": ["crypto", "fiat"]
+    },
+    "public.wallet_reconciliation_finding_kind": {
+      "name": "wallet_reconciliation_finding_kind",
+      "schema": "public",
+      "values": [
+        "missing_deposit",
+        "unattributed_deposit",
+        "amount_mismatch",
+        "currency_mismatch",
+        "status_mismatch",
+        "unknown_at_provider",
+        "unconfigured_asset",
+        "stuck_sweep"
+      ]
+    },
+    "public.wallet_reconciliation_finding_status": {
+      "name": "wallet_reconciliation_finding_status",
+      "schema": "public",
+      "values": ["open", "resolved"]
+    },
+    "public.wallet_transaction_direction": {
+      "name": "wallet_transaction_direction",
+      "schema": "public",
+      "values": ["credit", "debit"]
+    },
+    "public.wallet_transaction_status": {
+      "name": "wallet_transaction_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "rejected", "on_hold", "cancelled"]
+    },
+    "public.wallet_transaction_type": {
+      "name": "wallet_transaction_type",
+      "schema": "public",
+      "values": [
+        "deposit",
+        "withdrawal",
+        "bet",
+        "win",
+        "loss",
+        "bonus",
+        "tip",
+        "gift",
+        "rain",
+        "manual_credit",
+        "manual_debit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/wallet/drizzle/migrations/meta/0015_snapshot.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/0015_snapshot.json
@@ -1,0 +1,1937 @@
+{
+  "id": "5ef1db6f-9a71-4cc2-985f-7262006c7aad",
+  "prevId": "9cb907e0-23be-4124-bd49-3d3191a186c4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auto_withdrawal_rule": {
+      "name": "auto_withdrawal_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auto_withdrawal_rule_user_id_unique": {
+          "name": "auto_withdrawal_rule_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_user_id_unique": {
+          "name": "wallet_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_asset": {
+      "name": "wallet_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_asset_id": {
+          "name": "provider_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_deposit": {
+          "name": "min_deposit",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_withdrawal": {
+          "name": "min_withdrawal",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawal_fee": {
+          "name": "withdrawal_fee",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deposit_enabled": {
+          "name": "deposit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "withdrawal_enabled": {
+          "name": "withdrawal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sweep_fee_ceiling": {
+          "name": "sweep_fee_ceiling",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool_liquidity_floor": {
+          "name": "pool_liquidity_floor",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_asset_currency_network_idx": {
+          "name": "wallet_asset_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_auto_withdrawal_config": {
+      "name": "wallet_auto_withdrawal_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "fiat_threshold": {
+          "name": "fiat_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crypto_threshold": {
+          "name": "crypto_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_risk_flags": {
+          "name": "exclude_risk_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['high_risk','bonus_abuser','kyc_rejected','withdrawal_review','multi_account']::text[]"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_auto_withdrawal_config_singletonKey_unique": {
+          "name": "wallet_auto_withdrawal_config_singletonKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_balance": {
+      "name": "wallet_balance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_balance_wallet_id_currency_idx": {
+          "name": "wallet_balance_wallet_id_currency_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_balance_wallet_id_wallet_id_fk": {
+          "name": "wallet_balance_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_balance",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_bonus_credit": {
+      "name": "wallet_bonus_credit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "wallet_bonus_credit_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credited_amount": {
+          "name": "credited_amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_multiplier": {
+          "name": "rollover_multiplier",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_required": {
+          "name": "rollover_required",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_progress": {
+          "name": "rollover_progress",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_bonus_credit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wallet_bonus_credit_user_id_currency_status_idx": {
+          "name": "wallet_bonus_credit_user_id_currency_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_bonus_credit_wallet_id_idx": {
+          "name": "wallet_bonus_credit_wallet_id_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_bonus_credit_wallet_id_wallet_id_fk": {
+          "name": "wallet_bonus_credit_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_bonus_credit",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_bonus_rollover_config": {
+      "name": "wallet_bonus_rollover_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_bonus_rollover_config_singletonKey_unique": {
+          "name": "wallet_bonus_rollover_config_singletonKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_custody_sweep": {
+      "name": "wallet_custody_sweep",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_fee": {
+          "name": "estimated_fee",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool_ref": {
+          "name": "pool_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_custody_sweep_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_custody_sweep_user_id_currency_network_idx": {
+          "name": "wallet_custody_sweep_user_id_currency_network_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending','processing','unknown')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_external_id_idx": {
+          "name": "wallet_custody_sweep_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_custody_sweep\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_status_created_at_idx": {
+          "name": "wallet_custody_sweep_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_provider_name_created_at_idx": {
+          "name": "wallet_custody_sweep_provider_name_created_at_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_deposit_address": {
+      "name": "wallet_deposit_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_deposit_address_user_id_currency_network_idx": {
+          "name": "wallet_deposit_address_user_id_currency_network_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_user_id_currency_idx": {
+          "name": "wallet_deposit_address_user_id_currency_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_tag_idx": {
+          "name": "wallet_deposit_address_address_tag_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_network_currency_idx": {
+          "name": "wallet_deposit_address_address_network_currency_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NULL AND \"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_idx": {
+          "name": "wallet_deposit_address_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_job_run": {
+      "name": "wallet_job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_job_run_job_name_idx": {
+          "name": "wallet_job_run_job_name_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_job_run\".\"finished_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_job_run_job_name_started_at_idx": {
+          "name": "wallet_job_run_job_name_started_at_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_provider_vault": {
+      "name": "wallet_provider_vault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_account_id": {
+          "name": "vault_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_provider_vault_user_id_provider_name_idx": {
+          "name": "wallet_provider_vault_user_id_provider_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_provider_vault_provider_name_vault_account_id_idx": {
+          "name": "wallet_provider_vault_provider_name_vault_account_id_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vault_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_reconciliation_finding": {
+      "name": "wallet_reconciliation_finding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "wallet_reconciliation_finding_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_reconciliation_finding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_reconciliation_finding_kind_external_id_idx": {
+          "name": "wallet_reconciliation_finding_kind_external_id_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_reconciliation_finding\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_reconciliation_finding_status_created_at_idx": {
+          "name": "wallet_reconciliation_finding_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_reconciliation_finding_run_id_idx": {
+          "name": "wallet_reconciliation_finding_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transaction": {
+      "name": "wallet_transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "wallet_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rail": {
+          "name": "rail",
+          "type": "wallet_rail",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "wallet_transaction_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref_id": {
+          "name": "provider_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_address": {
+          "name": "destination_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_tag": {
+          "name": "destination_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_wallet_id": {
+          "name": "destination_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transaction_wallet_id_idx": {
+          "name": "wallet_transaction_wallet_id_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_created_at_idx": {
+          "name": "wallet_transaction_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_type_idx": {
+          "name": "wallet_transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_idx": {
+          "name": "wallet_transaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_rail_idx": {
+          "name": "wallet_transaction_rail_idx",
+          "columns": [
+            {
+              "expression": "rail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_idx": {
+          "name": "wallet_transaction_currency_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_network_idx": {
+          "name": "wallet_transaction_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_tx_hash_idx": {
+          "name": "wallet_transaction_tx_hash_idx",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_type_created_at_idx": {
+          "name": "wallet_transaction_status_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_type_status_idx": {
+          "name": "wallet_transaction_wallet_id_type_status_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_provider_ref_id_idx": {
+          "name": "wallet_transaction_provider_ref_id_idx",
+          "columns": [
+            {
+              "expression": "provider_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"provider_ref_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_idempotency_key_idx": {
+          "name": "wallet_transaction_wallet_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transaction_wallet_id_wallet_id_fk": {
+          "name": "wallet_transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_withdrawal_address": {
+      "name": "wallet_withdrawal_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_tag": {
+          "name": "destination_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_wallet_id": {
+          "name": "provider_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_withdrawal_address_user_id_currency_network_address_idx": {
+          "name": "wallet_withdrawal_address_user_id_currency_network_address_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"destination_tag\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_withdrawal_address_user_id_created_at_idx": {
+          "name": "wallet_withdrawal_address_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.wallet_bonus_credit_source_type": {
+      "name": "wallet_bonus_credit_source_type",
+      "schema": "public",
+      "values": ["gift", "rain"]
+    },
+    "public.wallet_bonus_credit_status": {
+      "name": "wallet_bonus_credit_status",
+      "schema": "public",
+      "values": ["active", "completed"]
+    },
+    "public.wallet_custody_sweep_status": {
+      "name": "wallet_custody_sweep_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "unknown"]
+    },
+    "public.wallet_job_run_status": {
+      "name": "wallet_job_run_status",
+      "schema": "public",
+      "values": ["running", "completed", "failed", "abandoned"]
+    },
+    "public.wallet_rail": {
+      "name": "wallet_rail",
+      "schema": "public",
+      "values": ["crypto", "fiat"]
+    },
+    "public.wallet_reconciliation_finding_kind": {
+      "name": "wallet_reconciliation_finding_kind",
+      "schema": "public",
+      "values": [
+        "missing_deposit",
+        "unattributed_deposit",
+        "amount_mismatch",
+        "currency_mismatch",
+        "status_mismatch",
+        "unknown_at_provider",
+        "unconfigured_asset",
+        "stuck_sweep"
+      ]
+    },
+    "public.wallet_reconciliation_finding_status": {
+      "name": "wallet_reconciliation_finding_status",
+      "schema": "public",
+      "values": ["open", "resolved"]
+    },
+    "public.wallet_transaction_direction": {
+      "name": "wallet_transaction_direction",
+      "schema": "public",
+      "values": ["credit", "debit"]
+    },
+    "public.wallet_transaction_status": {
+      "name": "wallet_transaction_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "rejected", "on_hold", "cancelled"]
+    },
+    "public.wallet_transaction_type": {
+      "name": "wallet_transaction_type",
+      "schema": "public",
+      "values": [
+        "deposit",
+        "withdrawal",
+        "bet",
+        "win",
+        "loss",
+        "bonus",
+        "tip",
+        "gift",
+        "rain",
+        "manual_credit",
+        "manual_debit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1787607548687,
       "tag": "0013_polite_peter_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1787610320209,
+      "tag": "0014_abandoned_madripoor",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1787610320209,
       "tag": "0014_abandoned_madripoor",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1787749886002,
+      "tag": "0015_right_oracle",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1787569976931,
       "tag": "0012_long_wong",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1787607548687,
+      "tag": "0013_polite_peter_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/wallet/plugin.ts
+++ b/packages/core/src/wallet/plugin.ts
@@ -9,6 +9,7 @@ import {
   PAYMENT_WEBHOOK_VERIFIER,
   PAYMENT_PROVIDERS,
   DEFAULT_PAYMENT_PROVIDER,
+  REALTIME_TRANSPORT,
   WALLET_COMMANDS,
   WALLET_READER,
   WALLET_ASSET_CATALOG,
@@ -20,8 +21,11 @@ import {
   AUDIT_WRITER,
   JOB_QUEUE,
   UuidSchema,
+  domainEventSchemas,
   queue,
+  type RealtimeTransport,
 } from '@openora/core/contracts';
+import type { WalletBalanceChangeReason } from './contract/index.js';
 import { WalletService } from './service/wallet.service.js';
 import { WalletCommandsService } from './service/wallet-commands.service.js';
 import {
@@ -32,7 +36,7 @@ import {
 import { WalletReaderService } from './adapters/wallet-reader.service.js';
 import { WalletAssetCatalogService } from './adapters/wallet-asset-catalog.service.js';
 import { DrizzleAdminWalletReporting } from './admin-reporting.js';
-import { createWalletRouter } from './router/index.js';
+import { createWalletRouter, walletBalanceChannel } from './router/index.js';
 import { MockPaymentAdapter } from './adapters/mock/mock-payment-adapter.js';
 import { HmacPaymentWebhookVerifier } from './adapters/hmac-payment-webhook-verifier.js';
 import { ReconciliationService } from './service/reconciliation.service.js';
@@ -59,6 +63,90 @@ export default {
     // closes over this ref, same shape as pam/tag's evalSvc - subscriptions/workers
     // wire before router factories run, but are set before any real job arrives.
     let reconciliationRef: ReconciliationService | null = null;
+
+    // Set inside the router factory (container access); the balance-changed event
+    // handlers below close over this ref - same shape as compliance's kycStatusChannel
+    // publish. Subscriptions wire before router factories run, but are set before any
+    // real event arrives.
+    let realtimeTransport: RealtimeTransport | null = null;
+
+    // Publishes a change *signal*, never the balance itself - see the comment on
+    // WalletBalanceUpdateSchema. Only wired to events that actually move a settled
+    // balance (see the `ctx.events.on` calls below); `wallet.withdrawal.approved` and
+    // `wallet.withdrawal.completed` are deliberately absent - approval only flips a
+    // pending withdrawal to `processing` and completion just finalizes the PSP leg, the
+    // funds were already debited at `wallet.withdrawal.requested` time.
+    const publishBalanceChanged = (
+      userId: string,
+      currency: string,
+      reason: WalletBalanceChangeReason,
+      eventId: string,
+    ) => {
+      if (!realtimeTransport) {
+        return;
+      }
+      return realtimeTransport.publish(walletBalanceChannel(userId), {
+        eventId,
+        currency,
+        reason,
+      });
+    };
+
+    ctx.events.on('wallet.deposit.completed', (payload, envelope) => {
+      const parsed = domainEventSchemas['wallet.deposit.completed'].safeParse(payload);
+      if (!parsed.success || !envelope) {
+        return;
+      }
+      publishBalanceChanged(parsed.data.userId, parsed.data.currency, 'deposit', envelope.eventId);
+    });
+    ctx.events.on('wallet.withdrawal.requested', (payload, envelope) => {
+      const parsed = domainEventSchemas['wallet.withdrawal.requested'].safeParse(payload);
+      if (!parsed.success || !envelope) {
+        return;
+      }
+      publishBalanceChanged(
+        parsed.data.userId,
+        parsed.data.currency,
+        'withdrawal',
+        envelope.eventId,
+      );
+    });
+    ctx.events.on('wallet.withdrawal.failed', (payload, envelope) => {
+      const parsed = domainEventSchemas['wallet.withdrawal.failed'].safeParse(payload);
+      if (!parsed.success || !envelope) {
+        return;
+      }
+      publishBalanceChanged(
+        parsed.data.userId,
+        parsed.data.currency,
+        'withdrawal',
+        envelope.eventId,
+      );
+    });
+    ctx.events.on('wallet.withdrawal.rejected', (payload, envelope) => {
+      const parsed = domainEventSchemas['wallet.withdrawal.rejected'].safeParse(payload);
+      if (!parsed.success || !envelope) {
+        return;
+      }
+      publishBalanceChanged(
+        parsed.data.userId,
+        parsed.data.currency,
+        'withdrawal',
+        envelope.eventId,
+      );
+    });
+    ctx.events.on('wallet.manual_adjustment.created', (payload, envelope) => {
+      const parsed = domainEventSchemas['wallet.manual_adjustment.created'].safeParse(payload);
+      if (!parsed.success || !envelope) {
+        return;
+      }
+      publishBalanceChanged(
+        parsed.data.userId,
+        parsed.data.currency,
+        'adjustment',
+        envelope.eventId,
+      );
+    });
 
     // One memoized instance backs the cron worker and the router factory below - lazily
     // constructed (subscriptions/workers wire before router factories run), matching
@@ -127,6 +215,7 @@ export default {
     // importing wallet tables. Overlay-rebindable, but bound here so it always works.
     ctx.provide(WALLET_ASSET_CATALOG, (c) => new WalletAssetCatalogService(c.get(DRIZZLE)));
     ctx.routers.add('wallet', (c) => {
+      realtimeTransport = c.get(REALTIME_TRANSPORT);
       const platformConfig = c.has(PLATFORM_CONFIG) ? c.get(PLATFORM_CONFIG) : undefined;
       const walletService = new WalletService({
         drizzle: c.get(DRIZZLE),
@@ -185,6 +274,7 @@ export default {
         reconciliation,
         jobQueue,
         reconciliationQueue: WALLET_RECONCILIATION_QUEUE,
+        realtime: realtimeTransport,
         limiter: c.get(RATE_LIMITER),
       });
     });

--- a/packages/core/src/wallet/router/index.ts
+++ b/packages/core/src/wallet/router/index.ts
@@ -182,6 +182,7 @@ export function createWalletRouter({
             network: input.network,
             idempotencyKey: input.idempotencyKey,
             destinationAddress: input.destinationAddress,
+            destinationTag: input.destinationTag,
             ...context.clientMeta,
           }),
       );

--- a/packages/core/src/wallet/router/index.ts
+++ b/packages/core/src/wallet/router/index.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { implement, ORPCError } from '@orpc/server';
 import {
+  createEventStreamGenerator,
   getUserId,
   mapErrors,
   assertRateLimit,
@@ -18,8 +19,10 @@ import {
   type QueueName,
   type RateLimiterAdapter,
   type RateLimitKey,
+  type RealtimeTransport,
+  type User,
 } from '@openora/core/contracts';
-import { walletContract } from '../contract/index.js';
+import { walletContract, type WalletBalanceUpdate } from '../contract/index.js';
 import { CUSTODY_SWEEP_QUEUE } from '../service/custody-sweep.service.js';
 import {
   WalletService,
@@ -96,6 +99,21 @@ async function dispatchWebhook(
   return { ok: true as const };
 }
 
+export function walletBalanceChannel(userId: User['id']): string {
+  return `wallet:balance:${userId}`;
+}
+
+export function createWalletBalanceStream(
+  realtime: RealtimeTransport,
+  userId: User['id'],
+  signal: AbortSignal | undefined,
+): AsyncGenerator<WalletBalanceUpdate> {
+  return createEventStreamGenerator(
+    (push) => realtime.subscribe<WalletBalanceUpdate>(walletBalanceChannel(userId), push),
+    { signal },
+  );
+}
+
 /**
  * Named rather than positional. Half of these are structurally similar ports, so a
  * positional slip type-checks; and the sweep and reconciliation branches each add their
@@ -110,6 +128,7 @@ export type WalletRouterDeps = {
   reconciliation: ReconciliationService;
   jobQueue: JobQueueAdapter;
   reconciliationQueue: QueueName;
+  realtime: RealtimeTransport;
   limiter?: RateLimiterAdapter<RateLimitKey>;
 };
 
@@ -121,6 +140,7 @@ export function createWalletRouter({
   reconciliation,
   jobQueue,
   reconciliationQueue,
+  realtime,
   limiter,
 }: WalletRouterDeps) {
   const os = implement(walletContract).$context<OssContext>();
@@ -136,6 +156,12 @@ export function createWalletRouter({
     getBalance: os.getBalance.handler(({ context }) => wallet.getBalance(getUserId(context))),
 
     getBalances: os.getBalances.handler(({ context }) => wallet.getBalances(getUserId(context))),
+
+    // Player-scoped: the channel is keyed by the session's userId, never an input
+    // parameter, so a player can never subscribe to another player's balance channel.
+    streamBalance: os.streamBalance.handler(({ signal, context }) => {
+      return createWalletBalanceStream(realtime, getUserId(context), signal);
+    }),
 
     setActiveCurrency: os.setActiveCurrency.handler(({ input, context }) =>
       mapErrors({ NOT_FOUND: WalletNotFoundError }, () =>

--- a/packages/core/src/wallet/schema/index.ts
+++ b/packages/core/src/wallet/schema/index.ts
@@ -32,8 +32,10 @@ import {
 import {
   BONUS_CREDIT_SOURCE_TYPES,
   BONUS_CREDIT_STATUSES,
+  MANUAL_ADJUSTMENT_DIRECTIONS,
   type BonusCreditSourceType,
   type BonusCreditStatus,
+  type ManualAdjustmentDirection,
 } from '../contract/index.js';
 
 // Enum values derive from the canonical tuples so the DB enum can never drift from
@@ -58,6 +60,15 @@ export const walletBonusCreditSourceTypeEnum = pgEnum(
 export const walletBonusCreditStatusEnum = pgEnum(
   'wallet_bonus_credit_status',
   BONUS_CREDIT_STATUSES,
+);
+
+// Same credit/debit vocabulary as a manual adjustment (contract/index.ts) - a wallet
+// move only ever has these two directions, so one enum covers both. Nullable: rows
+// written before this column existed (all gift/rain/tip legs pre-dating it, plus any
+// other historical row) have no recoverable direction and stay NULL rather than guess.
+export const walletTransactionDirectionEnum = pgEnum(
+  'wallet_transaction_direction',
+  MANUAL_ADJUSTMENT_DIRECTIONS,
 );
 
 export const wallet = pgTable('wallet', {
@@ -106,6 +117,11 @@ export const walletTransaction = pgTable(
       .notNull()
       .default('pending'),
     rail: walletRailEnum().$type<WalletRail>(),
+    // Which way this leg moved money. Derived from what the operation IS (never a
+    // caller input) and set at every insert site going forward; NULL only for rows
+    // written before this column existed. See the enum comment above for why gift/
+    // rain/tip needed this at all - they wrote the same `type` for both legs.
+    direction: walletTransactionDirectionEnum().$type<ManualAdjustmentDirection>(),
     // Admin user id (cross-module). Bare uuid, no .references - the user table is
     // owned by another domain.
     reviewedBy: uuid(),

--- a/packages/core/src/wallet/schema/index.ts
+++ b/packages/core/src/wallet/schema/index.ts
@@ -220,6 +220,11 @@ export const walletWithdrawalAddress = pgTable(
     currency: text().notNull(),
     network: text().notNull(),
     address: text().notNull(),
+    // On a tag/memo chain the address alone does not name a beneficiary - one exchange address
+    // serves every account behind it, and the tag picks which. The tag is therefore part of the
+    // whitelisted destination, not a per-withdrawal free field: without it here a player who
+    // saved a shared address could pay out to anyone else holding an account at it.
+    destinationTag: text(),
     // Which custody provider `providerWalletId` belongs to. Without it a provider swap would
     // silently reuse the previous vendor's id and pay out to whatever that id now names.
     providerName: text(),
@@ -231,12 +236,15 @@ export const walletWithdrawalAddress = pgTable(
     createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
-    // A double submit conflicts instead of duplicating the same destination twice.
+    // A double submit conflicts instead of duplicating the same destination twice. The tag is
+    // coalesced because two NULLs are distinct to a unique index, which would let the untagged
+    // form of an address be saved twice.
     uniqueIndex('wallet_withdrawal_address_user_id_currency_network_address_idx').on(
       t.userId,
       t.currency,
       t.network,
       t.address,
+      sql`coalesce(${t.destinationTag}, '')`,
     ),
     index('wallet_withdrawal_address_user_id_created_at_idx').on(t.userId, t.createdAt),
   ],

--- a/packages/core/src/wallet/schema/index.ts
+++ b/packages/core/src/wallet/schema/index.ts
@@ -117,6 +117,7 @@ export const walletTransaction = pgTable(
     providerName: text(),
     providerRefId: text(),
     destinationAddress: text(),
+    destinationTag: text(),
     destinationWalletId: text(),
     txHash: text(),
     // Reserved escape hatch for genuinely free-form, non-queryable extras. Provider

--- a/packages/core/src/wallet/service/wallet-commands.service.ts
+++ b/packages/core/src/wallet/service/wallet-commands.service.ts
@@ -24,7 +24,7 @@ import {
   walletBonusRolloverConfig,
   type Wallet,
 } from '../schema/index.js';
-import type { BonusCreditSourceType } from '../contract/index.js';
+import type { BonusCreditSourceType, ManualAdjustmentDirection } from '../contract/index.js';
 import {
   creditWalletBalance,
   balanceKey,
@@ -63,11 +63,15 @@ export class WalletCommandsService implements WalletCommands {
   ) {}
 
   // Completed, internal-settlement ledger row (no provider ref) shared by every gameplay move.
+  // `direction` is required (not optional) so a new call site can't compile without deciding
+  // it - `debit()` always passes 'debit', `credit()` always passes 'credit', including the
+  // gift/rain/tip legs that share one `type` for both sides of the transfer.
   private writeLedgerRow(
     txn: DrizzleDb,
     row: { id: string; currency: string },
     type: WalletTransactionType,
     amount: string,
+    direction: ManualAdjustmentDirection,
   ) {
     return txn.insert(walletTransaction).values({
       walletId: row.id,
@@ -75,6 +79,7 @@ export class WalletCommandsService implements WalletCommands {
       amount,
       currency: row.currency,
       status: 'completed',
+      direction,
       rail: railFor(row.currency, this.platformConfig?.wallet?.cryptoCurrencies),
     });
   }
@@ -98,7 +103,7 @@ export class WalletCommandsService implements WalletCommands {
     const available = await readWalletBalance(txn, row.id, row.currency);
 
     if (type === 'loss') {
-      await this.writeLedgerRow(txn, row, 'loss', '0');
+      await this.writeLedgerRow(txn, row, 'loss', '0', 'debit');
       return { ok: true, newBalance: available, currency: row.currency };
     }
 
@@ -113,7 +118,7 @@ export class WalletCommandsService implements WalletCommands {
       return { ok: false, available };
     }
 
-    await this.writeLedgerRow(txn, row, type, amount);
+    await this.writeLedgerRow(txn, row, type, amount, 'debit');
 
     if (type === 'bet') {
       const completedBonusCredits = await this.applyBonusRolloverProgress(txn, {
@@ -151,7 +156,7 @@ export class WalletCommandsService implements WalletCommands {
       throw new Error('wallet credit: no row');
     }
 
-    await this.writeLedgerRow(txn, row, type, amount);
+    await this.writeLedgerRow(txn, row, type, amount, 'credit');
 
     if (type === 'gift' || type === 'rain') {
       await this.createBonusCredit(txn, {

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -1091,6 +1091,7 @@ export class WalletService {
     network,
     idempotencyKey,
     destinationAddress,
+    destinationTag,
     ip,
     userAgent,
   }: {
@@ -1100,6 +1101,7 @@ export class WalletService {
     network?: string;
     idempotencyKey?: string;
     destinationAddress?: string;
+    destinationTag?: string;
   } & ClientMeta): Promise<TransactionResult> {
     await this.rateLimit(userId);
     await this.assertKycForWithdrawal(userId);
@@ -1157,6 +1159,7 @@ export class WalletService {
             rail: this.resolveRail(currency),
             network: settlementNetwork,
             destinationAddress: destinationAddress ?? null,
+            destinationTag: destinationTag ?? null,
             destinationWalletId,
           },
         });
@@ -1414,6 +1417,7 @@ export class WalletService {
         rail: tx.rail,
         adminId,
         destinationAddress: tx.destinationAddress,
+        destinationTag: tx.destinationTag,
         // The provider-side whitelisted destination for that address, when the bound adapter
         // whitelists at all. Absent for an address that predates whitelisting or was never in
         // the book, and such an adapter is expected to refuse rather than pay out to the raw

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -1321,6 +1321,7 @@ export class WalletService {
         riskTags,
         requestedAt: r.tx.createdAt.toISOString(),
         destinationAddress: r.tx.destinationAddress,
+        destinationTag: r.tx.destinationTag,
         txHash: r.tx.txHash,
       };
     });

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -217,6 +217,7 @@ function toWithdrawalAddressDto(row: WalletWithdrawalAddressRow): WithdrawalAddr
     currency: row.currency,
     network: row.network,
     address: row.address,
+    destinationTag: row.destinationTag,
     createdAt: row.createdAt.toISOString(),
   };
 }
@@ -1123,6 +1124,7 @@ export class WalletService {
       currency,
       settlementNetwork,
       destinationAddress,
+      destinationTag,
     );
 
     const { transactionId, status, replayed, walletId, rail } = await this.drizzle.db.transaction(
@@ -2595,19 +2597,31 @@ export class WalletService {
   }
 
   /**
-   * Refuses a payout to an address the provider has not approved. A no-op for an adapter that
+   * Refuses a payout to a destination the provider has not approved. A no-op for an adapter that
    * does not whitelist, and for a fiat rail, which has no address at all.
+   *
+   * The tag is matched as strictly as the address. On a tag chain one exchange address is shared
+   * by every account behind it, so an address-only check would let a player whitelist their own
+   * account at that exchange and then pay out to a stranger's tag at the same address - an
+   * auto-approved withdrawal would do it with nobody looking.
    */
   private async requireWhitelistedWalletId(
     userId: Uuid,
     currency: string,
     network: string | null,
     destinationAddress: string | undefined,
+    destinationTag: string | undefined,
   ): Promise<string | null> {
     if (!this.payment.whitelistWithdrawalAddress || !destinationAddress) {
       return null;
     }
-    const walletId = await this.whitelistedWalletId(userId, currency, network, destinationAddress);
+    const walletId = await this.whitelistedWalletId(
+      userId,
+      currency,
+      network,
+      destinationAddress,
+      destinationTag,
+    );
     if (!walletId) {
       throw new DestinationAddressNotWhitelistedError();
     }
@@ -2615,15 +2629,17 @@ export class WalletService {
   }
 
   /**
-   * The approved destination saved for this address, or null. Matched on the address itself
-   * rather than an id on the transaction, because a withdrawal is requested by address and may
-   * name one the player never saved.
+   * The approved destination saved for this (address, tag) pair, or null. Matched on the pair
+   * itself rather than an id on the transaction, because a withdrawal is requested by address
+   * and may name one the player never saved. An absent tag matches only a row saved without
+   * one: a tagged payout against an untagged whitelist row is a different beneficiary.
    */
   private async whitelistedWalletId(
     userId: Uuid,
     currency: string,
     network: string | null,
     address: string | null | undefined,
+    destinationTag: string | null | undefined,
   ): Promise<string | null> {
     if (!this.payment.whitelistWithdrawalAddress || !address) {
       return null;
@@ -2633,6 +2649,7 @@ export class WalletService {
       .select({
         id: walletWithdrawalAddress.id,
         network: walletWithdrawalAddress.network,
+        destinationTag: walletWithdrawalAddress.destinationTag,
         providerName: walletWithdrawalAddress.providerName,
         providerWalletId: walletWithdrawalAddress.providerWalletId,
       })
@@ -2642,6 +2659,9 @@ export class WalletService {
           eq(walletWithdrawalAddress.userId, userId),
           eq(walletWithdrawalAddress.currency, currency),
           eq(walletWithdrawalAddress.address, address),
+          destinationTag
+            ? eq(walletWithdrawalAddress.destinationTag, destinationTag)
+            : isNull(walletWithdrawalAddress.destinationTag),
           ...(network ? [eq(walletWithdrawalAddress.network, network)] : []),
         ),
       )
@@ -2661,6 +2681,7 @@ export class WalletService {
       currency,
       network: row.network,
       address,
+      ...(row.destinationTag ? { destinationTag: row.destinationTag } : {}),
     });
     await this.drizzle.db
       .update(walletWithdrawalAddress)
@@ -2687,6 +2708,7 @@ export class WalletService {
       currency: input.currency,
       network: input.network,
       address: input.address,
+      ...(input.destinationTag ? { destinationTag: input.destinationTag } : {}),
     });
     return {
       providerName: await this.providerNameFor(input.currency, input.network),

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -778,6 +778,7 @@ export class WalletService {
           amount,
           currency,
           status: 'completed',
+          direction: 'credit',
           rail: this.resolveRail(currency),
           providerName: provider,
           providerRefId: psp.externalId,
@@ -877,6 +878,7 @@ export class WalletService {
           amount,
           currency,
           status: 'completed',
+          direction,
           reviewedBy: adminId,
           reviewedAt: new Date(),
           reviewReason: reason,
@@ -1041,7 +1043,12 @@ export class WalletService {
       rawIdempotencyKey: string | undefined;
       amount: string;
       currency: string;
-      values: Omit<typeof walletTransaction.$inferInsert, 'idempotencyKey'>;
+      // `direction` is nullable on the column (historical rows predate it) but every
+      // new insert must set it explicitly - narrowed to required+non-null here so a
+      // caller that forgets it fails to typecheck instead of writing another NULL row.
+      values: Omit<typeof walletTransaction.$inferInsert, 'idempotencyKey' | 'direction'> & {
+        direction: ManualAdjustmentDirection;
+      };
     },
   ): Promise<{ row: WalletTransaction; replayed: boolean }> {
     const idempotencyKey = rawIdempotencyKey
@@ -1156,6 +1163,7 @@ export class WalletService {
             amount,
             currency,
             status: 'pending',
+            direction: 'debit',
             rail: this.resolveRail(currency),
             network: settlementNetwork,
             destinationAddress: destinationAddress ?? null,
@@ -2272,6 +2280,7 @@ export class WalletService {
         currency: tx.currency,
         network: tx.network,
         status: tx.status,
+        direction: tx.direction,
         createdAt: tx.createdAt.toISOString(),
         reviewedBy: includeInternal ? tx.reviewedBy : null,
         reviewedAt: includeInternal ? (tx.reviewedAt?.toISOString() ?? null) : null,
@@ -2408,6 +2417,7 @@ export class WalletService {
           amount: event.amount,
           currency: event.currency,
           status: 'completed',
+          direction: 'credit',
           rail: this.resolveRail(event.currency),
           // Prefer the chain the vendor reported; fall back to the one the address was
           // issued on, which is the only network an address-only webhook can imply.


### PR DESCRIPTION
## What

Four commits on the wallet money path. The first two were already on the branch; the last two are new.

- `feat(wallet): carry a destination tag through the withdrawal path`
- `feat(wallet): show the destination tag on the withdrawal queue`
- `feat(wallet): record a direction on every ledger row and stream balance changes`
- `fix(server): keep sse responses untransformed end to end`

## Ledger direction

`wallet_transaction` gains a `direction` column. It used to be inferred from `type`, which is fine for eight of them and wrong for three: `gift`, `rain` and `tip` write the **same** type for the sender's debit leg and the recipient's credit leg, so a row of one of those types had no recoverable direction at all.

`writeLedgerRow` now takes `direction` as a required parameter with no default. Both social-transfer legs route through it, so the compiler enforces this rather than a convention. `insertIdempotentTransaction` is narrowed the same way.

Migration `0014` backfills only the eight unambiguous types. Historical `gift`/`rain`/`tip` rows are left NULL deliberately: guessing would fabricate money-direction data that was never recorded. Consumers render an unknown direction with no sign.

## Balance stream

`wallet.streamBalance` publishes `{ eventId, currency, reason }` over an event iterator, with **no amount on the wire**. Carrying the number would make the stream itself a money surface, where a dropped or reordered frame leaves a stale balance and nothing to correct it. A signal lets the client refetch instead, which is cheap and self-correcting.

The channel is keyed on the session's user id, never on an input parameter.

## SSE responses opt out of transformation

Found while measuring the stream above: an end-to-end balance push took **11.8 seconds**, arriving in batches. Against the API directly it was **87ms**.

The cause is compression, not the transport. An SSE body is a sequence of small frames that only mean anything on arrival, and Next's built-in gzip held them until its own flush threshold. nginx and a CDN buffer the same way by default.

`text/event-stream` responses now carry `Cache-Control: no-store, no-transform` (the standards-defined opt-out, which the `compression` middleware Next bundles honours) plus `X-Accel-Buffering: no` for nginx's separate proxy-buffering stage. Ordinary responses keep plain `no-store` and stay compressed.

Measured after the change: 119 / 77 / 55 ms.

## Verification beyond CI

The e2e test database on a machine that migrated before the `0012`/`0013` rewrite in 37bd2d01 carries journal rows with no matching file and fails to migrate. Recreate `oss_igaming_test` before running the integration suites locally.