### PR TITLE
feat(notifications): in-app notifications backend

### DIFF
--- a/.changeset/notifications-list-pagination.md
+++ b/.changeset/notifications-list-pagination.md
@@ -1,7 +1,0 @@
----
-'@openora/core': minor
----
-
-`GET /notifications` now returns the shared offset-pagination envelope (`{ items, total, page, limit }`, via `paginated(NotificationSchema)`) instead of a bare `Notification[]`, and accepts `page`/`limit`/`sortBy`/`sortOrder` query params.
-
-BREAKING CHANGE: a consumer reading the old bare-array response (e.g. calling `.map()` directly on the payload) must switch to reading `.items` off the new envelope. The `useNotifications` React hook already returns the paginated shape.

--- a/.changeset/notifications-list-pagination.md
+++ b/.changeset/notifications-list-pagination.md
@@ -1,0 +1,7 @@
+---
+'@openora/core': minor
+---
+
+`GET /notifications` now returns the shared offset-pagination envelope (`{ items, total, page, limit }`, via `paginated(NotificationSchema)`) instead of a bare `Notification[]`, and accepts `page`/`limit`/`sortBy`/`sortOrder` query params.
+
+BREAKING CHANGE: a consumer reading the old bare-array response (e.g. calling `.map()` directly on the payload) must switch to reading `.items` off the new envelope. The `useNotifications` React hook already returns the paginated shape.

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -118,8 +118,12 @@
       "routes": [
         "chat-commands.adminListCommands",
         "chat-commands.adminUpdateCommand",
+        "chat-commands.claimGift",
+        "chat-commands.getGift",
         "chat-commands.listCommands",
-        "chat-commands.mentionSearch"
+        "chat-commands.mentionSearch",
+        "chat-commands.postGift",
+        "chat-commands.postRain"
       ]
     },
     {
@@ -283,7 +287,9 @@
       "routes": [
         "notifications.list",
         "notifications.markAllRead",
-        "notifications.markRead"
+        "notifications.markRead",
+        "notifications.stream",
+        "notifications.unreadCount"
       ]
     },
     {
@@ -342,6 +348,19 @@
       ]
     },
     {
+      "id": "social-transfers",
+      "group": "engagement",
+      "tables": [
+        "player_donate",
+        "player_gift",
+        "player_rain",
+        "player_rain_receiver"
+      ],
+      "routes": [
+        "social-transfers.sendDonate"
+      ]
+    },
+    {
       "id": "tag",
       "group": "pam",
       "tables": [
@@ -369,8 +388,6 @@
         "wallet_asset",
         "wallet_auto_withdrawal_config",
         "wallet_balance",
-        "wallet_bonus_credit",
-        "wallet_bonus_rollover_config",
         "wallet_custody_sweep",
         "wallet_deposit_address",
         "wallet_job_run",
@@ -381,14 +398,12 @@
       ],
       "routes": [
         "wallet.approve",
-        "wallet.bonusRolloverStatus",
         "wallet.create",
         "wallet.create",
         "wallet.delete",
         "wallet.delete",
         "wallet.delete",
         "wallet.deposit",
-        "wallet.get",
         "wallet.get",
         "wallet.get",
         "wallet.getAddress",
@@ -408,9 +423,7 @@
         "wallet.run",
         "wallet.set",
         "wallet.set",
-        "wallet.set",
         "wallet.setActiveCurrency",
-        "wallet.streamBalance",
         "wallet.update",
         "wallet.webhook",
         "wallet.webhookForProvider",
@@ -471,6 +484,7 @@
         "packages/core/src/engagement/chat-commands/plugin.ts",
         "packages/core/src/engagement/chat/plugin.ts",
         "packages/core/src/engagement/notifications/plugin.ts",
+        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/pam/identity/plugin.ts",
         "packages/core/src/pam/player-management/plugin.ts",
         "packages/core/src/pam/tag/plugin.ts",
@@ -505,6 +519,7 @@
         "packages/core/src/compliance/plugin.ts",
         "packages/core/src/engagement/chat-commands/plugin.ts",
         "packages/core/src/engagement/chat/plugin.ts",
+        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/pam/player-management/plugin.ts",
         "packages/core/src/pam/player-note/plugin.ts",
         "packages/core/src/wallet/plugin.ts"
@@ -530,6 +545,7 @@
         "packages/core/src/casino/lobby/plugin.ts",
         "packages/core/src/cms/plugin.ts",
         "packages/core/src/compliance/plugin.ts",
+        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/iam/plugin.ts",
         "packages/core/src/pam/identity/plugin.ts"
       ]
@@ -542,6 +558,7 @@
       "boundIn": [
         "packages/core/src/engagement/chat-commands/plugin.ts",
         "packages/core/src/engagement/chat/plugin.ts",
+        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/pam/player-management/plugin.ts"
       ]
     },
@@ -560,7 +577,8 @@
       "token": "CHAT_ROOM_ACCESS",
       "status": "wired",
       "boundIn": [
-        "packages/core/src/engagement/chat/plugin.ts"
+        "packages/core/src/engagement/chat/plugin.ts",
+        "packages/core/src/engagement/social-transfers/plugin.ts"
       ]
     },
     {
@@ -569,7 +587,8 @@
       "token": "CHAT_SYSTEM_WRITER",
       "status": "wired",
       "boundIn": [
-        "packages/core/src/engagement/chat/plugin.ts"
+        "packages/core/src/engagement/chat/plugin.ts",
+        "packages/core/src/engagement/social-transfers/plugin.ts"
       ]
     },
     {
@@ -628,6 +647,16 @@
       "status": "wired",
       "boundIn": [
         "packages/core/src/compliance/plugin.ts"
+      ]
+    },
+    {
+      "category": "gift-commands",
+      "interface": "SendGiftArgs",
+      "token": "GIFT_COMMANDS",
+      "status": "wired",
+      "boundIn": [
+        "packages/core/src/engagement/chat-commands/plugin.ts",
+        "packages/core/src/engagement/social-transfers/plugin.ts"
       ]
     },
     {
@@ -760,6 +789,16 @@
       ]
     },
     {
+      "category": "rain-commands",
+      "interface": "SendRainArgs",
+      "token": "RAIN_COMMANDS",
+      "status": "wired",
+      "boundIn": [
+        "packages/core/src/engagement/chat-commands/plugin.ts",
+        "packages/core/src/engagement/social-transfers/plugin.ts"
+      ]
+    },
+    {
       "category": "realtime",
       "interface": "RealtimePresence",
       "token": "REALTIME_TRANSPORT",
@@ -767,7 +806,7 @@
       "boundIn": [
         "packages/core/src/compliance/plugin.ts",
         "packages/core/src/engagement/chat/plugin.ts",
-        "packages/core/src/wallet/plugin.ts"
+        "packages/core/src/engagement/notifications/plugin.ts"
       ]
     },
     {
@@ -826,6 +865,7 @@
       "status": "wired",
       "boundIn": [
         "packages/core/src/casino/gaming/plugin.ts",
+        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/wallet/plugin.ts"
       ]
     },
@@ -841,9 +881,13 @@
     }
   ],
   "events": [
+    "chat.donate.sent",
+    "chat.gift.claimed",
+    "chat.gift.sent",
     "chat.message.sent",
     "chat.private_room.created",
     "chat.private_room.deleted",
+    "chat.rain.distributed",
     "chat.room.created",
     "chat.room.deleted",
     "chat.room.member.banned",
@@ -853,6 +897,7 @@
     "chat.room.updated",
     "chat.user.blocked",
     "chat.user.ignored",
+    "chat.user.mentioned",
     "chat.user.unblocked",
     "chat.user.unignored",
     "cms.banner.created",
@@ -896,7 +941,6 @@
     "identity.user.phone_login",
     "identity.user.reactivated",
     "identity.user.registered",
-    "identity.user.registration.failed",
     "identity.user.unauthorized_access",
     "identity.user.unlocked",
     "notifications.created",
@@ -919,7 +963,6 @@
     "tag.player.assigned",
     "tag.player.removed",
     "tag.rule.upserted",
-    "wallet.bonus_rollover.completed",
     "wallet.deposit.completed",
     "wallet.manual_adjustment.created",
     "wallet.reconciliation.alert",
@@ -1079,30 +1122,6 @@
       "file": "packages/core/src/engagement/chat/contract/index.ts"
     },
     {
-      "name": "BonusCreditSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
-      "name": "BonusCreditSourceTypeSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
-      "name": "BonusCreditStatusSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
-      "name": "BonusRolloverConfigSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
-      "name": "BonusRolloverStatusInputSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
-      "name": "BonusRolloverStatusSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
       "name": "BrandingSchema",
       "file": "packages/core/src/contracts/schemas/igaming-config.ts"
     },
@@ -1139,24 +1158,12 @@
       "file": "packages/core/src/contracts/schemas/identity.ts"
     },
     {
-      "name": "ChatAttachmentKindSchema",
-      "file": "packages/core/src/contracts/schemas/chat-attachment.ts"
-    },
-    {
-      "name": "ChatAttachmentSchema",
-      "file": "packages/core/src/contracts/schemas/chat-attachment.ts"
-    },
-    {
       "name": "ChatCommandDescriptorSchema",
       "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
     },
     {
       "name": "ChatCommandTypeSchema",
       "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
-    },
-    {
-      "name": "ChatConfigSchema",
-      "file": "packages/core/src/contracts/schemas/platform-config.ts"
     },
     {
       "name": "ChatConnectionGrantSchema",
@@ -1239,6 +1246,10 @@
       "file": "packages/core/src/engagement/chat/contract/index.ts"
     },
     {
+      "name": "ClaimGiftOutputSchema",
+      "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
+    },
+    {
       "name": "ClientMetaSchema",
       "file": "packages/core/src/contracts/schemas/common.ts"
     },
@@ -1304,10 +1315,6 @@
     },
     {
       "name": "DepositInputSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
-      "name": "DestinationTagInputSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
@@ -1457,6 +1464,10 @@
     {
       "name": "GiftCommandMetadataSchema",
       "file": "packages/core/src/contracts/schemas/chat-command-metadata.ts"
+    },
+    {
+      "name": "GiftStateSchema",
+      "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
     },
     {
       "name": "GrantInputSchema",
@@ -1647,6 +1658,10 @@
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
+      "name": "MarkNotificationReadOutputSchema",
+      "file": "packages/core/src/engagement/notifications/contract/index.ts"
+    },
+    {
       "name": "MemberSchema",
       "file": "packages/core/src/contracts/schemas/identity.ts"
     },
@@ -1675,7 +1690,19 @@
       "file": "packages/core/src/analytics/contract/financial.ts"
     },
     {
+      "name": "NotificationCountSchema",
+      "file": "packages/core/src/engagement/notifications/contract/index.ts"
+    },
+    {
+      "name": "NotificationDataSchema",
+      "file": "packages/core/src/engagement/notifications/contract/index.ts"
+    },
+    {
       "name": "NotificationSchema",
+      "file": "packages/core/src/engagement/notifications/contract/index.ts"
+    },
+    {
+      "name": "NotificationSortBySchema",
       "file": "packages/core/src/engagement/notifications/contract/index.ts"
     },
     {
@@ -1701,10 +1728,6 @@
     {
       "name": "PaginatedPlayerSearchArgsSchema",
       "file": "packages/core/src/contracts/schemas/player.ts"
-    },
-    {
-      "name": "PasswordSchema",
-      "file": "packages/core/src/contracts/schemas/identity.ts"
     },
     {
       "name": "PaymentWebhookInputSchema",
@@ -1839,6 +1862,14 @@
       "file": "packages/core/src/casino/gaming/contract/index.ts"
     },
     {
+      "name": "PostGiftInputSchema",
+      "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
+    },
+    {
+      "name": "PostRainInputSchema",
+      "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
+    },
+    {
       "name": "ProfileCommandMetadataSchema",
       "file": "packages/core/src/contracts/schemas/chat-command-metadata.ts"
     },
@@ -1869,10 +1900,6 @@
     {
       "name": "RegistrationConfigSchema",
       "file": "packages/core/src/contracts/schemas/platform-config.ts"
-    },
-    {
-      "name": "RegistrationFailureReasonSchema",
-      "file": "packages/core/src/contracts/schemas/identity.ts"
     },
     {
       "name": "RegistrationsOverTimePointSchema",
@@ -1908,10 +1935,6 @@
     },
     {
       "name": "RequestPasswordResetInputSchema",
-      "file": "packages/core/src/contracts/schemas/identity.ts"
-    },
-    {
-      "name": "ResendEmailVerificationInputSchema",
       "file": "packages/core/src/contracts/schemas/identity.ts"
     },
     {
@@ -1963,16 +1986,12 @@
       "file": "packages/core/src/compliance/contract/rg.ts"
     },
     {
+      "name": "SendDonateInputSchema",
+      "file": "packages/core/src/engagement/social-transfers/contract/index.ts"
+    },
+    {
       "name": "SendFriendRequestInputSchema",
       "file": "packages/core/src/engagement/social/contract/index.ts"
-    },
-    {
-      "name": "SendGlobalMessageInputSchema",
-      "file": "packages/core/src/engagement/chat/contract/index.ts"
-    },
-    {
-      "name": "SendRoomMessageInputSchema",
-      "file": "packages/core/src/engagement/chat/contract/index.ts"
     },
     {
       "name": "SessionItemSchema",
@@ -1996,10 +2015,6 @@
     },
     {
       "name": "SetAutoWithdrawalRuleInputSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
-      "name": "SetBonusRolloverConfigInputSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
@@ -2155,19 +2170,11 @@
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
-      "name": "WalletBalanceChangeReasonSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
       "name": "WalletBalanceSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
       "name": "WalletBalancesSchema",
-      "file": "packages/core/src/wallet/contract/index.ts"
-    },
-    {
-      "name": "WalletBalanceUpdateSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1702,6 +1702,10 @@
       "file": "packages/core/src/engagement/notifications/contract/index.ts"
     },
     {
+      "name": "NotificationsConfigSchema",
+      "file": "packages/core/src/contracts/schemas/platform-config.ts"
+    },
+    {
       "name": "NotificationSortBySchema",
       "file": "packages/core/src/engagement/notifications/contract/index.ts"
     },

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -118,12 +118,8 @@
       "routes": [
         "chat-commands.adminListCommands",
         "chat-commands.adminUpdateCommand",
-        "chat-commands.claimGift",
-        "chat-commands.getGift",
         "chat-commands.listCommands",
-        "chat-commands.mentionSearch",
-        "chat-commands.postGift",
-        "chat-commands.postRain"
+        "chat-commands.mentionSearch"
       ]
     },
     {
@@ -348,19 +344,6 @@
       ]
     },
     {
-      "id": "social-transfers",
-      "group": "engagement",
-      "tables": [
-        "player_donate",
-        "player_gift",
-        "player_rain",
-        "player_rain_receiver"
-      ],
-      "routes": [
-        "social-transfers.sendDonate"
-      ]
-    },
-    {
       "id": "tag",
       "group": "pam",
       "tables": [
@@ -388,6 +371,8 @@
         "wallet_asset",
         "wallet_auto_withdrawal_config",
         "wallet_balance",
+        "wallet_bonus_credit",
+        "wallet_bonus_rollover_config",
         "wallet_custody_sweep",
         "wallet_deposit_address",
         "wallet_job_run",
@@ -398,12 +383,14 @@
       ],
       "routes": [
         "wallet.approve",
+        "wallet.bonusRolloverStatus",
         "wallet.create",
         "wallet.create",
         "wallet.delete",
         "wallet.delete",
         "wallet.delete",
         "wallet.deposit",
+        "wallet.get",
         "wallet.get",
         "wallet.get",
         "wallet.getAddress",
@@ -423,7 +410,9 @@
         "wallet.run",
         "wallet.set",
         "wallet.set",
+        "wallet.set",
         "wallet.setActiveCurrency",
+        "wallet.streamBalance",
         "wallet.update",
         "wallet.webhook",
         "wallet.webhookForProvider",
@@ -484,7 +473,6 @@
         "packages/core/src/engagement/chat-commands/plugin.ts",
         "packages/core/src/engagement/chat/plugin.ts",
         "packages/core/src/engagement/notifications/plugin.ts",
-        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/pam/identity/plugin.ts",
         "packages/core/src/pam/player-management/plugin.ts",
         "packages/core/src/pam/tag/plugin.ts",
@@ -519,7 +507,6 @@
         "packages/core/src/compliance/plugin.ts",
         "packages/core/src/engagement/chat-commands/plugin.ts",
         "packages/core/src/engagement/chat/plugin.ts",
-        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/pam/player-management/plugin.ts",
         "packages/core/src/pam/player-note/plugin.ts",
         "packages/core/src/wallet/plugin.ts"
@@ -545,7 +532,6 @@
         "packages/core/src/casino/lobby/plugin.ts",
         "packages/core/src/cms/plugin.ts",
         "packages/core/src/compliance/plugin.ts",
-        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/iam/plugin.ts",
         "packages/core/src/pam/identity/plugin.ts"
       ]
@@ -558,7 +544,6 @@
       "boundIn": [
         "packages/core/src/engagement/chat-commands/plugin.ts",
         "packages/core/src/engagement/chat/plugin.ts",
-        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/pam/player-management/plugin.ts"
       ]
     },
@@ -577,8 +562,7 @@
       "token": "CHAT_ROOM_ACCESS",
       "status": "wired",
       "boundIn": [
-        "packages/core/src/engagement/chat/plugin.ts",
-        "packages/core/src/engagement/social-transfers/plugin.ts"
+        "packages/core/src/engagement/chat/plugin.ts"
       ]
     },
     {
@@ -587,8 +571,7 @@
       "token": "CHAT_SYSTEM_WRITER",
       "status": "wired",
       "boundIn": [
-        "packages/core/src/engagement/chat/plugin.ts",
-        "packages/core/src/engagement/social-transfers/plugin.ts"
+        "packages/core/src/engagement/chat/plugin.ts"
       ]
     },
     {
@@ -647,16 +630,6 @@
       "status": "wired",
       "boundIn": [
         "packages/core/src/compliance/plugin.ts"
-      ]
-    },
-    {
-      "category": "gift-commands",
-      "interface": "SendGiftArgs",
-      "token": "GIFT_COMMANDS",
-      "status": "wired",
-      "boundIn": [
-        "packages/core/src/engagement/chat-commands/plugin.ts",
-        "packages/core/src/engagement/social-transfers/plugin.ts"
       ]
     },
     {
@@ -789,16 +762,6 @@
       ]
     },
     {
-      "category": "rain-commands",
-      "interface": "SendRainArgs",
-      "token": "RAIN_COMMANDS",
-      "status": "wired",
-      "boundIn": [
-        "packages/core/src/engagement/chat-commands/plugin.ts",
-        "packages/core/src/engagement/social-transfers/plugin.ts"
-      ]
-    },
-    {
       "category": "realtime",
       "interface": "RealtimePresence",
       "token": "REALTIME_TRANSPORT",
@@ -806,7 +769,8 @@
       "boundIn": [
         "packages/core/src/compliance/plugin.ts",
         "packages/core/src/engagement/chat/plugin.ts",
-        "packages/core/src/engagement/notifications/plugin.ts"
+        "packages/core/src/engagement/notifications/plugin.ts",
+        "packages/core/src/wallet/plugin.ts"
       ]
     },
     {
@@ -865,7 +829,6 @@
       "status": "wired",
       "boundIn": [
         "packages/core/src/casino/gaming/plugin.ts",
-        "packages/core/src/engagement/social-transfers/plugin.ts",
         "packages/core/src/wallet/plugin.ts"
       ]
     },
@@ -881,13 +844,9 @@
     }
   ],
   "events": [
-    "chat.donate.sent",
-    "chat.gift.claimed",
-    "chat.gift.sent",
     "chat.message.sent",
     "chat.private_room.created",
     "chat.private_room.deleted",
-    "chat.rain.distributed",
     "chat.room.created",
     "chat.room.deleted",
     "chat.room.member.banned",
@@ -941,6 +900,7 @@
     "identity.user.phone_login",
     "identity.user.reactivated",
     "identity.user.registered",
+    "identity.user.registration.failed",
     "identity.user.unauthorized_access",
     "identity.user.unlocked",
     "notifications.created",
@@ -963,6 +923,7 @@
     "tag.player.assigned",
     "tag.player.removed",
     "tag.rule.upserted",
+    "wallet.bonus_rollover.completed",
     "wallet.deposit.completed",
     "wallet.manual_adjustment.created",
     "wallet.reconciliation.alert",
@@ -1122,6 +1083,30 @@
       "file": "packages/core/src/engagement/chat/contract/index.ts"
     },
     {
+      "name": "BonusCreditSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "BonusCreditSourceTypeSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "BonusCreditStatusSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "BonusRolloverConfigSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "BonusRolloverStatusInputSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "BonusRolloverStatusSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
       "name": "BrandingSchema",
       "file": "packages/core/src/contracts/schemas/igaming-config.ts"
     },
@@ -1158,12 +1143,24 @@
       "file": "packages/core/src/contracts/schemas/identity.ts"
     },
     {
+      "name": "ChatAttachmentKindSchema",
+      "file": "packages/core/src/contracts/schemas/chat-attachment.ts"
+    },
+    {
+      "name": "ChatAttachmentSchema",
+      "file": "packages/core/src/contracts/schemas/chat-attachment.ts"
+    },
+    {
       "name": "ChatCommandDescriptorSchema",
       "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
     },
     {
       "name": "ChatCommandTypeSchema",
       "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
+    },
+    {
+      "name": "ChatConfigSchema",
+      "file": "packages/core/src/contracts/schemas/platform-config.ts"
     },
     {
       "name": "ChatConnectionGrantSchema",
@@ -1246,10 +1243,6 @@
       "file": "packages/core/src/engagement/chat/contract/index.ts"
     },
     {
-      "name": "ClaimGiftOutputSchema",
-      "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
-    },
-    {
       "name": "ClientMetaSchema",
       "file": "packages/core/src/contracts/schemas/common.ts"
     },
@@ -1315,6 +1308,10 @@
     },
     {
       "name": "DepositInputSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "DestinationTagInputSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
@@ -1464,10 +1461,6 @@
     {
       "name": "GiftCommandMetadataSchema",
       "file": "packages/core/src/contracts/schemas/chat-command-metadata.ts"
-    },
-    {
-      "name": "GiftStateSchema",
-      "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
     },
     {
       "name": "GrantInputSchema",
@@ -1734,6 +1727,10 @@
       "file": "packages/core/src/contracts/schemas/player.ts"
     },
     {
+      "name": "PasswordSchema",
+      "file": "packages/core/src/contracts/schemas/identity.ts"
+    },
+    {
       "name": "PaymentWebhookInputSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
@@ -1866,14 +1863,6 @@
       "file": "packages/core/src/casino/gaming/contract/index.ts"
     },
     {
-      "name": "PostGiftInputSchema",
-      "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
-    },
-    {
-      "name": "PostRainInputSchema",
-      "file": "packages/core/src/engagement/chat-commands/contract/index.ts"
-    },
-    {
       "name": "ProfileCommandMetadataSchema",
       "file": "packages/core/src/contracts/schemas/chat-command-metadata.ts"
     },
@@ -1904,6 +1893,10 @@
     {
       "name": "RegistrationConfigSchema",
       "file": "packages/core/src/contracts/schemas/platform-config.ts"
+    },
+    {
+      "name": "RegistrationFailureReasonSchema",
+      "file": "packages/core/src/contracts/schemas/identity.ts"
     },
     {
       "name": "RegistrationsOverTimePointSchema",
@@ -1939,6 +1932,10 @@
     },
     {
       "name": "RequestPasswordResetInputSchema",
+      "file": "packages/core/src/contracts/schemas/identity.ts"
+    },
+    {
+      "name": "ResendEmailVerificationInputSchema",
       "file": "packages/core/src/contracts/schemas/identity.ts"
     },
     {
@@ -1990,12 +1987,16 @@
       "file": "packages/core/src/compliance/contract/rg.ts"
     },
     {
-      "name": "SendDonateInputSchema",
-      "file": "packages/core/src/engagement/social-transfers/contract/index.ts"
-    },
-    {
       "name": "SendFriendRequestInputSchema",
       "file": "packages/core/src/engagement/social/contract/index.ts"
+    },
+    {
+      "name": "SendGlobalMessageInputSchema",
+      "file": "packages/core/src/engagement/chat/contract/index.ts"
+    },
+    {
+      "name": "SendRoomMessageInputSchema",
+      "file": "packages/core/src/engagement/chat/contract/index.ts"
     },
     {
       "name": "SessionItemSchema",
@@ -2019,6 +2020,10 @@
     },
     {
       "name": "SetAutoWithdrawalRuleInputSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "SetBonusRolloverConfigInputSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
@@ -2174,11 +2179,19 @@
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
+      "name": "WalletBalanceChangeReasonSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
       "name": "WalletBalanceSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
       "name": "WalletBalancesSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "WalletBalanceUpdateSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {

--- a/docs/platform/system-design.md
+++ b/docs/platform/system-design.md
@@ -289,20 +289,20 @@ flowchart TB
 
 <!-- gen:catalog-reference -->
 
-Generated from `docs/catalog.json` - 18 modules, 219 routes, 40 adapter ports, 87 events. Edit the code, then run `pnpm gen:catalog`.
+Generated from `docs/catalog.json` - 19 modules, 225 routes, 42 adapter ports, 92 events. Edit the code, then run `pnpm gen:catalog`.
 
-| Domain                        | Modules                                                    | Tables                                                                              | Routes |
-| ----------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------ |
-| `@openora/core/admin-console` | admin-console                                              | (owns none - reads through ports)                                                   | 8      |
-| `@openora/core/analytics`     | analytics                                                  | (owns none - reads through ports)                                                   | 3      |
-| `@openora/core/audit`         | audit                                                      | audit_log                                                                           | 2      |
-| `@openora/core/casino`        | gaming · lobby                                             | featured_slot, game, game_round, lobby_category + 1 more                            | 9      |
-| `@openora/core/cms`           | cms                                                        | banner, page                                                                        | 10     |
-| `@openora/core/compliance`    | compliance                                                 | geo_rule, kyc_verification, rg_exclusion, rg_flag + 1 more                          | 20     |
-| `@openora/core/engagement`    | chat · chat-commands · notifications · social              | chat_command_config, chat_message, chat_mute, chat_platform_ban + 11 more           | 68     |
-| `@openora/core/iam`           | iam                                                        | admin_invitation, admin_role, admin_role_assignment, admin_role_permission          | 17     |
-| `@openora/core/pam`           | identity · player-management · player-note · profile · tag | account, player, player_note, player_tag + 7 more                                   | 47     |
-| `@openora/core/wallet`        | wallet                                                     | auto_withdrawal_rule, wallet, wallet_asset, wallet_auto_withdrawal_config + 10 more | 35     |
+| Domain                        | Modules                                                          | Tables                                                                              | Routes |
+| ----------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------ |
+| `@openora/core/admin-console` | admin-console                                                    | (owns none - reads through ports)                                                   | 8      |
+| `@openora/core/analytics`     | analytics                                                        | (owns none - reads through ports)                                                   | 3      |
+| `@openora/core/audit`         | audit                                                            | audit_log                                                                           | 2      |
+| `@openora/core/casino`        | gaming · lobby                                                   | featured_slot, game, game_round, lobby_category + 1 more                            | 9      |
+| `@openora/core/cms`           | cms                                                              | banner, page                                                                        | 10     |
+| `@openora/core/compliance`    | compliance                                                       | geo_rule, kyc_verification, rg_exclusion, rg_flag + 1 more                          | 20     |
+| `@openora/core/engagement`    | chat · chat-commands · notifications · social · social-transfers | chat_command_config, chat_message, chat_mute, chat_platform_ban + 15 more           | 75     |
+| `@openora/core/iam`           | iam                                                              | admin_invitation, admin_role, admin_role_assignment, admin_role_permission          | 17     |
+| `@openora/core/pam`           | identity · player-management · player-note · profile · tag       | account, player, player_note, player_tag + 7 more                                   | 47     |
+| `@openora/core/wallet`        | wallet                                                           | auto_withdrawal_rule, wallet, wallet_asset, wallet_auto_withdrawal_config + 10 more | 34     |
 
 <!-- /gen:catalog-reference -->
 

--- a/docs/platform/system-design.md
+++ b/docs/platform/system-design.md
@@ -289,20 +289,20 @@ flowchart TB
 
 <!-- gen:catalog-reference -->
 
-Generated from `docs/catalog.json` - 19 modules, 225 routes, 42 adapter ports, 92 events. Edit the code, then run `pnpm gen:catalog`.
+Generated from `docs/catalog.json` - 18 modules, 221 routes, 40 adapter ports, 88 events. Edit the code, then run `pnpm gen:catalog`.
 
-| Domain                        | Modules                                                          | Tables                                                                              | Routes |
-| ----------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------ |
-| `@openora/core/admin-console` | admin-console                                                    | (owns none - reads through ports)                                                   | 8      |
-| `@openora/core/analytics`     | analytics                                                        | (owns none - reads through ports)                                                   | 3      |
-| `@openora/core/audit`         | audit                                                            | audit_log                                                                           | 2      |
-| `@openora/core/casino`        | gaming · lobby                                                   | featured_slot, game, game_round, lobby_category + 1 more                            | 9      |
-| `@openora/core/cms`           | cms                                                              | banner, page                                                                        | 10     |
-| `@openora/core/compliance`    | compliance                                                       | geo_rule, kyc_verification, rg_exclusion, rg_flag + 1 more                          | 20     |
-| `@openora/core/engagement`    | chat · chat-commands · notifications · social · social-transfers | chat_command_config, chat_message, chat_mute, chat_platform_ban + 15 more           | 75     |
-| `@openora/core/iam`           | iam                                                              | admin_invitation, admin_role, admin_role_assignment, admin_role_permission          | 17     |
-| `@openora/core/pam`           | identity · player-management · player-note · profile · tag       | account, player, player_note, player_tag + 7 more                                   | 47     |
-| `@openora/core/wallet`        | wallet                                                           | auto_withdrawal_rule, wallet, wallet_asset, wallet_auto_withdrawal_config + 10 more | 34     |
+| Domain                        | Modules                                                    | Tables                                                                              | Routes |
+| ----------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------ |
+| `@openora/core/admin-console` | admin-console                                              | (owns none - reads through ports)                                                   | 8      |
+| `@openora/core/analytics`     | analytics                                                  | (owns none - reads through ports)                                                   | 3      |
+| `@openora/core/audit`         | audit                                                      | audit_log                                                                           | 2      |
+| `@openora/core/casino`        | gaming · lobby                                             | featured_slot, game, game_round, lobby_category + 1 more                            | 9      |
+| `@openora/core/cms`           | cms                                                        | banner, page                                                                        | 10     |
+| `@openora/core/compliance`    | compliance                                                 | geo_rule, kyc_verification, rg_exclusion, rg_flag + 1 more                          | 20     |
+| `@openora/core/engagement`    | chat · chat-commands · notifications · social              | chat_command_config, chat_message, chat_mute, chat_platform_ban + 11 more           | 70     |
+| `@openora/core/iam`           | iam                                                        | admin_invitation, admin_role, admin_role_assignment, admin_role_permission          | 17     |
+| `@openora/core/pam`           | identity · player-management · player-note · profile · tag | account, player, player_note, player_tag + 7 more                                   | 47     |
+| `@openora/core/wallet`        | wallet                                                     | auto_withdrawal_rule, wallet, wallet_asset, wallet_auto_withdrawal_config + 10 more | 35     |
 
 <!-- /gen:catalog-reference -->
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -254,6 +254,11 @@
       "import": "./dist/engagement/server.js",
       "default": "./dist/engagement/server.js"
     },
+    "./engagement/react": {
+      "types": "./dist/engagement/react.d.ts",
+      "import": "./dist/engagement/react.js",
+      "default": "./dist/engagement/react.js"
+    },
     "./engagement/contracts": {
       "types": "./dist/engagement/contracts.d.ts",
       "import": "./dist/engagement/contracts.js",

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -217,15 +217,6 @@ export const domainEventSchemas = {
     currency: CurrencyCodeSchema,
     creditedAmount: MoneyAmountSchema,
   }),
-  // Reserved: no emitter exists yet. A future settlement engine publishes this.
-  'gaming.bet.settled': z.object({
-    roundId: UuidSchema,
-    userId: UuidSchema,
-    playerId: UuidSchema.nullable(),
-    outcome: z.enum(['win', 'loss']),
-    amount: MoneyAmountSchema,
-    currency: CurrencyCodeSchema,
-  }),
 
   'chat.message.sent': z.object({
     messageId: UuidSchema,

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -535,14 +535,6 @@ export const domainEventSchemas = {
     requesterId: UuidSchema,
     addresseeId: UuidSchema,
   }),
-
-  // Reserved: no bonus module exists yet and nothing emits this.
-  'bonus.granted': z.object({
-    bonusId: UuidSchema,
-    userId: UuidSchema,
-    amount: MoneyAmountSchema,
-    currency: CurrencyCodeSchema,
-  }),
 } as const;
 
 export type DomainEventName = keyof typeof domainEventSchemas;

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -217,6 +217,15 @@ export const domainEventSchemas = {
     currency: CurrencyCodeSchema,
     creditedAmount: MoneyAmountSchema,
   }),
+  // Reserved: no emitter exists yet. A future settlement engine publishes this.
+  'gaming.bet.settled': z.object({
+    roundId: UuidSchema,
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+    outcome: z.enum(['win', 'loss']),
+    amount: MoneyAmountSchema,
+    currency: CurrencyCodeSchema,
+  }),
 
   'chat.message.sent': z.object({
     messageId: UuidSchema,
@@ -525,6 +534,14 @@ export const domainEventSchemas = {
     friendshipId: UuidSchema,
     requesterId: UuidSchema,
     addresseeId: UuidSchema,
+  }),
+
+  // Reserved: no bonus module exists yet and nothing emits this.
+  'bonus.granted': z.object({
+    bonusId: UuidSchema,
+    userId: UuidSchema,
+    amount: MoneyAmountSchema,
+    currency: CurrencyCodeSchema,
   }),
 } as const;
 

--- a/packages/core/src/contracts/schemas/platform-config.ts
+++ b/packages/core/src/contracts/schemas/platform-config.ts
@@ -129,6 +129,24 @@ export const WalletConfigSchema = z
 
 export type WalletConfig = z.infer<typeof WalletConfigSchema>;
 
+export const NotificationsConfigSchema = z
+  .object({
+    /**
+     * In-app notification retention knobs. Static config, not a DB row - nothing
+     * here is edited during an incident. Absent means the built-in defaults apply.
+     */
+    retention: z
+      .object({
+        days: z.number().int().positive().default(30),
+        cron: z.string().default('0 3 * * *'),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export type NotificationsConfig = z.infer<typeof NotificationsConfigSchema>;
+
 export const RegistrationConfigSchema = z
   .object({
     /** Version recorded beside the player's affirmative terms acceptance. */
@@ -209,6 +227,8 @@ export const PlatformConfigSchema = z
     wallet: WalletConfigSchema.optional(),
     /** Required before public registration is enabled. */
     registration: RegistrationConfigSchema.optional(),
+    /** In-app notification retention knobs. Absent = built-in default (30 days). */
+    notifications: NotificationsConfigSchema.optional(),
     /**
      * Player-facing language codes the operator supports (eg `['en', 'es']`).
      * Undefined or empty means no restriction - any value is accepted.

--- a/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
+++ b/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
@@ -642,6 +642,113 @@ describe('ChatService.sendRoomMessage (real PG)', () => {
   });
 });
 
+describe('ChatService @mention detection (real PG)', () => {
+  function mentionDirectory(summaries: AdminPlayerSummary[]) {
+    return mock<AdminUserDirectory>({
+      lookupPlayers: async () => [],
+      getPlayerByUsername: vi
+        .fn()
+        .mockImplementation((username: string) =>
+          Promise.resolve(
+            summaries.find((s) => s.username.toLowerCase() === username.toLowerCase()) ?? null,
+          ),
+        ),
+    });
+  }
+
+  function summaryFor(userId: string, username: string): AdminPlayerSummary {
+    return {
+      playerId: randomUUID(),
+      userId,
+      username,
+      email: `${username}@example.com`,
+      kycStatus: null,
+      language: null,
+      avatarUrl: null,
+      createdAt: new Date(),
+      level: 1,
+      currency: 'USD',
+    };
+  }
+
+  it('resolves an @username in a room message and emits chat.user.mentioned', async () => {
+    const bobId = randomUUID();
+    const { svc, events } = makeService(mentionDirectory([summaryFor(bobId, 'bob')]));
+    const room = await seedRoom();
+
+    const msg = await svc.sendRoomMessage({
+      userId: randomUUID(),
+      username: 'alice',
+      roomId: room.id,
+      content: 'hello @bob, welcome',
+    });
+
+    await waitFor(() =>
+      vi.mocked(events.emit).mock.calls.some(([topic]) => topic === 'chat.user.mentioned'),
+    );
+    expect(events.emit).toHaveBeenCalledWith('chat.user.mentioned', {
+      mentionedUserId: bobId,
+      byUserId: msg.userId,
+      roomId: room.id,
+      messageId: msg.id,
+    });
+  });
+
+  it('resolves an @username in a global message with a null roomId', async () => {
+    const bobId = randomUUID();
+    const { svc, events } = makeService(mentionDirectory([summaryFor(bobId, 'bob')]));
+    const authorId = randomUUID();
+
+    const msg = await svc.sendGlobalMessage(authorId, 'alice', 'hey @bob');
+
+    await waitFor(() =>
+      vi.mocked(events.emit).mock.calls.some(([topic]) => topic === 'chat.user.mentioned'),
+    );
+    expect(events.emit).toHaveBeenCalledWith('chat.user.mentioned', {
+      mentionedUserId: bobId,
+      byUserId: authorId,
+      roomId: null,
+      messageId: msg.id,
+    });
+  });
+
+  it('excludes a self-mention', async () => {
+    const authorId = randomUUID();
+    const { svc, events } = makeService(mentionDirectory([summaryFor(authorId, 'alice')]));
+
+    await svc.sendGlobalMessage(authorId, 'alice', 'talking to myself @alice');
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events.emit).not.toHaveBeenCalledWith('chat.user.mentioned', expect.anything());
+  });
+
+  it('emits once per uniquely mentioned user even when repeated in the message', async () => {
+    const bobId = randomUUID();
+    const { svc, events } = makeService(mentionDirectory([summaryFor(bobId, 'bob')]));
+
+    await svc.sendGlobalMessage(randomUUID(), 'alice', '@bob @bob are you there @Bob?');
+
+    await waitFor(() =>
+      vi.mocked(events.emit).mock.calls.some(([topic]) => topic === 'chat.user.mentioned'),
+    );
+    const mentionCalls = vi
+      .mocked(events.emit)
+      .mock.calls.filter(([topic]) => topic === 'chat.user.mentioned');
+    expect(mentionCalls).toHaveLength(1);
+  });
+
+  it('silently drops an @token that does not resolve to a known username', async () => {
+    const { svc, events } = makeService(mentionDirectory([]));
+
+    await expect(
+      svc.sendGlobalMessage(randomUUID(), 'alice', 'hello @nobody'),
+    ).resolves.toBeDefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events.emit).not.toHaveBeenCalledWith('chat.user.mentioned', expect.anything());
+  });
+});
+
 describe('ChatService.deleteMessage (real PG)', () => {
   it('soft-deletes a message for a room owner and publishes a tombstone', async () => {
     const { svc } = makeService();

--- a/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
+++ b/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
@@ -699,7 +699,11 @@ describe('ChatService @mention detection (real PG)', () => {
     const { svc, events } = makeService(mentionDirectory([summaryFor(bobId, 'bob')]));
     const authorId = randomUUID();
 
-    const msg = await svc.sendGlobalMessage(authorId, 'alice', 'hey @bob');
+    const msg = await svc.sendGlobalMessage({
+      userId: authorId,
+      username: 'alice',
+      content: 'hey @bob',
+    });
 
     await waitFor(() =>
       vi.mocked(events.emit).mock.calls.some(([topic]) => topic === 'chat.user.mentioned'),
@@ -716,7 +720,11 @@ describe('ChatService @mention detection (real PG)', () => {
     const authorId = randomUUID();
     const { svc, events } = makeService(mentionDirectory([summaryFor(authorId, 'alice')]));
 
-    await svc.sendGlobalMessage(authorId, 'alice', 'talking to myself @alice');
+    await svc.sendGlobalMessage({
+      userId: authorId,
+      username: 'alice',
+      content: 'talking to myself @alice',
+    });
 
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(events.emit).not.toHaveBeenCalledWith('chat.user.mentioned', expect.anything());
@@ -726,7 +734,11 @@ describe('ChatService @mention detection (real PG)', () => {
     const bobId = randomUUID();
     const { svc, events } = makeService(mentionDirectory([summaryFor(bobId, 'bob')]));
 
-    await svc.sendGlobalMessage(randomUUID(), 'alice', '@bob @bob are you there @Bob?');
+    await svc.sendGlobalMessage({
+      userId: randomUUID(),
+      username: 'alice',
+      content: '@bob @bob are you there @Bob?',
+    });
 
     await waitFor(() =>
       vi.mocked(events.emit).mock.calls.some(([topic]) => topic === 'chat.user.mentioned'),
@@ -741,7 +753,7 @@ describe('ChatService @mention detection (real PG)', () => {
     const { svc, events } = makeService(mentionDirectory([]));
 
     await expect(
-      svc.sendGlobalMessage(randomUUID(), 'alice', 'hello @nobody'),
+      svc.sendGlobalMessage({ userId: randomUUID(), username: 'alice', content: 'hello @nobody' }),
     ).resolves.toBeDefined();
 
     await new Promise((resolve) => setTimeout(resolve, 20));
@@ -753,7 +765,11 @@ describe('ChatService @mention detection (real PG)', () => {
     const { svc, events } = makeService(mentionDirectory([summaryFor(acmeId, 'acme')]));
 
     await expect(
-      svc.sendGlobalMessage(randomUUID(), 'alice', 'contact me at info@acme.com'),
+      svc.sendGlobalMessage({
+        userId: randomUUID(),
+        username: 'alice',
+        content: 'contact me at info@acme.com',
+      }),
     ).resolves.toBeDefined();
 
     await new Promise((resolve) => setTimeout(resolve, 20));
@@ -766,7 +782,7 @@ describe('ChatService @mention detection (real PG)', () => {
     const { svc, events } = makeService(mentionDirectory([summaryFor(bobId, 'bob')]));
     await svc.blockUser(bobId, authorId);
 
-    await svc.sendGlobalMessage(authorId, 'alice', 'hello @bob');
+    await svc.sendGlobalMessage({ userId: authorId, username: 'alice', content: 'hello @bob' });
 
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(events.emit).not.toHaveBeenCalledWith('chat.user.mentioned', expect.anything());
@@ -776,7 +792,9 @@ describe('ChatService @mention detection (real PG)', () => {
     const authorId = randomUUID();
     const { svc, events } = makeService(mentionDirectory([summaryFor('not-a-valid-uuid', 'bob')]));
 
-    await expect(svc.sendGlobalMessage(authorId, 'alice', 'hello @bob')).resolves.toBeDefined();
+    await expect(
+      svc.sendGlobalMessage({ userId: authorId, username: 'alice', content: 'hello @bob' }),
+    ).resolves.toBeDefined();
 
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(events.emit).not.toHaveBeenCalledWith('chat.user.mentioned', expect.anything());

--- a/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
+++ b/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
@@ -747,6 +747,40 @@ describe('ChatService @mention detection (real PG)', () => {
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(events.emit).not.toHaveBeenCalledWith('chat.user.mentioned', expect.anything());
   });
+
+  it('does not treat the domain part of an email address as a mention', async () => {
+    const acmeId = randomUUID();
+    const { svc, events } = makeService(mentionDirectory([summaryFor(acmeId, 'acme')]));
+
+    await expect(
+      svc.sendGlobalMessage(randomUUID(), 'alice', 'contact me at info@acme.com'),
+    ).resolves.toBeDefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events.emit).not.toHaveBeenCalledWith('chat.user.mentioned', expect.anything());
+  });
+
+  it('does not emit chat.user.mentioned when the mentioned user has blocked the sender', async () => {
+    const bobId = randomUUID();
+    const authorId = randomUUID();
+    const { svc, events } = makeService(mentionDirectory([summaryFor(bobId, 'bob')]));
+    await svc.blockUser(bobId, authorId);
+
+    await svc.sendGlobalMessage(authorId, 'alice', 'hello @bob');
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events.emit).not.toHaveBeenCalledWith('chat.user.mentioned', expect.anything());
+  });
+
+  it('fails closed (does not emit) when the block check throws', async () => {
+    const authorId = randomUUID();
+    const { svc, events } = makeService(mentionDirectory([summaryFor('not-a-valid-uuid', 'bob')]));
+
+    await expect(svc.sendGlobalMessage(authorId, 'alice', 'hello @bob')).resolves.toBeDefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events.emit).not.toHaveBeenCalledWith('chat.user.mentioned', expect.anything());
+  });
 });
 
 describe('ChatService.deleteMessage (real PG)', () => {

--- a/packages/core/src/engagement/chat/service/chat.service.ts
+++ b/packages/core/src/engagement/chat/service/chat.service.ts
@@ -95,7 +95,7 @@ import {
 import { moderateContent, validateAttachment } from '../moderation/index.js';
 const logger = createLogger('chat');
 
-const MENTION_USERNAME_PATTERN = /@([a-zA-Z0-9_]{2,32})/g;
+const MENTION_USERNAME_PATTERN = /(?<![\w.])@([a-zA-Z0-9_]{2,32})/g;
 const MAX_MENTIONS_PER_MESSAGE = 20;
 const MENTION_RESOLVE_CONCURRENCY = 5;
 

--- a/packages/core/src/engagement/chat/service/chat.service.ts
+++ b/packages/core/src/engagement/chat/service/chat.service.ts
@@ -10,6 +10,7 @@ import {
   findOneOrThrow,
   serializeRow,
   pageToOffset,
+  mapConcurrent,
   withAdvisoryXactLock,
   type DrizzleDb,
   type DrizzleTx,
@@ -93,6 +94,57 @@ import {
 } from '../contract/constants.js';
 import { moderateContent, validateAttachment } from '../moderation/index.js';
 const logger = createLogger('chat');
+
+const MENTION_USERNAME_PATTERN = /@([a-zA-Z0-9_]{2,32})/g;
+const MAX_MENTIONS_PER_MESSAGE = 20;
+const MENTION_RESOLVE_CONCURRENCY = 5;
+
+function parseMentionedUsernames(content: string): string[] {
+  const usernames = new Set<string>();
+  for (const match of content.matchAll(MENTION_USERNAME_PATTERN)) {
+    const username = match[1];
+    if (username) {
+      usernames.add(username.toLowerCase());
+    }
+    if (usernames.size >= MAX_MENTIONS_PER_MESSAGE) {
+      break;
+    }
+  }
+  return [...usernames];
+}
+
+function emitMentions(
+  events: EventBus,
+  directory: AdminUserDirectory,
+  content: string,
+  byUserId: User['id'],
+  roomId: ChatRoom['id'] | null,
+  messageId: ChatMessage['id'],
+): void {
+  const usernames = parseMentionedUsernames(content);
+  if (usernames.length === 0) {
+    return;
+  }
+  void mapConcurrent(usernames, MENTION_RESOLVE_CONCURRENCY, (username) =>
+    directory.getPlayerByUsername(username).catch((err: unknown) => {
+      logger.error({ err, username, messageId }, 'chat mention lookup failed');
+      return null;
+    }),
+  )
+    .then((resolved) => {
+      const mentionedIds = new Set(
+        resolved.flatMap((summary) =>
+          summary && summary.userId !== byUserId ? [summary.userId] : [],
+        ),
+      );
+      for (const mentionedUserId of mentionedIds) {
+        events.emit('chat.user.mentioned', { mentionedUserId, byUserId, roomId, messageId });
+      }
+    })
+    .catch((err: unknown) => {
+      logger.error({ err, messageId }, 'chat mention resolution failed');
+    });
+}
 
 function publishChatEvent<T>(transport: RealtimeTransport, roomId: string | null, event: T): void {
   void Promise.resolve()
@@ -1140,6 +1192,7 @@ export class ChatService {
 
     const message = toPublicMessage(record);
     publishChatEvent(this.transport, roomId, message);
+    emitMentions(this.events, this.directory, safeContent, userId, roomId, record.id);
     return message;
   }
 
@@ -1216,6 +1269,7 @@ export class ChatService {
 
     const message = toPublicMessage(record);
     publishChatEvent(this.transport, null, message);
+    emitMentions(this.events, this.directory, safeContent, userId, null, record.id);
     return message;
   }
 

--- a/packages/core/src/engagement/chat/service/chat.service.ts
+++ b/packages/core/src/engagement/chat/service/chat.service.ts
@@ -113,37 +113,47 @@ function parseMentionedUsernames(content: string): string[] {
   return [...usernames];
 }
 
-function emitMentions(
-  events: EventBus,
-  directory: AdminUserDirectory,
-  content: string,
-  byUserId: User['id'],
-  roomId: ChatRoom['id'] | null,
-  messageId: ChatMessage['id'],
-): void {
+function emitMentions({
+  events,
+  directory,
+  isBlockedByMentioned,
+  content,
+  byUserId,
+  roomId,
+  messageId,
+}: {
+  events: EventBus;
+  directory: AdminUserDirectory;
+  isBlockedByMentioned: (mentionedUserId: User['id']) => Promise<boolean>;
+  content: string;
+  byUserId: User['id'];
+  roomId: ChatRoom['id'] | null;
+  messageId: ChatMessage['id'];
+}): void {
   const usernames = parseMentionedUsernames(content);
   if (usernames.length === 0) {
     return;
   }
-  void mapConcurrent(usernames, MENTION_RESOLVE_CONCURRENCY, (username) =>
-    directory.getPlayerByUsername(username).catch((err: unknown) => {
+  void mapConcurrent(usernames, MENTION_RESOLVE_CONCURRENCY, async (username) => {
+    const summary = await directory.getPlayerByUsername(username).catch((err: unknown) => {
       logger.error({ err, username, messageId }, 'chat mention lookup failed');
       return null;
-    }),
-  )
-    .then((resolved) => {
-      const mentionedIds = new Set(
-        resolved.flatMap((summary) =>
-          summary && summary.userId !== byUserId ? [summary.userId] : [],
-        ),
-      );
-      for (const mentionedUserId of mentionedIds) {
-        events.emit('chat.user.mentioned', { mentionedUserId, byUserId, roomId, messageId });
-      }
-    })
-    .catch((err: unknown) => {
-      logger.error({ err, messageId }, 'chat mention resolution failed');
     });
+    if (!summary || summary.userId === byUserId) {
+      return;
+    }
+    const mentionedUserId = summary.userId;
+    const blocked = await isBlockedByMentioned(mentionedUserId).catch((err: unknown) => {
+      logger.error({ err, mentionedUserId, messageId }, 'chat mention block check failed');
+      return true;
+    });
+    if (blocked) {
+      return;
+    }
+    events.emit('chat.user.mentioned', { mentionedUserId, byUserId, roomId, messageId });
+  }).catch((err: unknown) => {
+    logger.error({ err, messageId }, 'chat mention resolution failed');
+  });
 }
 
 function publishChatEvent<T>(transport: RealtimeTransport, roomId: string | null, event: T): void {
@@ -1192,7 +1202,16 @@ export class ChatService {
 
     const message = toPublicMessage(record);
     publishChatEvent(this.transport, roomId, message);
-    emitMentions(this.events, this.directory, safeContent, userId, roomId, record.id);
+    emitMentions({
+      events: this.events,
+      directory: this.directory,
+      isBlockedByMentioned: (mentionedUserId) =>
+        this.isBlocked(this.drizzle.db, mentionedUserId, userId),
+      content: safeContent,
+      byUserId: userId,
+      roomId,
+      messageId: record.id,
+    });
     return message;
   }
 
@@ -1269,7 +1288,16 @@ export class ChatService {
 
     const message = toPublicMessage(record);
     publishChatEvent(this.transport, null, message);
-    emitMentions(this.events, this.directory, safeContent, userId, null, record.id);
+    emitMentions({
+      events: this.events,
+      directory: this.directory,
+      isBlockedByMentioned: (mentionedUserId) =>
+        this.isBlocked(this.drizzle.db, mentionedUserId, userId),
+      content: safeContent,
+      byUserId: userId,
+      roomId: null,
+      messageId: record.id,
+    });
     return message;
   }
 
@@ -1565,7 +1593,11 @@ export class ChatService {
     return [...(await this.blockedIdsFor(viewerId))];
   }
 
-  async isBlocked(tx: DrizzleTx, blockerId: User['id'], blockedId: User['id']): Promise<boolean> {
+  async isBlocked(
+    tx: DrizzleDb | DrizzleTx,
+    blockerId: User['id'],
+    blockedId: User['id'],
+  ): Promise<boolean> {
     const [row] = await tx
       .select({ blockedId: chatUserBlock.blockedId })
       .from(chatUserBlock)

--- a/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
@@ -214,4 +214,129 @@ describe('notificationEventMap', () => {
     expect(entryFor('wallet.withdrawal.approved').sendEmail).toBe(true);
     expect(entryFor('wallet.withdrawal.rejected').sendEmail).toBe(true);
   });
+
+  describe('amount formatting in notification body text', () => {
+    const basePayloads = {
+      'wallet.withdrawal.approved': (amount: string) => ({
+        userId: randomUUID(),
+        amount,
+        currency: 'EUR',
+        transactionId: randomUUID(),
+        adminId: randomUUID(),
+      }),
+      'wallet.withdrawal.rejected': (amount: string) => ({
+        userId: randomUUID(),
+        amount,
+        currency: 'EUR',
+        transactionId: randomUUID(),
+        adminId: randomUUID(),
+        reason: 'test reason',
+      }),
+      'wallet.withdrawal.requested': (amount: string) => ({
+        userId: randomUUID(),
+        amount,
+        currency: 'EUR',
+        transactionId: randomUUID(),
+        playerId: null,
+      }),
+      'wallet.withdrawal.completed': (amount: string) => ({
+        userId: randomUUID(),
+        amount,
+        currency: 'EUR',
+        transactionId: randomUUID(),
+        playerId: null,
+      }),
+      'wallet.withdrawal.failed': (amount: string) => ({
+        userId: randomUUID(),
+        amount,
+        currency: 'EUR',
+        transactionId: randomUUID(),
+        adminId: randomUUID(),
+      }),
+      'wallet.deposit.completed': (amount: string) => ({
+        userId: randomUUID(),
+        amount,
+        currency: 'EUR',
+        transactionId: randomUUID(),
+        playerId: null,
+      }),
+      'wallet.manual_adjustment.created': (amount: string) => ({
+        userId: randomUUID(),
+        amount,
+        currency: 'EUR',
+        transactionId: randomUUID(),
+        playerId: null,
+        adminId: randomUUID(),
+        direction: 'credit' as const,
+        reason: 'goodwill credit',
+      }),
+      'chat.donate.sent': (amount: string) => ({
+        senderId: randomUUID(),
+        senderUsername: 'alice',
+        recipientId: randomUUID(),
+        recipientUsername: 'bob',
+        amount,
+        currency: 'EUR',
+        roomId: null,
+      }),
+      'gaming.bet.settled': (amount: string) => ({
+        roundId: randomUUID(),
+        userId: randomUUID(),
+        playerId: null,
+        outcome: 'win' as const,
+        amount,
+        currency: 'EUR',
+      }),
+      'bonus.granted': (amount: string) => ({
+        bonusId: randomUUID(),
+        userId: randomUUID(),
+        amount,
+        currency: 'EUR',
+      }),
+    } as const;
+
+    const events = Object.keys(basePayloads) as (keyof typeof basePayloads)[];
+
+    it.each(events)('trims the padded 18-decimal amount down to "100" in the %s body', (event) => {
+      const input = entryFor(event).handle(basePayloads[event]('100.000000000000000000'));
+
+      expect(input?.body).toContain('100');
+      expect(input?.body).not.toContain('100.000000000000000000');
+    });
+
+    it.each(events)(
+      'resolves a fractional amount to "0.5", not "0.5000000000000000" or "1", in the %s body',
+      (event) => {
+        const input = entryFor(event).handle(basePayloads[event]('0.500000000000000000'));
+
+        expect(input?.body).toContain('0.5');
+        expect(input?.body).not.toContain('0.5000000000000000');
+        expect(input?.body).not.toContain(' 1 ');
+      },
+    );
+
+    it.each(events)(
+      'adds a thousands separator, resolving to "1,234.5", in the %s body',
+      (event) => {
+        const input = entryFor(event).handle(basePayloads[event]('1234.500000000000000000'));
+
+        expect(input?.body).toContain('1,234.5');
+      },
+    );
+  });
+
+  it('leaves currency and reason untouched while only the amount substring is reformatted', () => {
+    const input = entryFor('wallet.manual_adjustment.created').handle({
+      userId: randomUUID(),
+      amount: '100.000000000000000000',
+      currency: 'EUR',
+      transactionId: randomUUID(),
+      playerId: null,
+      adminId: randomUUID(),
+      direction: 'credit',
+      reason: 'goodwill credit',
+    });
+
+    expect(input?.body).toBe('Your balance was credited 100 EUR. Reason: goodwill credit.');
+  });
 });

--- a/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
@@ -57,39 +57,6 @@ describe('notificationEventMap', () => {
     expect(input?.body).toContain('goodwill credit');
   });
 
-  it('maps chat.donate.sent to the recipient only, never the sender, carrying the room id', () => {
-    const senderId = randomUUID();
-    const recipientId = randomUUID();
-    const roomId = randomUUID();
-    const input = entryFor('chat.donate.sent').handle({
-      senderId,
-      senderUsername: 'alice',
-      recipientId,
-      recipientUsername: 'bob',
-      amount: '2.00',
-      currency: 'USD',
-      roomId,
-    });
-
-    expect(input?.userId).toBe(recipientId);
-    expect(input?.userId).not.toBe(senderId);
-    expect(input).toMatchObject({ type: 'tip.received', data: { roomId } });
-  });
-
-  it('omits a null roomId from chat.donate.sent data instead of carrying a null value', () => {
-    const input = entryFor('chat.donate.sent').handle({
-      senderId: randomUUID(),
-      senderUsername: 'alice',
-      recipientId: randomUUID(),
-      recipientUsername: 'bob',
-      amount: '2.00',
-      currency: 'USD',
-      roomId: null,
-    });
-
-    expect(input?.data).toBeNull();
-  });
-
   it('maps chat.user.mentioned to the mentioned user, not the author, carrying room and message ids', () => {
     const byUserId = randomUUID();
     const mentionedUserId = randomUUID();
@@ -175,7 +142,6 @@ describe('notificationEventMap', () => {
       'wallet.withdrawal.requested',
       'wallet.withdrawal.completed',
       'wallet.withdrawal.failed',
-      'chat.donate.sent',
       'chat.user.mentioned',
     ] as const;
 
@@ -243,15 +209,6 @@ describe('notificationEventMap', () => {
         adminId: randomUUID(),
         direction: 'credit' as const,
         reason: 'goodwill credit',
-      }),
-      'chat.donate.sent': (amount: string) => ({
-        senderId: randomUUID(),
-        senderUsername: 'alice',
-        recipientId: randomUUID(),
-        recipientUsername: 'bob',
-        amount,
-        currency: 'EUR',
-        roomId: null,
       }),
     } as const;
 

--- a/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
@@ -1,0 +1,217 @@
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect } from 'vitest';
+import { buildKycResubmissionNotification, notificationEventMap } from '../plugin.js';
+
+function entryFor(event: (typeof notificationEventMap)[number]['event']) {
+  const entry = notificationEventMap.find((e) => e.event === event);
+  if (!entry) {
+    throw new Error(`no notificationEventMap entry for ${event}`);
+  }
+  return entry;
+}
+
+describe('notificationEventMap', () => {
+  it('maps wallet.withdrawal.approved to an in-app notification for the payee, carrying the transaction id', () => {
+    const userId = randomUUID();
+    const transactionId = randomUUID();
+    const input = entryFor('wallet.withdrawal.approved').handle({
+      userId,
+      amount: '10.00',
+      currency: 'USD',
+      transactionId,
+      adminId: randomUUID(),
+    });
+
+    expect(input).toMatchObject({ userId, type: 'withdrawal.approved', data: { transactionId } });
+  });
+
+  it('maps wallet.deposit.completed to a deposit.completed notification, carrying the transaction id', () => {
+    const userId = randomUUID();
+    const transactionId = randomUUID();
+    const input = entryFor('wallet.deposit.completed').handle({
+      userId,
+      amount: '25.50',
+      currency: 'USD',
+      transactionId,
+      playerId: null,
+    });
+
+    expect(input).toMatchObject({ userId, type: 'deposit.completed', data: { transactionId } });
+  });
+
+  it('maps wallet.manual_adjustment.created to a balance.adjusted notification carrying the reason and transaction id', () => {
+    const userId = randomUUID();
+    const transactionId = randomUUID();
+    const input = entryFor('wallet.manual_adjustment.created').handle({
+      userId,
+      amount: '5.00',
+      currency: 'USD',
+      transactionId,
+      playerId: null,
+      adminId: randomUUID(),
+      direction: 'credit',
+      reason: 'goodwill credit',
+    });
+
+    expect(input).toMatchObject({ userId, type: 'balance.adjusted', data: { transactionId } });
+    expect(input?.body).toContain('goodwill credit');
+  });
+
+  it('maps chat.donate.sent to the recipient only, never the sender, carrying the room id', () => {
+    const senderId = randomUUID();
+    const recipientId = randomUUID();
+    const roomId = randomUUID();
+    const input = entryFor('chat.donate.sent').handle({
+      senderId,
+      senderUsername: 'alice',
+      recipientId,
+      recipientUsername: 'bob',
+      amount: '2.00',
+      currency: 'USD',
+      roomId,
+    });
+
+    expect(input?.userId).toBe(recipientId);
+    expect(input?.userId).not.toBe(senderId);
+    expect(input).toMatchObject({ type: 'tip.received', data: { roomId } });
+  });
+
+  it('omits a null roomId from chat.donate.sent data instead of carrying a null value', () => {
+    const input = entryFor('chat.donate.sent').handle({
+      senderId: randomUUID(),
+      senderUsername: 'alice',
+      recipientId: randomUUID(),
+      recipientUsername: 'bob',
+      amount: '2.00',
+      currency: 'USD',
+      roomId: null,
+    });
+
+    expect(input?.data).toBeNull();
+  });
+
+  it('maps chat.user.mentioned to the mentioned user, not the author, carrying room and message ids', () => {
+    const byUserId = randomUUID();
+    const mentionedUserId = randomUUID();
+    const roomId = randomUUID();
+    const messageId = randomUUID();
+    const input = entryFor('chat.user.mentioned').handle({
+      mentionedUserId,
+      byUserId,
+      roomId,
+      messageId,
+    });
+
+    expect(input?.userId).toBe(mentionedUserId);
+    expect(input).toMatchObject({ type: 'chat.mention', data: { roomId, messageId } });
+  });
+
+  it('carries only the message id for a global-chat mention (null roomId)', () => {
+    const messageId = randomUUID();
+    const input = entryFor('chat.user.mentioned').handle({
+      mentionedUserId: randomUUID(),
+      byUserId: randomUUID(),
+      roomId: null,
+      messageId,
+    });
+
+    expect(input?.data).toEqual({ messageId });
+  });
+
+  it('maps social.friend_request.sent to the requester id (who to link to)', () => {
+    const requesterId = randomUUID();
+    const input = entryFor('social.friend_request.sent').handle({
+      friendshipId: randomUUID(),
+      requesterId,
+      addresseeId: randomUUID(),
+      requesterUsername: 'alice',
+    });
+
+    expect(input).toMatchObject({
+      type: 'social.friend_request.received',
+      data: { requesterId },
+    });
+  });
+
+  it('maps social.friend_request.accepted to the accepter id, not the requester (self-referential otherwise)', () => {
+    const requesterId = randomUUID();
+    const accepterId = randomUUID();
+    const input = entryFor('social.friend_request.accepted').handle({
+      friendshipId: randomUUID(),
+      requesterId,
+      addresseeId: randomUUID(),
+      accepterId,
+      accepterUsername: 'bob',
+    });
+
+    expect(input?.userId).toBe(requesterId);
+    expect(input).toMatchObject({
+      type: 'social.friend_request.accepted',
+      data: { accepterId },
+    });
+  });
+
+  it('leaves data null for kyc.resubmission_requested (no linkable entity in the source payload)', () => {
+    const input = buildKycResubmissionNotification({ userId: randomUUID(), reason: 'blurry' });
+
+    expect(input.data).toBeNull();
+  });
+
+  it('includes dormant gaming.bet.settled and bonus.granted mappings that never fire today, carrying their own entity ids', () => {
+    const userId = randomUUID();
+    const roundId = randomUUID();
+    const bonusId = randomUUID();
+
+    const betInput = entryFor('gaming.bet.settled').handle({
+      roundId,
+      userId,
+      playerId: null,
+      outcome: 'win',
+      amount: '100.00',
+      currency: 'USD',
+    });
+    const bonusInput = entryFor('bonus.granted').handle({
+      bonusId,
+      userId,
+      amount: '10.00',
+      currency: 'USD',
+    });
+
+    expect(betInput).toMatchObject({ userId, type: 'bet.settled', data: { roundId } });
+    expect(bonusInput).toMatchObject({ userId, type: 'bonus.granted', data: { bonusId } });
+  });
+
+  it('returns null instead of throwing on a payload that fails schema validation', () => {
+    const input = entryFor('wallet.withdrawal.approved').handle({ garbage: true });
+
+    expect(input).toBeNull();
+  });
+
+  it('keeps email disabled for the pre-existing friend-request types, unchanged from before the map refactor', () => {
+    expect(entryFor('social.friend_request.sent').sendEmail).toBe(false);
+    expect(entryFor('social.friend_request.accepted').sendEmail).toBe(false);
+  });
+
+  it('enables email for every new trigger type added alongside the map, per product decision', () => {
+    const emailedEvents = [
+      'wallet.deposit.completed',
+      'wallet.manual_adjustment.created',
+      'wallet.withdrawal.requested',
+      'wallet.withdrawal.completed',
+      'wallet.withdrawal.failed',
+      'chat.donate.sent',
+      'chat.user.mentioned',
+      'gaming.bet.settled',
+      'bonus.granted',
+    ] as const;
+
+    for (const event of emailedEvents) {
+      expect(entryFor(event).sendEmail).toBe(true);
+    }
+  });
+
+  it('keeps email enabled for the pre-existing withdrawal approve/reject types', () => {
+    expect(entryFor('wallet.withdrawal.approved').sendEmail).toBe(true);
+    expect(entryFor('wallet.withdrawal.rejected').sendEmail).toBe(true);
+  });
+});

--- a/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
@@ -157,30 +157,6 @@ describe('notificationEventMap', () => {
     expect(input.data).toBeNull();
   });
 
-  it('includes dormant gaming.bet.settled and bonus.granted mappings that never fire today, carrying their own entity ids', () => {
-    const userId = randomUUID();
-    const roundId = randomUUID();
-    const bonusId = randomUUID();
-
-    const betInput = entryFor('gaming.bet.settled').handle({
-      roundId,
-      userId,
-      playerId: null,
-      outcome: 'win',
-      amount: '100.00',
-      currency: 'USD',
-    });
-    const bonusInput = entryFor('bonus.granted').handle({
-      bonusId,
-      userId,
-      amount: '10.00',
-      currency: 'USD',
-    });
-
-    expect(betInput).toMatchObject({ userId, type: 'bet.settled', data: { roundId } });
-    expect(bonusInput).toMatchObject({ userId, type: 'bonus.granted', data: { bonusId } });
-  });
-
   it('returns null instead of throwing on a payload that fails schema validation', () => {
     const input = entryFor('wallet.withdrawal.approved').handle({ garbage: true });
 
@@ -192,8 +168,8 @@ describe('notificationEventMap', () => {
     expect(entryFor('social.friend_request.accepted').sendEmail).toBe(false);
   });
 
-  it('enables email for every new trigger type added alongside the map, per product decision', () => {
-    const emailedEvents = [
+  it('keeps every newly-mapped trigger type in-app only (no email), per the email scope decision', () => {
+    const inAppOnlyEvents = [
       'wallet.deposit.completed',
       'wallet.manual_adjustment.created',
       'wallet.withdrawal.requested',
@@ -201,12 +177,10 @@ describe('notificationEventMap', () => {
       'wallet.withdrawal.failed',
       'chat.donate.sent',
       'chat.user.mentioned',
-      'gaming.bet.settled',
-      'bonus.granted',
     ] as const;
 
-    for (const event of emailedEvents) {
-      expect(entryFor(event).sendEmail).toBe(true);
+    for (const event of inAppOnlyEvents) {
+      expect(entryFor(event).sendEmail).toBe(false);
     }
   });
 
@@ -279,20 +253,6 @@ describe('notificationEventMap', () => {
         currency: 'EUR',
         roomId: null,
       }),
-      'gaming.bet.settled': (amount: string) => ({
-        roundId: randomUUID(),
-        userId: randomUUID(),
-        playerId: null,
-        outcome: 'win' as const,
-        amount,
-        currency: 'EUR',
-      }),
-      'bonus.granted': (amount: string) => ({
-        bonusId: randomUUID(),
-        userId: randomUUID(),
-        amount,
-        currency: 'EUR',
-      }),
     } as const;
 
     const events = Object.keys(basePayloads) as (keyof typeof basePayloads)[];
@@ -323,6 +283,27 @@ describe('notificationEventMap', () => {
         expect(input?.body).toContain('1,234.5');
       },
     );
+
+    it.each(events)(
+      'does not collapse a tiny 18-decimal-scaled amount to "0" in the %s body',
+      (event) => {
+        const input = entryFor(event).handle(basePayloads[event]('0.000000001000000000'));
+
+        expect(input?.body).toContain('0.000000001');
+      },
+    );
+  });
+
+  it('routes wallet.bonus_rollover.completed through the same amount formatter as every other entry', () => {
+    const input = entryFor('wallet.bonus_rollover.completed').handle({
+      userId: randomUUID(),
+      creditId: randomUUID(),
+      currency: 'EUR',
+      creditedAmount: '1234.500000000000000000',
+    });
+
+    expect(input?.body).toContain('1,234.5');
+    expect(input?.body).not.toContain('1234.500000000000000000');
   });
 
   it('leaves currency and reason untouched while only the amount substring is reformatted', () => {

--- a/packages/core/src/engagement/notifications/__tests__/notifications.router.int.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notifications.router.int.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { call } from '@orpc/server';
+import { sql } from 'drizzle-orm';
+import { createTestDb, InProcessRealtimeTransport, type TestDb } from '@openora/core/testing';
+import { makeEventBus, testContext } from '../../../testing/mock.js';
+import { migrate } from '../migrate.js';
+import { notification } from '../schema/index.js';
+import { createNotificationsRouter, notificationsChannel } from '../router/index.js';
+import { NotificationsService } from '../service/notifications.service.js';
+import type { Notification } from '../contract/index.js';
+
+let db: TestDb;
+
+function build() {
+  const notifications = new NotificationsService(db.drizzle, makeEventBus());
+  const realtime = new InProcessRealtimeTransport();
+  return { router: createNotificationsRouter({ notifications, realtime }), realtime };
+}
+
+const ctxFor = (userId: string) => testContext({ auth: { userId } });
+
+async function nextStreamEventAfterSubscribed<T>(
+  stream: AsyncGenerator<T>,
+  publish: () => void,
+): Promise<T> {
+  const pending = stream.next();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  publish();
+  const { value } = await pending;
+  return value;
+}
+
+async function seedNotification(overrides: Partial<typeof notification.$inferInsert> = {}) {
+  const [row] = await db.drizzle.db
+    .insert(notification)
+    .values({
+      userId: randomUUID(),
+      type: 'withdrawal.approved',
+      title: 'Payout approved',
+      body: 'Your withdrawal is on its way.',
+      ...overrides,
+    })
+    .returning();
+  return row!;
+}
+
+beforeAll(async () => {
+  db = await createTestDb([migrate]);
+});
+
+afterAll(async () => {
+  await db.drop();
+});
+
+beforeEach(async () => {
+  await db.drizzle.db.execute(sql`TRUNCATE ${notification} RESTART IDENTITY CASCADE`);
+});
+
+describe('notifications router: list', () => {
+  it('returns only the caller notifications, newest first, as a paginated page', async () => {
+    const { router } = build();
+    const userId = randomUUID();
+    const older = await seedNotification({
+      userId,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const newer = await seedNotification({
+      userId,
+      createdAt: new Date('2026-02-01T00:00:00.000Z'),
+    });
+    await seedNotification();
+
+    const page = await call(router.list, { page: 1, limit: 10 }, { context: ctxFor(userId) });
+
+    expect(page.items.map((n) => n.id)).toEqual([newer.id, older.id]);
+    expect(page.total).toBe(2);
+    expect(page.items[0]).toMatchObject({ readAt: null });
+  });
+
+  it('round-trips the data entity-reference bag, and reports null when there is none', async () => {
+    const { router } = build();
+    const userId = randomUUID();
+    const transactionId = randomUUID();
+    await seedNotification({ userId, data: { transactionId } });
+    await seedNotification({ userId, type: 'kyc.resubmission_requested', data: null });
+
+    const page = await call(router.list, { page: 1, limit: 10 }, { context: ctxFor(userId) });
+
+    const withData = page.items.find((n) => n.type === 'withdrawal.approved');
+    const withoutData = page.items.find((n) => n.type === 'kyc.resubmission_requested');
+    expect(withData?.data).toEqual({ transactionId });
+    expect(withoutData?.data).toBeNull();
+  });
+});
+
+describe('notifications router: unreadCount', () => {
+  it('counts only the callers unread notifications', async () => {
+    const { router } = build();
+    const userId = randomUUID();
+    await seedNotification({ userId });
+    await seedNotification({ userId, readAt: new Date() });
+    await seedNotification();
+
+    const result = await call(router.unreadCount, undefined, { context: ctxFor(userId) });
+
+    expect(result).toEqual({ count: 1 });
+  });
+});
+
+describe('notifications router: markRead', () => {
+  it('marks the callers own notification read', async () => {
+    const { router } = build();
+    const row = await seedNotification();
+
+    const result = await call(router.markRead, { id: row.id }, { context: ctxFor(row.userId) });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it('refuses to mark another players notification read', async () => {
+    const { router } = build();
+    const row = await seedNotification();
+
+    await expect(
+      call(router.markRead, { id: row.id }, { context: ctxFor(randomUUID()) }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+});
+
+describe('notifications router: markAllRead', () => {
+  it('flips only the callers unread rows and reports the count', async () => {
+    const { router } = build();
+    const userId = randomUUID();
+    await seedNotification({ userId });
+    await seedNotification({ userId });
+    const otherUsersNotification = await seedNotification();
+
+    const result = await call(router.markAllRead, undefined, { context: ctxFor(userId) });
+
+    expect(result).toEqual({ count: 2 });
+    const [stillUnread] = await db.drizzle.db
+      .select()
+      .from(notification)
+      .where(sql`${notification.id} = ${otherUsersNotification.id}`);
+    expect(stillUnread?.readAt).toBeNull();
+  });
+});
+
+describe('notifications router: stream', () => {
+  it('delivers a notification published on the callers channel', async () => {
+    const { router, realtime } = build();
+    const userId = randomUUID();
+    const controller = new AbortController();
+
+    const stream = await call(router.stream, undefined, {
+      context: ctxFor(userId),
+      signal: controller.signal,
+    });
+
+    const published: Notification = {
+      id: randomUUID(),
+      userId,
+      type: 'deposit.completed',
+      title: 'Deposit completed',
+      body: 'Your deposit of 10.00 USD has been completed.',
+      data: { transactionId: randomUUID() },
+      readAt: null,
+      createdAt: new Date().toISOString(),
+    };
+    const value = await nextStreamEventAfterSubscribed(stream, () =>
+      realtime.publish(notificationsChannel(userId), published),
+    );
+    controller.abort();
+
+    expect(value).toEqual(published);
+  });
+});

--- a/packages/core/src/engagement/notifications/__tests__/notifications.service.int.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notifications.service.int.test.ts
@@ -323,3 +323,28 @@ describe('NotificationsService.markAllRead (real PG)', () => {
     expect(await svc.markAllRead(userId)).toEqual({ count: 0 });
   });
 });
+
+describe('NotificationsService.purgeExpired (real PG)', () => {
+  it('deletes only rows older than the retention window, regardless of readAt', async () => {
+    const { svc } = makeService();
+    const expired = await seedNotification({
+      createdAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000),
+    });
+    const fresh = await seedNotification({
+      createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
+    });
+
+    expect(await svc.purgeExpired(30)).toEqual({ count: 1 });
+
+    const remaining = await db.drizzle.db.select().from(notification);
+    expect(remaining.map((r) => r.id)).toEqual([fresh.id]);
+    expect(remaining.find((r) => r.id === expired.id)).toBeUndefined();
+  });
+
+  it('returns zero when nothing is old enough to purge', async () => {
+    const { svc } = makeService();
+    await seedNotification({ createdAt: new Date() });
+
+    expect(await svc.purgeExpired(30)).toEqual({ count: 0 });
+  });
+});

--- a/packages/core/src/engagement/notifications/__tests__/notifications.service.int.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notifications.service.int.test.ts
@@ -164,7 +164,6 @@ describe('NotificationsService.create (real PG)', () => {
     ['withdrawal.requested', 'Withdrawal requested'],
     ['withdrawal.completed', 'Withdrawal completed'],
     ['withdrawal.failed', 'Withdrawal failed'],
-    ['tip.received', 'You received a tip'],
     ['chat.mention', 'You were mentioned'],
   ] as const)(
     'persists a %s notification produced by the map-driven dispatch',

--- a/packages/core/src/engagement/notifications/__tests__/notifications.service.int.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notifications.service.int.test.ts
@@ -59,7 +59,7 @@ describe('NotificationsService.create (real PG)', () => {
     expect(created).toMatchObject({ userId, title: 'Hello', readAt: null });
     expect(await db.drizzle.db.select().from(notification)).toHaveLength(1);
     expect(events.emit).toHaveBeenCalledWith('notifications.created', {
-      notificationId: created.id,
+      notificationId: created!.id,
       userId,
     });
   });
@@ -137,11 +137,11 @@ describe('NotificationsService.create (real PG)', () => {
       data: { transactionId },
     });
 
-    expect(created.data).toEqual({ transactionId });
+    expect(created?.data).toEqual({ transactionId });
     const [stored] = await db.drizzle.db
       .select()
       .from(notification)
-      .where(eq(notification.id, created.id));
+      .where(eq(notification.id, created!.id));
     expect(stored?.data).toEqual({ transactionId });
   });
 
@@ -155,7 +155,7 @@ describe('NotificationsService.create (real PG)', () => {
       body: 'body',
     });
 
-    expect(created.data).toBeNull();
+    expect(created?.data).toBeNull();
   });
 
   it.each([
@@ -166,8 +166,6 @@ describe('NotificationsService.create (real PG)', () => {
     ['withdrawal.failed', 'Withdrawal failed'],
     ['tip.received', 'You received a tip'],
     ['chat.mention', 'You were mentioned'],
-    ['bet.settled', 'Bet won'],
-    ['bonus.granted', 'Bonus granted'],
   ] as const)(
     'persists a %s notification produced by the map-driven dispatch',
     async (type, title) => {
@@ -179,6 +177,30 @@ describe('NotificationsService.create (real PG)', () => {
       expect(created).toMatchObject({ userId, type, title, readAt: null });
     },
   );
+
+  it('dedupes a retried delivery of the same eventId to exactly one row, without throwing', async () => {
+    const { svc } = makeService();
+    const userId = randomUUID();
+    const eventId = randomUUID();
+    const input = {
+      userId,
+      type: 'deposit.completed' as const,
+      title: 'Deposit completed',
+      body: 'body',
+      eventId,
+    };
+
+    const first = await svc.create(input);
+    const second = await svc.create(input);
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    const rows = await db.drizzle.db
+      .select()
+      .from(notification)
+      .where(eq(notification.eventId, eventId));
+    expect(rows).toHaveLength(1);
+  });
 });
 
 describe('NotificationsService.listForUser (real PG)', () => {

--- a/packages/core/src/engagement/notifications/__tests__/notifications.service.int.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notifications.service.int.test.ts
@@ -123,10 +123,66 @@ describe('NotificationsService.create (real PG)', () => {
       readAt: null,
     });
   });
+
+  it('persists the data entity-reference bag alongside the notification', async () => {
+    const { svc } = makeService();
+    const userId = randomUUID();
+    const transactionId = randomUUID();
+
+    const created = await svc.create({
+      userId,
+      type: 'deposit.completed',
+      title: 'Deposit completed',
+      body: 'body',
+      data: { transactionId },
+    });
+
+    expect(created.data).toEqual({ transactionId });
+    const [stored] = await db.drizzle.db
+      .select()
+      .from(notification)
+      .where(eq(notification.id, created.id));
+    expect(stored?.data).toEqual({ transactionId });
+  });
+
+  it('defaults data to null when the caller omits it', async () => {
+    const { svc } = makeService();
+
+    const created = await svc.create({
+      userId: randomUUID(),
+      type: 'kyc.resubmission_requested',
+      title: 'Document resubmission required',
+      body: 'body',
+    });
+
+    expect(created.data).toBeNull();
+  });
+
+  it.each([
+    ['deposit.completed', 'Deposit completed'],
+    ['balance.adjusted', 'Balance adjusted'],
+    ['withdrawal.requested', 'Withdrawal requested'],
+    ['withdrawal.completed', 'Withdrawal completed'],
+    ['withdrawal.failed', 'Withdrawal failed'],
+    ['tip.received', 'You received a tip'],
+    ['chat.mention', 'You were mentioned'],
+    ['bet.settled', 'Bet won'],
+    ['bonus.granted', 'Bonus granted'],
+  ] as const)(
+    'persists a %s notification produced by the map-driven dispatch',
+    async (type, title) => {
+      const { svc } = makeService();
+      const userId = randomUUID();
+
+      const created = await svc.create({ userId, type, title, body: 'body' });
+
+      expect(created).toMatchObject({ userId, type, title, readAt: null });
+    },
+  );
 });
 
 describe('NotificationsService.listForUser (real PG)', () => {
-  it('returns only the requesting player rows, newest first', async () => {
+  it('returns only the requesting player rows, newest first, with a total count', async () => {
     const { svc } = makeService();
     const userId = randomUUID();
     const older = await seedNotification({
@@ -139,18 +195,23 @@ describe('NotificationsService.listForUser (real PG)', () => {
     });
     await seedNotification();
 
-    const rows = await svc.listForUser(userId);
+    const page = await svc.listForUser({ userId, page: 1, limit: 100 });
 
-    expect(rows.map((r) => r.id)).toEqual([newer.id, older.id]);
+    expect(page.items.map((r) => r.id)).toEqual([newer.id, older.id]);
+    expect(page.total).toBe(2);
+    expect(page).toMatchObject({ page: 1, limit: 100 });
   });
 
-  it('returns an empty list for a player with nothing on file', async () => {
+  it('returns an empty page for a player with nothing on file', async () => {
     const { svc } = makeService();
 
-    expect(await svc.listForUser(randomUUID())).toEqual([]);
+    expect(await svc.listForUser({ userId: randomUUID(), page: 1, limit: 100 })).toMatchObject({
+      items: [],
+      total: 0,
+    });
   });
 
-  it('caps the feed at fifty rows', async () => {
+  it('paginates using page/limit and reports the full total', async () => {
     const { svc } = makeService();
     const userId = randomUUID();
     await db.drizzle.db.insert(notification).values(
@@ -162,7 +223,31 @@ describe('NotificationsService.listForUser (real PG)', () => {
       })),
     );
 
-    expect(await svc.listForUser(userId)).toHaveLength(50);
+    const firstPage = await svc.listForUser({ userId, page: 1, limit: 50 });
+    const secondPage = await svc.listForUser({ userId, page: 2, limit: 50 });
+
+    expect(firstPage.items).toHaveLength(50);
+    expect(secondPage.items).toHaveLength(5);
+    expect(firstPage.total).toBe(55);
+  });
+});
+
+describe('NotificationsService.unreadCount (real PG)', () => {
+  it('counts only unread rows for the requesting player', async () => {
+    const { svc } = makeService();
+    const userId = randomUUID();
+    await seedNotification({ userId });
+    await seedNotification({ userId });
+    await seedNotification({ userId, readAt: new Date() });
+    await seedNotification();
+
+    expect(await svc.unreadCount(userId)).toBe(2);
+  });
+
+  it('returns zero for a player with nothing unread', async () => {
+    const { svc } = makeService();
+
+    expect(await svc.unreadCount(randomUUID())).toBe(0);
   });
 });
 

--- a/packages/core/src/engagement/notifications/contract/index.ts
+++ b/packages/core/src/engagement/notifications/contract/index.ts
@@ -15,7 +15,6 @@ export const NOTIFICATION_TYPES = [
   'withdrawal.requested',
   'withdrawal.completed',
   'withdrawal.failed',
-  'tip.received',
   'chat.mention',
 ] as const;
 export const NotificationTypeSchema = z.enum(NOTIFICATION_TYPES);

--- a/packages/core/src/engagement/notifications/contract/index.ts
+++ b/packages/core/src/engagement/notifications/contract/index.ts
@@ -1,6 +1,7 @@
-import { oc } from '@orpc/contract';
+import { eventIterator, oc } from '@orpc/contract';
 import * as z from 'zod';
 import { IdInputSchema, TimestampSchema, UuidSchema } from '@openora/core/contracts';
+import { PageQuerySchema, SortOrderSchema, paginated } from '@openora/core/contracts/kit';
 
 export const NOTIFICATION_TYPES = [
   'withdrawal.approved',
@@ -9,9 +10,24 @@ export const NOTIFICATION_TYPES = [
   'social.friend_request.received',
   'social.friend_request.accepted',
   'wallet.bonus_rollover.completed',
+  'deposit.completed',
+  'balance.adjusted',
+  'withdrawal.requested',
+  'withdrawal.completed',
+  'withdrawal.failed',
+  'tip.received',
+  'chat.mention',
+  'bet.settled',
+  'bonus.granted',
 ] as const;
 export const NotificationTypeSchema = z.enum(NOTIFICATION_TYPES);
 export type NotificationType = z.infer<typeof NotificationTypeSchema>;
+
+// Bare entity-reference IDs mirrored from the source domain event's own payload (eg
+// `{ roomId, messageId }`) - never a path, URL, or asset reference. Lets a consumer
+// build its own banner/CTA mapping keyed off `type` without openora knowing routes.
+export const NotificationDataSchema = z.record(z.string(), z.string());
+export type NotificationData = z.infer<typeof NotificationDataSchema>;
 
 export const NotificationSchema = z.object({
   id: UuidSchema,
@@ -19,9 +35,11 @@ export const NotificationSchema = z.object({
   type: NotificationTypeSchema,
   title: z.string(),
   body: z.string(),
+  data: NotificationDataSchema.nullable(),
   readAt: z.string().nullable(),
   createdAt: TimestampSchema,
 });
+export type Notification = z.infer<typeof NotificationSchema>;
 
 // Internal-only - fed by domain-event handlers in plugin.ts, not a wire route.
 export const CreateNotificationInputSchema = z.object({
@@ -29,18 +47,45 @@ export const CreateNotificationInputSchema = z.object({
   type: NotificationTypeSchema,
   title: z.string(),
   body: z.string(),
+  data: NotificationDataSchema.nullable().optional(),
 });
 export type CreateNotificationInput = z.infer<typeof CreateNotificationInputSchema>;
 
+export const NOTIFICATION_SORT_BY_VALUES = ['createdAt'] as const;
+export const NotificationSortBySchema = z.enum(NOTIFICATION_SORT_BY_VALUES).default('createdAt');
+export type NotificationSortBy = z.infer<typeof NotificationSortBySchema>;
+
+export const NotificationCountSchema = z.object({ count: z.number() });
+export type NotificationCount = z.infer<typeof NotificationCountSchema>;
+
+export const MarkNotificationReadOutputSchema = z.object({ success: z.literal(true) });
+export type MarkNotificationReadOutput = z.infer<typeof MarkNotificationReadOutputSchema>;
+
 export const notificationsContract = {
-  list: oc.route({ method: 'GET', path: '/notifications' }).output(z.array(NotificationSchema)),
+  list: oc
+    .route({ method: 'GET', path: '/notifications' })
+    .input(
+      PageQuerySchema.extend({
+        sortBy: NotificationSortBySchema.optional(),
+        sortOrder: SortOrderSchema.default('desc').optional(),
+      }),
+    )
+    .output(paginated(NotificationSchema)),
+
+  unreadCount: oc
+    .route({ method: 'GET', path: '/notifications/unread-count' })
+    .output(NotificationCountSchema),
+
+  stream: oc
+    .route({ method: 'GET', path: '/notifications/stream' })
+    .output(eventIterator(NotificationSchema)),
 
   markRead: oc
     .route({ method: 'POST', path: '/notifications/{id}/read' })
     .input(IdInputSchema)
-    .output(z.object({ success: z.literal(true) })),
+    .output(MarkNotificationReadOutputSchema),
 
   markAllRead: oc
     .route({ method: 'POST', path: '/notifications/read-all' })
-    .output(z.object({ count: z.number() })),
+    .output(NotificationCountSchema),
 };

--- a/packages/core/src/engagement/notifications/contract/index.ts
+++ b/packages/core/src/engagement/notifications/contract/index.ts
@@ -17,8 +17,6 @@ export const NOTIFICATION_TYPES = [
   'withdrawal.failed',
   'tip.received',
   'chat.mention',
-  'bet.settled',
-  'bonus.granted',
 ] as const;
 export const NotificationTypeSchema = z.enum(NOTIFICATION_TYPES);
 export type NotificationType = z.infer<typeof NotificationTypeSchema>;
@@ -48,6 +46,7 @@ export const CreateNotificationInputSchema = z.object({
   title: z.string(),
   body: z.string(),
   data: NotificationDataSchema.nullable().optional(),
+  eventId: UuidSchema.nullable().optional(),
 });
 export type CreateNotificationInput = z.infer<typeof CreateNotificationInputSchema>;
 

--- a/packages/core/src/engagement/notifications/drizzle/migrations/0001_classy_pixie.sql
+++ b/packages/core/src/engagement/notifications/drizzle/migrations/0001_classy_pixie.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "notification" ADD COLUMN "data" jsonb;

--- a/packages/core/src/engagement/notifications/drizzle/migrations/0002_open_madame_web.sql
+++ b/packages/core/src/engagement/notifications/drizzle/migrations/0002_open_madame_web.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "notification" ADD COLUMN "event_id" uuid;--> statement-breakpoint
+CREATE UNIQUE INDEX "notification_event_id_idx" ON "notification" USING btree ("event_id");

--- a/packages/core/src/engagement/notifications/drizzle/migrations/meta/0001_snapshot.json
+++ b/packages/core/src/engagement/notifications/drizzle/migrations/meta/0001_snapshot.json
@@ -1,0 +1,98 @@
+{
+  "id": "fa9988e3-5040-4f86-b921-4320fa27eeaa",
+  "prevId": "c5045022-6772-41f6-b8cc-54dc6f58645d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_id_idx": {
+          "name": "notification_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/engagement/notifications/drizzle/migrations/meta/0002_snapshot.json
+++ b/packages/core/src/engagement/notifications/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,119 @@
+{
+  "id": "a7e44828-dab8-4c21-ad56-ea8e67992ea5",
+  "prevId": "fa9988e3-5040-4f86-b921-4320fa27eeaa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_user_id_idx": {
+          "name": "notification_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_event_id_idx": {
+          "name": "notification_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/engagement/notifications/drizzle/migrations/meta/_journal.json
+++ b/packages/core/src/engagement/notifications/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1787595667142,
       "tag": "0001_classy_pixie",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1787911988004,
+      "tag": "0002_open_madame_web",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/engagement/notifications/drizzle/migrations/meta/_journal.json
+++ b/packages/core/src/engagement/notifications/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1783555224659,
       "tag": "0000_sparkling_kulan_gath",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1787595667142,
+      "tag": "0001_classy_pixie",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/engagement/notifications/plugin.ts
+++ b/packages/core/src/engagement/notifications/plugin.ts
@@ -26,6 +26,8 @@ import { NotificationsService } from './service/notifications.service.js';
 import type { CreateNotificationInput } from './contract/index.js';
 
 const KYC_RESUBMISSION_NOTIFY_QUEUE = queue('kyc-resubmission-notify');
+const NOTIFICATIONS_RETENTION_PURGE_QUEUE = queue('notifications-retention-purge');
+const NOTIFICATION_RETENTION_DAYS = 30;
 
 const KycResubmissionNotifyJobSchema = z.object({
   userId: UuidSchema,
@@ -374,6 +376,18 @@ export default {
       },
     });
 
+    ctx.jobs.worker({
+      queue: NOTIFICATIONS_RETENTION_PURGE_QUEUE,
+      schema: z.object({}),
+      handler: async () => {
+        if (!svcRef) {
+          return;
+        }
+        const { count } = await svcRef.purgeExpired(NOTIFICATION_RETENTION_DAYS);
+        logger.info({ count }, 'notification retention purge complete');
+      },
+    });
+
     ctx.routers.add('notifications', (c) => {
       const svc = new NotificationsService(c.get(DRIZZLE), c.get(EVENT_BUS));
       svcRef = svc;
@@ -381,6 +395,14 @@ export default {
       directoryRef = c.get(ADMIN_USER_DIRECTORY);
       jobQueueRef = c.get(JOB_QUEUE);
       realtimeRef = c.get(REALTIME_TRANSPORT);
+      // Off-peak, one hour after tag's daily-evaluation (0 2 * * *), so the in-process
+      // driver doesn't run both sweeps at once in dev/test.
+      void jobQueueRef.schedule(
+        NOTIFICATIONS_RETENTION_PURGE_QUEUE,
+        'notifications.retention-purge.daily',
+        {},
+        { cron: '0 3 * * *' },
+      );
       return createNotificationsRouter({ notifications: svc, realtime: realtimeRef });
     });
   },

--- a/packages/core/src/engagement/notifications/plugin.ts
+++ b/packages/core/src/engagement/notifications/plugin.ts
@@ -319,7 +319,9 @@ export default {
       }
       const dto = toNotificationDto(record);
       if (dto) {
-        void realtimeRef.publish(notificationsChannel(record.userId), dto);
+        void Promise.resolve(realtimeRef.publish(notificationsChannel(record.userId), dto)).catch(
+          (err: unknown) => logger.error({ err }, 'notification realtime publish failed'),
+        );
       }
     };
 

--- a/packages/core/src/engagement/notifications/plugin.ts
+++ b/packages/core/src/engagement/notifications/plugin.ts
@@ -32,6 +32,18 @@ const KycResubmissionNotifyJobSchema = z.object({
   reason: z.string().nullable(),
 });
 
+// p.amount on every wallet/chat/gaming event payload is a MoneyAmount decimal string
+// scaled to MONEY_SCALE = 18 (crypto-first precision), eg "100.000000000000000000" -
+// display-only trimming for notification text; Number() can lose precision below its
+// ~15-17 significant digits for an extreme 18-decimal value, an accepted tradeoff.
+function formatMoneyAmount(amount: string): string {
+  const value = Number(amount);
+  if (!Number.isFinite(value)) {
+    return amount;
+  }
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 8 }).format(value);
+}
+
 type NotificationMapEntry = {
   event: DomainEventName;
   sendEmail: boolean;
@@ -80,7 +92,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'withdrawal.approved',
       title: 'Withdrawal approved',
-      body: `Your withdrawal of ${p.amount} ${p.currency} has been approved and is being processed.`,
+      body: `Your withdrawal of ${formatMoneyAmount(p.amount)} ${p.currency} has been approved and is being processed.`,
       data: { transactionId: p.transactionId },
     }),
     { sendEmail: true },
@@ -92,7 +104,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'withdrawal.rejected',
       title: 'Withdrawal rejected',
-      body: `Your withdrawal of ${p.amount} ${p.currency} was rejected and the funds were returned to your balance.${p.reason ? ` Reason: ${p.reason}.` : ''}`,
+      body: `Your withdrawal of ${formatMoneyAmount(p.amount)} ${p.currency} was rejected and the funds were returned to your balance.${p.reason ? ` Reason: ${p.reason}.` : ''}`,
       data: { transactionId: p.transactionId },
     }),
     { sendEmail: true },
@@ -104,7 +116,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'withdrawal.requested',
       title: 'Withdrawal requested',
-      body: `Your withdrawal request of ${p.amount} ${p.currency} has been received and is pending review.`,
+      body: `Your withdrawal request of ${formatMoneyAmount(p.amount)} ${p.currency} has been received and is pending review.`,
       data: { transactionId: p.transactionId },
     }),
     { sendEmail: true },
@@ -116,7 +128,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'withdrawal.completed',
       title: 'Withdrawal completed',
-      body: `Your withdrawal of ${p.amount} ${p.currency} has been completed.`,
+      body: `Your withdrawal of ${formatMoneyAmount(p.amount)} ${p.currency} has been completed.`,
       data: { transactionId: p.transactionId },
     }),
     { sendEmail: true },
@@ -128,7 +140,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'withdrawal.failed',
       title: 'Withdrawal failed',
-      body: `Your withdrawal of ${p.amount} ${p.currency} failed and the funds were returned to your balance.`,
+      body: `Your withdrawal of ${formatMoneyAmount(p.amount)} ${p.currency} failed and the funds were returned to your balance.`,
       data: { transactionId: p.transactionId },
     }),
     { sendEmail: true },
@@ -140,7 +152,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'deposit.completed',
       title: 'Deposit completed',
-      body: `Your deposit of ${p.amount} ${p.currency} has been completed.`,
+      body: `Your deposit of ${formatMoneyAmount(p.amount)} ${p.currency} has been completed.`,
       data: { transactionId: p.transactionId },
     }),
     { sendEmail: true },
@@ -152,7 +164,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'balance.adjusted',
       title: 'Balance adjusted',
-      body: `Your balance was ${p.direction === 'credit' ? 'credited' : 'debited'} ${p.amount} ${p.currency}. Reason: ${p.reason}.`,
+      body: `Your balance was ${p.direction === 'credit' ? 'credited' : 'debited'} ${formatMoneyAmount(p.amount)} ${p.currency}. Reason: ${p.reason}.`,
       data: { transactionId: p.transactionId },
     }),
     { sendEmail: true },
@@ -176,7 +188,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.recipientId,
       type: 'tip.received',
       title: 'You received a tip',
-      body: `${p.senderUsername} sent you ${p.amount} ${p.currency}.`,
+      body: `${p.senderUsername} sent you ${formatMoneyAmount(p.amount)} ${p.currency}.`,
       data: compactData({ roomId: p.roomId }),
     }),
     { sendEmail: true },
@@ -230,7 +242,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'bet.settled',
       title: p.outcome === 'win' ? 'Bet won' : 'Bet settled',
-      body: `Your bet settled as a ${p.outcome} for ${p.amount} ${p.currency}.`,
+      body: `Your bet settled as a ${p.outcome} for ${formatMoneyAmount(p.amount)} ${p.currency}.`,
       data: { roundId: p.roundId },
     }),
     { sendEmail: true },
@@ -242,7 +254,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'bonus.granted',
       title: 'Bonus granted',
-      body: `You were granted a bonus of ${p.amount} ${p.currency}.`,
+      body: `You were granted a bonus of ${formatMoneyAmount(p.amount)} ${p.currency}.`,
       data: { bonusId: p.bonusId },
     }),
     { sendEmail: true },

--- a/packages/core/src/engagement/notifications/plugin.ts
+++ b/packages/core/src/engagement/notifications/plugin.ts
@@ -3,18 +3,27 @@ import {
   ADMIN_USER_DIRECTORY,
   JOB_QUEUE,
   NOTIFICATION_DELIVERY_ADAPTER,
+  REALTIME_TRANSPORT,
   UuidSchema,
   domainEventSchemas,
   queue,
   type AdminUserDirectory,
+  type DomainEventName,
+  type DomainEventPayload,
   type JobQueueAdapter,
   type NotificationDeliveryAdapter,
+  type RealtimeTransport,
 } from '@openora/core/contracts';
 import { createLogger, EVENT_BUS, DRIZZLE } from '@openora/core/server';
 import type { CoreTokenCatalog, Plugin } from '@openora/core/server';
 import { MockNotificationDeliveryAdapter } from './adapters/mock/mock-notification-adapter.js';
-import { createNotificationsRouter } from './router/index.js';
+import {
+  createNotificationsRouter,
+  notificationsChannel,
+  toNotificationDto,
+} from './router/index.js';
 import { NotificationsService } from './service/notifications.service.js';
+import type { CreateNotificationInput } from './contract/index.js';
 
 const KYC_RESUBMISSION_NOTIFY_QUEUE = queue('kyc-resubmission-notify');
 
@@ -23,10 +32,240 @@ const KycResubmissionNotifyJobSchema = z.object({
   reason: z.string().nullable(),
 });
 
+type NotificationMapEntry = {
+  event: DomainEventName;
+  sendEmail: boolean;
+  handle: (payload: unknown) => CreateNotificationInput | null;
+};
+
+// Drops null/undefined entity refs (eg a nullable roomId) so `data` only ever carries
+// fields the source event actually had a value for; an all-null payload becomes `null`.
+function compactData(
+  fields: Record<string, string | null | undefined>,
+): Record<string, string> | null {
+  const entries = Object.entries(fields).filter(
+    (entry): entry is [string, string] => entry[1] !== null && entry[1] !== undefined,
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+// A plain array literal would widen every entry's `event` to DomainEventName and lose the
+// payload type tied to it; this generic keeps K bound per entry so buildNotification stays
+// checked against that one event's actual payload shape.
+function mapEvent<K extends DomainEventName>(
+  event: K,
+  buildNotification: (payload: DomainEventPayload<K>) => CreateNotificationInput,
+  options: { sendEmail: boolean },
+): NotificationMapEntry {
+  return {
+    event,
+    sendEmail: options.sendEmail,
+    handle: (payload) => {
+      const parsed = domainEventSchemas[event].safeParse(payload);
+      if (!parsed.success) {
+        return null;
+      }
+      // Library boundary: TS cannot narrow a domainEventSchemas lookup keyed by this
+      // function's own generic K to that one event's payload type; the pairing holds
+      // by domainEventSchemas' own definition (DomainEventPayload<K> is inferred from it).
+      return buildNotification(parsed.data as DomainEventPayload<K>);
+    },
+  };
+}
+
+export const notificationEventMap: NotificationMapEntry[] = [
+  mapEvent(
+    'wallet.withdrawal.approved',
+    (p) => ({
+      userId: p.userId,
+      type: 'withdrawal.approved',
+      title: 'Withdrawal approved',
+      body: `Your withdrawal of ${p.amount} ${p.currency} has been approved and is being processed.`,
+      data: { transactionId: p.transactionId },
+    }),
+    { sendEmail: true },
+  ),
+
+  mapEvent(
+    'wallet.withdrawal.rejected',
+    (p) => ({
+      userId: p.userId,
+      type: 'withdrawal.rejected',
+      title: 'Withdrawal rejected',
+      body: `Your withdrawal of ${p.amount} ${p.currency} was rejected and the funds were returned to your balance.${p.reason ? ` Reason: ${p.reason}.` : ''}`,
+      data: { transactionId: p.transactionId },
+    }),
+    { sendEmail: true },
+  ),
+
+  mapEvent(
+    'wallet.withdrawal.requested',
+    (p) => ({
+      userId: p.userId,
+      type: 'withdrawal.requested',
+      title: 'Withdrawal requested',
+      body: `Your withdrawal request of ${p.amount} ${p.currency} has been received and is pending review.`,
+      data: { transactionId: p.transactionId },
+    }),
+    { sendEmail: true },
+  ),
+
+  mapEvent(
+    'wallet.withdrawal.completed',
+    (p) => ({
+      userId: p.userId,
+      type: 'withdrawal.completed',
+      title: 'Withdrawal completed',
+      body: `Your withdrawal of ${p.amount} ${p.currency} has been completed.`,
+      data: { transactionId: p.transactionId },
+    }),
+    { sendEmail: true },
+  ),
+
+  mapEvent(
+    'wallet.withdrawal.failed',
+    (p) => ({
+      userId: p.userId,
+      type: 'withdrawal.failed',
+      title: 'Withdrawal failed',
+      body: `Your withdrawal of ${p.amount} ${p.currency} failed and the funds were returned to your balance.`,
+      data: { transactionId: p.transactionId },
+    }),
+    { sendEmail: true },
+  ),
+
+  mapEvent(
+    'wallet.deposit.completed',
+    (p) => ({
+      userId: p.userId,
+      type: 'deposit.completed',
+      title: 'Deposit completed',
+      body: `Your deposit of ${p.amount} ${p.currency} has been completed.`,
+      data: { transactionId: p.transactionId },
+    }),
+    { sendEmail: true },
+  ),
+
+  mapEvent(
+    'wallet.manual_adjustment.created',
+    (p) => ({
+      userId: p.userId,
+      type: 'balance.adjusted',
+      title: 'Balance adjusted',
+      body: `Your balance was ${p.direction === 'credit' ? 'credited' : 'debited'} ${p.amount} ${p.currency}. Reason: ${p.reason}.`,
+      data: { transactionId: p.transactionId },
+    }),
+    { sendEmail: true },
+  ),
+
+  mapEvent(
+    'wallet.bonus_rollover.completed',
+    (p) => ({
+      userId: p.userId,
+      type: 'wallet.bonus_rollover.completed',
+      title: 'Bonus unlocked',
+      body: `Your ${p.creditedAmount} ${p.currency} bonus credit has cleared its rollover requirement and is now fully withdrawable.`,
+      data: null,
+    }),
+    { sendEmail: false },
+  ),
+
+  mapEvent(
+    'chat.donate.sent',
+    (p) => ({
+      userId: p.recipientId,
+      type: 'tip.received',
+      title: 'You received a tip',
+      body: `${p.senderUsername} sent you ${p.amount} ${p.currency}.`,
+      data: compactData({ roomId: p.roomId }),
+    }),
+    { sendEmail: true },
+  ),
+
+  mapEvent(
+    'chat.user.mentioned',
+    (p) => ({
+      userId: p.mentionedUserId,
+      type: 'chat.mention',
+      title: 'You were mentioned',
+      body: 'You were mentioned in a chat message.',
+      data: compactData({ roomId: p.roomId, messageId: p.messageId }),
+    }),
+    { sendEmail: true },
+  ),
+
+  // Pre-existing types: in-app only, unchanged from before the declarative-map refactor.
+  mapEvent(
+    'social.friend_request.sent',
+    (p) => ({
+      userId: p.addresseeId,
+      type: 'social.friend_request.received',
+      title: 'New friend request',
+      body: `${p.requesterUsername} sent you a friend request.`,
+      data: { requesterId: p.requesterId },
+    }),
+    { sendEmail: false },
+  ),
+
+  mapEvent(
+    'social.friend_request.accepted',
+    (p) => ({
+      userId: p.requesterId,
+      type: 'social.friend_request.accepted',
+      title: 'Friend request accepted',
+      body: `${p.accepterUsername} accepted your friend request.`,
+      // accepterId, not requesterId: the recipient of THIS notification is the
+      // requester, so the linkable "other party" is whoever just accepted.
+      data: { accepterId: p.accepterId },
+    }),
+    { sendEmail: false },
+  ),
+
+  // Dormant: gaming.bet.settled and bonus.granted have no emitter yet (see
+  // contracts/schemas/events.ts). These entries never fire until a future module
+  // publishes them, but the mapping is ready the moment one does.
+  mapEvent(
+    'gaming.bet.settled',
+    (p) => ({
+      userId: p.userId,
+      type: 'bet.settled',
+      title: p.outcome === 'win' ? 'Bet won' : 'Bet settled',
+      body: `Your bet settled as a ${p.outcome} for ${p.amount} ${p.currency}.`,
+      data: { roundId: p.roundId },
+    }),
+    { sendEmail: true },
+  ),
+
+  mapEvent(
+    'bonus.granted',
+    (p) => ({
+      userId: p.userId,
+      type: 'bonus.granted',
+      title: 'Bonus granted',
+      body: `You were granted a bonus of ${p.amount} ${p.currency}.`,
+      data: { bonusId: p.bonusId },
+    }),
+    { sendEmail: true },
+  ),
+];
+
+export function buildKycResubmissionNotification(payload: {
+  userId: string;
+  reason: string | null;
+}): CreateNotificationInput {
+  return {
+    userId: payload.userId,
+    type: 'kyc.resubmission_requested',
+    title: 'Document resubmission required',
+    body: `An admin has requested you resubmit your verification documents.${payload.reason ? ` Reason: ${payload.reason}.` : ''}`,
+    data: null,
+  };
+}
+
 export default {
   id: 'notifications',
   // ADMIN_USER_DIRECTORY (owned by identity) resolves the player's email for the
-  // withdrawal delivery emails; pin load order so a split still finds the port. See ADR-0017.
+  // delivery emails; pin load order so a split still finds the port. See ADR-0017.
   dependsOn: ['identity'],
   register(ctx) {
     ctx.provide(NOTIFICATION_DELIVERY_ADAPTER, () => new MockNotificationDeliveryAdapter());
@@ -39,6 +278,7 @@ export default {
     let deliveryRef: NotificationDeliveryAdapter | null = null;
     let directoryRef: AdminUserDirectory | null = null;
     let jobQueueRef: JobQueueAdapter | null = null;
+    let realtimeRef: RealtimeTransport | null = null;
 
     // Best-effort email alongside the in-app notification; a missing user or delivery
     // failure is logged, never thrown - the in-app notification already landed.
@@ -59,77 +299,36 @@ export default {
         .catch((err) => logger.error({ err }, 'notification email delivery failed'));
     };
 
-    ctx.events.on('wallet.withdrawal.approved', (payload) => {
-      const parsed = domainEventSchemas['wallet.withdrawal.approved'].safeParse(payload);
-      if (!parsed.success || !svcRef) {
+    const publishNotification = (record: Awaited<ReturnType<NotificationsService['create']>>) => {
+      if (!realtimeRef) {
         return;
       }
-      const p = parsed.data;
-      const title = 'Withdrawal approved';
-      const body = `Your withdrawal of ${p.amount} ${p.currency} has been approved and is being processed.`;
-      svcRef
-        .create({ userId: p.userId, type: 'withdrawal.approved', title, body })
-        .catch((err) => logger.error({ err }, 'withdrawal.approved notification failed'));
-      sendEmail(p.userId, title, body);
-    });
+      const dto = toNotificationDto(record);
+      if (dto) {
+        void realtimeRef.publish(notificationsChannel(record.userId), dto);
+      }
+    };
 
-    ctx.events.on('wallet.withdrawal.rejected', (payload) => {
-      const parsed = domainEventSchemas['wallet.withdrawal.rejected'].safeParse(payload);
-      if (!parsed.success || !svcRef) {
-        return;
-      }
-      const p = parsed.data;
-      const reason = p.reason ? ` Reason: ${p.reason}.` : '';
-      const title = 'Withdrawal rejected';
-      const body = `Your withdrawal of ${p.amount} ${p.currency} was rejected and the funds were returned to your balance.${reason}`;
-      svcRef
-        .create({ userId: p.userId, type: 'withdrawal.rejected', title, body })
-        .catch((err) => logger.error({ err }, 'withdrawal.rejected notification failed'));
-      sendEmail(p.userId, title, body);
-    });
-
-    ctx.events.on('wallet.bonus_rollover.completed', (payload) => {
-      const parsed = domainEventSchemas['wallet.bonus_rollover.completed'].safeParse(payload);
-      if (!parsed.success || !svcRef) {
-        return;
-      }
-      const p = parsed.data;
-      const title = 'Bonus unlocked';
-      const body = `Your ${p.creditedAmount} ${p.currency} bonus credit has cleared its rollover requirement and is now fully withdrawable.`;
-      svcRef
-        .create({ userId: p.userId, type: 'wallet.bonus_rollover.completed', title, body })
-        .catch((err) =>
-          logger.error({ err }, 'wallet.bonus_rollover.completed notification failed'),
-        );
-    });
-
-    ctx.events.on('social.friend_request.sent', (payload) => {
-      const parsed = domainEventSchemas['social.friend_request.sent'].safeParse(payload);
-      if (!parsed.success || !svcRef) {
-        return;
-      }
-      const p = parsed.data;
-      const title = 'New friend request';
-      const body = `${p.requesterUsername} sent you a friend request.`;
-      svcRef
-        .create({ userId: p.addresseeId, type: 'social.friend_request.received', title, body })
-        .catch((err) => logger.error({ err }, 'social.friend_request.sent notification failed'));
-    });
-
-    ctx.events.on('social.friend_request.accepted', (payload) => {
-      const parsed = domainEventSchemas['social.friend_request.accepted'].safeParse(payload);
-      if (!parsed.success || !svcRef) {
-        return;
-      }
-      const p = parsed.data;
-      const title = 'Friend request accepted';
-      const body = `${p.accepterUsername} accepted your friend request.`;
-      svcRef
-        .create({ userId: p.requesterId, type: 'social.friend_request.accepted', title, body })
-        .catch((err) =>
-          logger.error({ err }, 'social.friend_request.accepted notification failed'),
-        );
-    });
+    for (const entry of notificationEventMap) {
+      ctx.events.on(entry.event, (payload) => {
+        const input = entry.handle(payload);
+        if (!input || !svcRef) {
+          return;
+        }
+        const svc = svcRef;
+        svc
+          .create(input)
+          .then((record) => {
+            publishNotification(record);
+            if (entry.sendEmail) {
+              sendEmail(input.userId, input.title, input.body);
+            }
+          })
+          .catch((err) =>
+            logger.error({ err, event: entry.event }, 'notification dispatch failed'),
+          );
+      });
+    }
 
     ctx.events.on('compliance.kyc.updated', (payload, envelope) => {
       const parsed = domainEventSchemas['compliance.kyc.updated'].safeParse(payload);
@@ -156,16 +355,10 @@ export default {
         if (!svcRef) {
           return;
         }
-        const reasonText = payload.reason ? ` Reason: ${payload.reason}.` : '';
-        const title = 'Document resubmission required';
-        const body = `An admin has requested you resubmit your verification documents.${reasonText}`;
-        await svcRef.create({
-          userId: payload.userId,
-          type: 'kyc.resubmission_requested',
-          title,
-          body,
-        });
-        sendEmail(payload.userId, title, body);
+        const input = buildKycResubmissionNotification(payload);
+        const record = await svcRef.create(input);
+        publishNotification(record);
+        sendEmail(input.userId, input.title, input.body);
       },
     });
 
@@ -175,7 +368,8 @@ export default {
       deliveryRef = c.get(NOTIFICATION_DELIVERY_ADAPTER);
       directoryRef = c.get(ADMIN_USER_DIRECTORY);
       jobQueueRef = c.get(JOB_QUEUE);
-      return createNotificationsRouter(svc);
+      realtimeRef = c.get(REALTIME_TRANSPORT);
+      return createNotificationsRouter({ notifications: svc, realtime: realtimeRef });
     });
   },
 } as const satisfies Plugin<CoreTokenCatalog>;

--- a/packages/core/src/engagement/notifications/plugin.ts
+++ b/packages/core/src/engagement/notifications/plugin.ts
@@ -3,6 +3,7 @@ import {
   ADMIN_USER_DIRECTORY,
   JOB_QUEUE,
   NOTIFICATION_DELIVERY_ADAPTER,
+  PLATFORM_CONFIG,
   REALTIME_TRANSPORT,
   UuidSchema,
   domainEventSchemas,
@@ -23,27 +24,36 @@ import {
   toNotificationDto,
 } from './router/index.js';
 import { NotificationsService } from './service/notifications.service.js';
-import type { CreateNotificationInput } from './contract/index.js';
+import { CreateNotificationInputSchema, type CreateNotificationInput } from './contract/index.js';
 
 const KYC_RESUBMISSION_NOTIFY_QUEUE = queue('kyc-resubmission-notify');
 const NOTIFICATIONS_RETENTION_PURGE_QUEUE = queue('notifications-retention-purge');
-const NOTIFICATION_RETENTION_DAYS = 30;
+const NOTIFICATIONS_DISPATCH_QUEUE = queue('notifications-dispatch');
+
+const DEFAULT_NOTIFICATIONS_RETENTION_DAYS = 30;
+const DEFAULT_NOTIFICATIONS_RETENTION_CRON = '0 3 * * *';
 
 const KycResubmissionNotifyJobSchema = z.object({
   userId: UuidSchema,
   reason: z.string().nullable(),
 });
 
-// p.amount on every wallet/chat/gaming event payload is a MoneyAmount decimal string
-// scaled to MONEY_SCALE = 18 (crypto-first precision), eg "100.000000000000000000" -
-// display-only trimming for notification text; Number() can lose precision below its
-// ~15-17 significant digits for an extreme 18-decimal value, an accepted tradeoff.
+const NotificationDispatchJobSchema = z.object({
+  event: z.string(),
+  input: CreateNotificationInputSchema,
+  sendEmail: z.boolean(),
+});
+
 function formatMoneyAmount(amount: string): string {
-  const value = Number(amount);
-  if (!Number.isFinite(value)) {
+  const match = /^(-)?(\d+)(?:\.(\d+))?$/.exec(amount);
+  if (!match) {
     return amount;
   }
-  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 8 }).format(value);
+  const [, sign, integerPart, fractionPart] = match;
+  const groupedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const trimmedFraction = fractionPart ? fractionPart.replace(/0+$/, '') : '';
+  const magnitude = trimmedFraction ? `${groupedInteger}.${trimmedFraction}` : groupedInteger;
+  return sign ? `${sign}${magnitude}` : magnitude;
 }
 
 type NotificationMapEntry = {
@@ -121,7 +131,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       body: `Your withdrawal request of ${formatMoneyAmount(p.amount)} ${p.currency} has been received and is pending review.`,
       data: { transactionId: p.transactionId },
     }),
-    { sendEmail: true },
+    { sendEmail: false },
   ),
 
   mapEvent(
@@ -133,7 +143,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       body: `Your withdrawal of ${formatMoneyAmount(p.amount)} ${p.currency} has been completed.`,
       data: { transactionId: p.transactionId },
     }),
-    { sendEmail: true },
+    { sendEmail: false },
   ),
 
   mapEvent(
@@ -145,7 +155,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       body: `Your withdrawal of ${formatMoneyAmount(p.amount)} ${p.currency} failed and the funds were returned to your balance.`,
       data: { transactionId: p.transactionId },
     }),
-    { sendEmail: true },
+    { sendEmail: false },
   ),
 
   mapEvent(
@@ -157,7 +167,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       body: `Your deposit of ${formatMoneyAmount(p.amount)} ${p.currency} has been completed.`,
       data: { transactionId: p.transactionId },
     }),
-    { sendEmail: true },
+    { sendEmail: false },
   ),
 
   mapEvent(
@@ -169,7 +179,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       body: `Your balance was ${p.direction === 'credit' ? 'credited' : 'debited'} ${formatMoneyAmount(p.amount)} ${p.currency}. Reason: ${p.reason}.`,
       data: { transactionId: p.transactionId },
     }),
-    { sendEmail: true },
+    { sendEmail: false },
   ),
 
   mapEvent(
@@ -178,7 +188,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       userId: p.userId,
       type: 'wallet.bonus_rollover.completed',
       title: 'Bonus unlocked',
-      body: `Your ${p.creditedAmount} ${p.currency} bonus credit has cleared its rollover requirement and is now fully withdrawable.`,
+      body: `Your ${formatMoneyAmount(p.creditedAmount)} ${p.currency} bonus credit has cleared its rollover requirement and is now fully withdrawable.`,
       data: null,
     }),
     { sendEmail: false },
@@ -193,7 +203,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       body: `${p.senderUsername} sent you ${formatMoneyAmount(p.amount)} ${p.currency}.`,
       data: compactData({ roomId: p.roomId }),
     }),
-    { sendEmail: true },
+    { sendEmail: false },
   ),
 
   mapEvent(
@@ -205,7 +215,7 @@ export const notificationEventMap: NotificationMapEntry[] = [
       body: 'You were mentioned in a chat message.',
       data: compactData({ roomId: p.roomId, messageId: p.messageId }),
     }),
-    { sendEmail: true },
+    { sendEmail: false },
   ),
 
   // Pre-existing types: in-app only, unchanged from before the declarative-map refactor.
@@ -233,33 +243,6 @@ export const notificationEventMap: NotificationMapEntry[] = [
       data: { accepterId: p.accepterId },
     }),
     { sendEmail: false },
-  ),
-
-  // Dormant: gaming.bet.settled and bonus.granted have no emitter yet (see
-  // contracts/schemas/events.ts). These entries never fire until a future module
-  // publishes them, but the mapping is ready the moment one does.
-  mapEvent(
-    'gaming.bet.settled',
-    (p) => ({
-      userId: p.userId,
-      type: 'bet.settled',
-      title: p.outcome === 'win' ? 'Bet won' : 'Bet settled',
-      body: `Your bet settled as a ${p.outcome} for ${formatMoneyAmount(p.amount)} ${p.currency}.`,
-      data: { roundId: p.roundId },
-    }),
-    { sendEmail: true },
-  ),
-
-  mapEvent(
-    'bonus.granted',
-    (p) => ({
-      userId: p.userId,
-      type: 'bonus.granted',
-      title: 'Bonus granted',
-      body: `You were granted a bonus of ${formatMoneyAmount(p.amount)} ${p.currency}.`,
-      data: { bonusId: p.bonusId },
-    }),
-    { sendEmail: true },
   ),
 ];
 
@@ -293,6 +276,7 @@ export default {
     let directoryRef: AdminUserDirectory | null = null;
     let jobQueueRef: JobQueueAdapter | null = null;
     let realtimeRef: RealtimeTransport | null = null;
+    let retentionDaysRef = DEFAULT_NOTIFICATIONS_RETENTION_DAYS;
 
     // Best-effort email alongside the in-app notification; a missing user or delivery
     // failure is logged, never thrown - the in-app notification already landed.
@@ -313,7 +297,9 @@ export default {
         .catch((err) => logger.error({ err }, 'notification email delivery failed'));
     };
 
-    const publishNotification = (record: Awaited<ReturnType<NotificationsService['create']>>) => {
+    const publishNotification = (
+      record: NonNullable<Awaited<ReturnType<NotificationsService['create']>>>,
+    ) => {
       if (!realtimeRef) {
         return;
       }
@@ -326,22 +312,27 @@ export default {
     };
 
     for (const entry of notificationEventMap) {
-      ctx.events.on(entry.event, (payload) => {
+      ctx.events.on(entry.event, (payload, envelope) => {
         const input = entry.handle(payload);
-        if (!input || !svcRef) {
+        if (!input || !jobQueueRef || !envelope) {
           return;
         }
-        const svc = svcRef;
-        svc
-          .create(input)
-          .then((record) => {
-            publishNotification(record);
-            if (entry.sendEmail) {
-              sendEmail(input.userId, input.title, input.body);
-            }
-          })
+        jobQueueRef
+          .enqueue(
+            NOTIFICATIONS_DISPATCH_QUEUE,
+            {
+              event: entry.event,
+              input: { ...input, eventId: envelope.eventId },
+              sendEmail: entry.sendEmail,
+            },
+            {
+              idempotencyKey: `notifications-dispatch:${envelope.eventId}`,
+              attempts: 5,
+              backoff: { type: 'exponential', delayMs: 1000 },
+            },
+          )
           .catch((err) =>
-            logger.error({ err, event: entry.event }, 'notification dispatch failed'),
+            logger.error({ err, event: entry.event }, 'notification dispatch enqueue failed'),
           );
       });
     }
@@ -355,11 +346,18 @@ export default {
       if (p.status !== 'resubmission_requested' || p.source !== 'manual') {
         return;
       }
+      if (!envelope?.eventId) {
+        logger.warn(
+          { userId: p.userId },
+          'kyc-resubmission-notify enqueue skipped: missing eventId',
+        );
+        return;
+      }
       jobQueueRef
         .enqueue(
           KYC_RESUBMISSION_NOTIFY_QUEUE,
           { userId: p.userId, reason: p.reason },
-          { idempotencyKey: `kyc-resubmission-notify:${envelope?.eventId ?? p.userId}` },
+          { idempotencyKey: `kyc-resubmission-notify:${envelope.eventId}` },
         )
         .catch((err) => logger.error({ err }, 'kyc-resubmission-notify enqueue failed'));
     });
@@ -373,8 +371,35 @@ export default {
         }
         const input = buildKycResubmissionNotification(payload);
         const record = await svcRef.create(input);
+        if (!record) {
+          return;
+        }
         publishNotification(record);
         sendEmail(input.userId, input.title, input.body);
+      },
+    });
+
+    ctx.jobs.worker({
+      queue: NOTIFICATIONS_DISPATCH_QUEUE,
+      schema: NotificationDispatchJobSchema,
+      handler: async ({ payload }) => {
+        if (!svcRef) {
+          return;
+        }
+        const record = await svcRef.create(payload.input);
+        if (!record) {
+          return;
+        }
+        publishNotification(record);
+        if (payload.sendEmail) {
+          sendEmail(record.userId, record.title, record.body);
+        }
+      },
+      onDeadLetter: (jobCtx, error) => {
+        logger.error(
+          { err: error, event: jobCtx.payload.event, jobId: jobCtx.id },
+          'notification dispatch exhausted retries',
+        );
       },
     });
 
@@ -385,7 +410,7 @@ export default {
         if (!svcRef) {
           return;
         }
-        const { count } = await svcRef.purgeExpired(NOTIFICATION_RETENTION_DAYS);
+        const { count } = await svcRef.purgeExpired(retentionDaysRef);
         logger.info({ count }, 'notification retention purge complete');
       },
     });
@@ -397,13 +422,18 @@ export default {
       directoryRef = c.get(ADMIN_USER_DIRECTORY);
       jobQueueRef = c.get(JOB_QUEUE);
       realtimeRef = c.get(REALTIME_TRANSPORT);
+      const platformConfig = c.has(PLATFORM_CONFIG) ? c.get(PLATFORM_CONFIG) : undefined;
+      retentionDaysRef =
+        platformConfig?.notifications?.retention?.days ?? DEFAULT_NOTIFICATIONS_RETENTION_DAYS;
+      const purgeCron =
+        platformConfig?.notifications?.retention?.cron ?? DEFAULT_NOTIFICATIONS_RETENTION_CRON;
       // Off-peak, one hour after tag's daily-evaluation (0 2 * * *), so the in-process
       // driver doesn't run both sweeps at once in dev/test.
       void jobQueueRef.schedule(
         NOTIFICATIONS_RETENTION_PURGE_QUEUE,
         'notifications.retention-purge.daily',
         {},
-        { cron: '0 3 * * *' },
+        { cron: purgeCron },
       );
       return createNotificationsRouter({ notifications: svc, realtime: realtimeRef });
     });

--- a/packages/core/src/engagement/notifications/plugin.ts
+++ b/packages/core/src/engagement/notifications/plugin.ts
@@ -195,18 +195,6 @@ export const notificationEventMap: NotificationMapEntry[] = [
   ),
 
   mapEvent(
-    'chat.donate.sent',
-    (p) => ({
-      userId: p.recipientId,
-      type: 'tip.received',
-      title: 'You received a tip',
-      body: `${p.senderUsername} sent you ${formatMoneyAmount(p.amount)} ${p.currency}.`,
-      data: compactData({ roomId: p.roomId }),
-    }),
-    { sendEmail: false },
-  ),
-
-  mapEvent(
     'chat.user.mentioned',
     (p) => ({
       userId: p.mentionedUserId,

--- a/packages/core/src/engagement/notifications/react/notifications.ts
+++ b/packages/core/src/engagement/notifications/react/notifications.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { useCallback } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import type { Paginated } from '@openora/core/contracts/kit';
+import {
+  useEventStream,
+  useOrpcClient,
+  useOrpcQueryUtils,
+  type UseEventStreamOptions,
+  type UseEventStreamResult,
+} from '@openora/core/react';
+import {
+  notificationsContract,
+  type MarkNotificationReadOutput,
+  type Notification,
+  type NotificationCount,
+} from '../contract/index.js';
+
+export type UseNotificationsResult = UseQueryResult<Paginated<Notification>, Error>;
+export type UseUnreadNotificationCountResult = UseQueryResult<NotificationCount, Error>;
+export type UseMarkNotificationReadResult = UseMutationResult<
+  MarkNotificationReadOutput,
+  Error,
+  { id: string }
+>;
+export type UseMarkAllNotificationsReadResult = UseMutationResult<
+  NotificationCount,
+  Error,
+  unknown
+>;
+export type UseNotificationStreamResult = UseEventStreamResult<Notification>;
+
+type NotificationsUtils = ReturnType<typeof useOrpcQueryUtils<typeof notificationsContract>>;
+
+const invalidateNotifications = (utils: NotificationsUtils, queryClient: QueryClient) => () =>
+  Promise.all([
+    queryClient.invalidateQueries({ queryKey: utils.list.key() }),
+    queryClient.invalidateQueries({ queryKey: utils.unreadCount.key() }),
+  ]);
+
+export function useNotifications(
+  input: { page?: number; limit?: number } = {},
+): UseNotificationsResult {
+  const utils = useOrpcQueryUtils(notificationsContract);
+  return useQuery(utils.list.queryOptions({ input }));
+}
+
+export function useUnreadNotificationCount(): UseUnreadNotificationCountResult {
+  const utils = useOrpcQueryUtils(notificationsContract);
+  return useQuery(utils.unreadCount.queryOptions({ input: {} }));
+}
+
+export function useMarkNotificationRead(): UseMarkNotificationReadResult {
+  const utils = useOrpcQueryUtils(notificationsContract);
+  const queryClient = useQueryClient();
+  return useMutation({
+    ...utils.markRead.mutationOptions(),
+    onSuccess: invalidateNotifications(utils, queryClient),
+  });
+}
+
+export function useMarkAllNotificationsRead(): UseMarkAllNotificationsReadResult {
+  const utils = useOrpcQueryUtils(notificationsContract);
+  const queryClient = useQueryClient();
+  return useMutation({
+    ...utils.markAllRead.mutationOptions(),
+    onSuccess: invalidateNotifications(utils, queryClient),
+  });
+}
+
+export function useNotificationStream(
+  options?: UseEventStreamOptions<Notification>,
+): UseNotificationStreamResult {
+  const client = useOrpcClient(notificationsContract);
+  const subscribe = useCallback(
+    (signal: AbortSignal) => client.stream(undefined, { signal }),
+    [client],
+  );
+  return useEventStream<Notification>(subscribe, options);
+}

--- a/packages/core/src/engagement/notifications/router/index.ts
+++ b/packages/core/src/engagement/notifications/router/index.ts
@@ -9,6 +9,7 @@ import type { RealtimeTransport, User } from '@openora/core/contracts';
 import {
   notificationsContract,
   NotificationTypeSchema,
+  NotificationDataSchema,
   type Notification,
 } from '../contract/index.js';
 import type { Notification as NotificationRow } from '../schema/index.js';
@@ -27,13 +28,18 @@ export function toNotificationDto(row: NotificationRow): Notification | null {
   if (!type.success) {
     return null;
   }
+  const data =
+    row.data === null || row.data === undefined ? null : NotificationDataSchema.safeParse(row.data);
+  if (data && !data.success) {
+    return null;
+  }
   return {
     id: row.id,
     userId: row.userId,
     type: type.data,
     title: row.title,
     body: row.body,
-    data: row.data ?? null,
+    data: data ? data.data : null,
     readAt: row.readAt ? row.readAt.toISOString() : null,
     createdAt: row.createdAt.toISOString(),
   };
@@ -61,7 +67,7 @@ export function createNotificationsRouter({
 
   return os.router({
     list: os.list.handler(({ input, context }) =>
-      notifications.listForUser({ userId: getUserId(context), ...input }).then((page) => ({
+      notifications.listForUser({ ...input, userId: getUserId(context) }).then((page) => ({
         ...page,
         items: page.items.flatMap((row) => {
           const dto = toNotificationDto(row);

--- a/packages/core/src/engagement/notifications/router/index.ts
+++ b/packages/core/src/engagement/notifications/router/index.ts
@@ -1,33 +1,81 @@
 import { implement } from '@orpc/server';
-import { getUserId, mapErrors, type OssContext } from '@openora/core/server';
-import { notificationsContract, NotificationTypeSchema } from '../contract/index.js';
+import {
+  createEventStreamGenerator,
+  getUserId,
+  mapErrors,
+  type OssContext,
+} from '@openora/core/server';
+import type { RealtimeTransport, User } from '@openora/core/contracts';
+import {
+  notificationsContract,
+  NotificationTypeSchema,
+  type Notification,
+} from '../contract/index.js';
+import type { Notification as NotificationRow } from '../schema/index.js';
 import {
   NotificationsService,
   NotificationNotFoundError,
   NotificationOwnershipError,
 } from '../service/notifications.service.js';
 
-export function createNotificationsRouter(notifications: NotificationsService) {
+export function notificationsChannel(userId: User['id']): string {
+  return `notifications:${userId}`;
+}
+
+export function toNotificationDto(row: NotificationRow): Notification | null {
+  const type = NotificationTypeSchema.safeParse(row.type);
+  if (!type.success) {
+    return null;
+  }
+  return {
+    id: row.id,
+    userId: row.userId,
+    type: type.data,
+    title: row.title,
+    body: row.body,
+    data: row.data ?? null,
+    readAt: row.readAt ? row.readAt.toISOString() : null,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+export function createNotificationStream(
+  realtime: RealtimeTransport,
+  userId: User['id'],
+  signal: AbortSignal | undefined,
+): AsyncGenerator<Notification> {
+  return createEventStreamGenerator(
+    (push) => realtime.subscribe<Notification>(notificationsChannel(userId), push),
+    { signal },
+  );
+}
+
+export function createNotificationsRouter({
+  notifications,
+  realtime,
+}: {
+  notifications: NotificationsService;
+  realtime: RealtimeTransport;
+}) {
   const os = implement(notificationsContract).$context<OssContext>();
 
   return os.router({
-    list: os.list.handler(({ context }) =>
-      notifications.listForUser(getUserId(context)).then((items) =>
-        items.flatMap((n) => {
-          const type = NotificationTypeSchema.safeParse(n.type);
-          if (!type.success) {
-            return [];
-          }
-          return [
-            {
-              ...n,
-              type: type.data,
-              readAt: n.readAt ? n.readAt.toISOString() : null,
-              createdAt: n.createdAt.toISOString(),
-            },
-          ];
+    list: os.list.handler(({ input, context }) =>
+      notifications.listForUser({ userId: getUserId(context), ...input }).then((page) => ({
+        ...page,
+        items: page.items.flatMap((row) => {
+          const dto = toNotificationDto(row);
+          return dto ? [dto] : [];
         }),
-      ),
+      })),
+    ),
+
+    unreadCount: os.unreadCount.handler(({ context }) =>
+      notifications.unreadCount(getUserId(context)).then((count) => ({ count })),
+    ),
+
+    stream: os.stream.handler(({ signal, context }) =>
+      createNotificationStream(realtime, getUserId(context), signal),
     ),
 
     markRead: os.markRead.handler(async ({ input, context }) => {

--- a/packages/core/src/engagement/notifications/schema/index.ts
+++ b/packages/core/src/engagement/notifications/schema/index.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, jsonb, index } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, timestamp, jsonb, index, uniqueIndex } from 'drizzle-orm/pg-core';
 
 export const notification = pgTable(
   'notification',
@@ -11,8 +11,12 @@ export const notification = pgTable(
     data: jsonb().$type<Record<string, string>>(),
     readAt: timestamp({ withTimezone: true }),
     createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+    eventId: uuid(),
   },
-  (t) => [index('notification_user_id_idx').on(t.userId)],
+  (t) => [
+    index('notification_user_id_idx').on(t.userId),
+    uniqueIndex('notification_event_id_idx').on(t.eventId),
+  ],
 );
 
 export type Notification = typeof notification.$inferSelect;

--- a/packages/core/src/engagement/notifications/schema/index.ts
+++ b/packages/core/src/engagement/notifications/schema/index.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, index } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, timestamp, jsonb, index } from 'drizzle-orm/pg-core';
 
 export const notification = pgTable(
   'notification',
@@ -8,6 +8,7 @@ export const notification = pgTable(
     type: text().notNull(),
     title: text().notNull(),
     body: text().notNull(),
+    data: jsonb().$type<Record<string, string>>(),
     readAt: timestamp({ withTimezone: true }),
     createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/core/src/engagement/notifications/service/notifications.service.ts
+++ b/packages/core/src/engagement/notifications/service/notifications.service.ts
@@ -10,7 +10,7 @@ import {
 } from '@openora/core/server';
 import { eq, and, isNull, asc, desc, count, lt } from 'drizzle-orm';
 import type { PaginationOptions, User } from '@openora/core/contracts';
-import { notification } from '../schema/index.js';
+import { notification, type Notification } from '../schema/index.js';
 import type { CreateNotificationInput, NotificationSortBy } from '../contract/index.js';
 
 export const NotificationNotFoundError = makeNotFoundError('Notification');
@@ -28,14 +28,18 @@ export class NotificationsService {
     private readonly events: EventBus,
   ) {}
 
-  async create(input: CreateNotificationInput) {
-    const record = findOneOrThrow(
-      await this.drizzle.db
-        .insert(notification)
-        .values({ ...input, data: input.data ?? null })
-        .returning(),
-      new NotificationInsertFailedError(),
-    );
+  async create(input: CreateNotificationInput): Promise<Notification | null> {
+    const [record] = await this.drizzle.db
+      .insert(notification)
+      .values({ ...input, data: input.data ?? null, eventId: input.eventId ?? null })
+      .onConflictDoNothing({ target: notification.eventId })
+      .returning();
+    if (!record) {
+      if (input.eventId) {
+        return null;
+      }
+      throw new NotificationInsertFailedError();
+    }
     this.events.emit('notifications.created', {
       notificationId: record.id,
       userId: input.userId,
@@ -47,6 +51,7 @@ export class NotificationsService {
     userId,
     page,
     limit,
+    sortBy = 'createdAt',
     sortOrder,
   }: PaginationOptions<{ userId: User['id'] }, NotificationSortBy>) {
     const dir = sortOrder === 'asc' ? asc : desc;
@@ -56,7 +61,7 @@ export class NotificationsService {
         .select()
         .from(notification)
         .where(where)
-        .orderBy(dir(notification.createdAt))
+        .orderBy(dir(notification[sortBy]))
         .limit(limit)
         .offset(pageToOffset(page, limit)),
       this.drizzle.db.select({ n: count() }).from(notification).where(where),
@@ -102,10 +107,9 @@ export class NotificationsService {
   // the retention window regardless of read state.
   async purgeExpired(retentionDays: number) {
     const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
-    const rows = await this.drizzle.db
+    const result = await this.drizzle.db
       .delete(notification)
-      .where(lt(notification.createdAt, cutoff))
-      .returning({ id: notification.id });
-    return { count: rows.length };
+      .where(lt(notification.createdAt, cutoff));
+    return { count: result.rowCount ?? 0 };
   }
 }

--- a/packages/core/src/engagement/notifications/service/notifications.service.ts
+++ b/packages/core/src/engagement/notifications/service/notifications.service.ts
@@ -8,7 +8,7 @@ import {
   findOneOrThrow,
   pageToOffset,
 } from '@openora/core/server';
-import { eq, and, isNull, asc, desc, count } from 'drizzle-orm';
+import { eq, and, isNull, asc, desc, count, lt } from 'drizzle-orm';
 import type { PaginationOptions, User } from '@openora/core/contracts';
 import { notification } from '../schema/index.js';
 import type { CreateNotificationInput, NotificationSortBy } from '../contract/index.js';
@@ -94,6 +94,17 @@ export class NotificationsService {
       .update(notification)
       .set({ readAt: new Date() })
       .where(and(eq(notification.userId, userId), isNull(notification.readAt)))
+      .returning({ id: notification.id });
+    return { count: rows.length };
+  }
+
+  // Unconditional on age (read or unread), not gated on readAt - deletes anything past
+  // the retention window regardless of read state.
+  async purgeExpired(retentionDays: number) {
+    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+    const rows = await this.drizzle.db
+      .delete(notification)
+      .where(lt(notification.createdAt, cutoff))
       .returning({ id: notification.id });
     return { count: rows.length };
   }

--- a/packages/core/src/engagement/notifications/service/notifications.service.ts
+++ b/packages/core/src/engagement/notifications/service/notifications.service.ts
@@ -6,11 +6,12 @@ import {
   assertOwnership,
   DrizzleService,
   findOneOrThrow,
+  pageToOffset,
 } from '@openora/core/server';
-import { eq, and, isNull, desc } from 'drizzle-orm';
-import type { User } from '@openora/core/contracts';
+import { eq, and, isNull, asc, desc, count } from 'drizzle-orm';
+import type { PaginationOptions, User } from '@openora/core/contracts';
 import { notification } from '../schema/index.js';
-import type { CreateNotificationInput } from '../contract/index.js';
+import type { CreateNotificationInput, NotificationSortBy } from '../contract/index.js';
 
 export const NotificationNotFoundError = makeNotFoundError('Notification');
 
@@ -31,7 +32,7 @@ export class NotificationsService {
     const record = findOneOrThrow(
       await this.drizzle.db
         .insert(notification)
-        .values({ ...input })
+        .values({ ...input, data: input.data ?? null })
         .returning(),
       new NotificationInsertFailedError(),
     );
@@ -42,13 +43,33 @@ export class NotificationsService {
     return record;
   }
 
-  async listForUser(userId: User['id']) {
-    return this.drizzle.db
-      .select()
+  async listForUser({
+    userId,
+    page,
+    limit,
+    sortOrder,
+  }: PaginationOptions<{ userId: User['id'] }, NotificationSortBy>) {
+    const dir = sortOrder === 'asc' ? asc : desc;
+    const where = eq(notification.userId, userId);
+    const [rows, [{ n }]] = await Promise.all([
+      this.drizzle.db
+        .select()
+        .from(notification)
+        .where(where)
+        .orderBy(dir(notification.createdAt))
+        .limit(limit)
+        .offset(pageToOffset(page, limit)),
+      this.drizzle.db.select({ n: count() }).from(notification).where(where),
+    ]);
+    return { items: rows, total: Number(n), page, limit };
+  }
+
+  async unreadCount(userId: User['id']) {
+    const [{ n }] = await this.drizzle.db
+      .select({ n: count() })
       .from(notification)
-      .where(eq(notification.userId, userId))
-      .orderBy(desc(notification.createdAt))
-      .limit(50);
+      .where(and(eq(notification.userId, userId), isNull(notification.readAt)));
+    return Number(n);
   }
 
   async markRead(id: string, userId: User['id']) {

--- a/packages/core/src/engagement/react.ts
+++ b/packages/core/src/engagement/react.ts
@@ -1,0 +1,13 @@
+// `@openora/core/engagement/react` - domain-owned hooks, keeping the base @openora/core/react SDK domain-agnostic.
+export {
+  useNotifications,
+  useUnreadNotificationCount,
+  useMarkNotificationRead,
+  useMarkAllNotificationsRead,
+  useNotificationStream,
+  type UseNotificationsResult,
+  type UseUnreadNotificationCountResult,
+  type UseMarkNotificationReadResult,
+  type UseMarkAllNotificationsReadResult,
+  type UseNotificationStreamResult,
+} from './notifications/react/notifications.js';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -63,6 +63,7 @@
       "@openora/core/engagement/plugins/chat-commands": ["./src/engagement/chat-commands/plugin.ts"],
       "@openora/core/engagement/plugins/notifications": ["./src/engagement/notifications/plugin.ts"],
       "@openora/core/engagement/plugins/social": ["./src/engagement/social/plugin.ts"],
+      "@openora/core/engagement/react": ["./src/engagement/react.ts"],
       "@openora/core/engagement/schema/chat": ["./src/engagement/chat/schema/index.ts"],
       "@openora/core/engagement/schema/chat-commands": ["./src/engagement/chat-commands/schema/index.ts"],
       "@openora/core/engagement/schema/notifications": ["./src/engagement/notifications/schema/index.ts"],

--- a/packages/testing/src/__tests__/kyc.e2e.test.ts
+++ b/packages/testing/src/__tests__/kyc.e2e.test.ts
@@ -360,8 +360,8 @@ describe('KYC admin actions: resubmit / override / bulk-approve (default stack)'
 
     await vi.waitFor(async () => {
       const notifyRes = await client.get('/notifications');
-      const notifications = await readJson(notifyRes);
-      const found = (notifications as Array<{ type: string; body: string }>).find(
+      const { items } = await readJson(notifyRes);
+      const found = (items as Array<{ type: string; body: string }>).find(
         (n) => n.type === 'kyc.resubmission_requested',
       );
       expect(found).toBeTruthy();

--- a/packages/testing/src/__tests__/qa-bonus-rollover.e2e.test.ts
+++ b/packages/testing/src/__tests__/qa-bonus-rollover.e2e.test.ts
@@ -194,11 +194,13 @@ describe('bonus-rollover AC end-to-end: bonus credit -> locked balance -> wageri
     await vi.waitFor(async () => {
       const notifRes = await recipient.get('/notifications');
       expect(notifRes.status).toBe(200);
-      const notifications = (await readJson(notifRes)) as Array<{
-        type: string;
-        title: string;
-        body: string;
-      }>;
+      const { items: notifications } = (await readJson(notifRes)) as {
+        items: Array<{
+          type: string;
+          title: string;
+          body: string;
+        }>;
+      };
       const releaseNotif = notifications.find((n) => n.type === 'wallet.bonus_rollover.completed');
       expect(
         releaseNotif,

--- a/packages/testing/src/__tests__/social-friend-requests.e2e.test.ts
+++ b/packages/testing/src/__tests__/social-friend-requests.e2e.test.ts
@@ -172,11 +172,9 @@ describe('AC: recipient gets an in-app notification, type round-trips, and audit
     await vi.waitFor(async () => {
       const listRes = await b.client.get('/notifications');
       expect(listRes.status).toBe(200);
-      const items = (await readJson(listRes)) as Array<{
-        type: string;
-        title: string;
-        body: string;
-      }>;
+      const { items } = (await readJson(listRes)) as {
+        items: Array<{ type: string; title: string; body: string }>;
+      };
       const row = items.find((n) => n.type === 'social.friend_request.received');
       // This is the exact silent-drop failure mode the brief calls out: a
       // notification whose `type` is missing from NOTIFICATION_TYPES is written
@@ -330,10 +328,9 @@ describe('locked decision: mutual/simultaneous request auto-accepts', () => {
 
     // A was the ORIGINAL requester - A gets the accepted notification, not B.
     await vi.waitFor(async () => {
-      const items = (await readJson(await a.client.get('/notifications'))) as Array<{
-        type: string;
-        body: string;
-      }>;
+      const { items } = (await readJson(await a.client.get('/notifications'))) as {
+        items: Array<{ type: string; body: string }>;
+      };
       const row = items.find((n) => n.type === 'social.friend_request.accepted');
       expect(row).toBeTruthy();
       expect(row?.body).toContain(b.username);
@@ -400,9 +397,9 @@ describe('break-it: rapid concurrent double-submit at the same target', () => {
     expect(await friendshipRowCount(app.container, a.userId, b.userId)).toBe(1);
 
     await vi.waitFor(async () => {
-      const items = (await readJson(await b.client.get('/notifications'))) as Array<{
-        type: string;
-      }>;
+      const { items } = (await readJson(await b.client.get('/notifications'))) as {
+        items: Array<{ type: string }>;
+      };
       const matches = items.filter((n) => n.type === 'social.friend_request.received');
       expect(matches.length).toBe(1);
     });


### PR DESCRIPTION
## Summary

Adds the backend for in-app notifications: triggers from wallet, chat, and social events, correctly formatted money amounts in notification bodies, and a 30-day retention purge job.

## Why

Consumers need a headless notifications surface that reacts to platform events (wallet, chat, social) and exposes them through the notifications contract/router, without unbounded row growth over time.

## Alternatives considered

None.

## Risks

None. `pnpm verify` passes except `test:integration`, which fails locally due to a pre-existing stale Postgres state (`type "wallet_custody_sweep_status" already exists`) unrelated to this change — this branch does not touch wallet schema or migrations.