### PR TITLE
fix(identity): forward better-auth error codes to the client

### DIFF
--- a/packages/core/src/pam/identity/__tests__/identity.service.int.test.ts
+++ b/packages/core/src/pam/identity/__tests__/identity.service.int.test.ts
@@ -478,6 +478,61 @@ describe('IdentityService - login banned-user 403 (not the RG block)', () => {
     );
     expect(events.emit).not.toHaveBeenCalledWith('rg.exclusion.login_blocked', expect.anything());
   });
+
+  it("forwards better-auth's error code so a client can tell an unverified email from bad credentials", async () => {
+    await seedUser();
+    signInEmailMock.mockResolvedValue(
+      jsonResponse({ message: 'Email not verified', code: 'EMAIL_NOT_VERIFIED' }, 403),
+    );
+    const svc = buildService();
+
+    await expect(
+      svc.login({ email: EMAIL, password: 'whatever1' }, {}, new Headers()),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      data: { code: 'EMAIL_NOT_VERIFIED' },
+    });
+  });
+
+  it('omits the data code when better-auth sends none', async () => {
+    await seedUser();
+    signInEmailMock.mockResolvedValue(jsonResponse({ message: 'BANNED_USER' }, 403));
+    const svc = buildService();
+
+    await expect(
+      svc.login({ email: EMAIL, password: 'whatever1' }, {}, new Headers()),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', data: undefined });
+  });
+
+  it('ignores an error body that is not the shape better-auth documents', async () => {
+    await seedUser();
+    signInEmailMock.mockResolvedValue(jsonResponse({ message: 'Denied', code: 42 }, 403));
+    const svc = buildService();
+
+    await expect(
+      svc.login({ email: EMAIL, password: 'whatever1' }, {}, new Headers()),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Request failed (403)',
+      data: undefined,
+    });
+  });
+
+  it('falls back to the status message when the error body is not JSON', async () => {
+    await seedUser();
+    signInEmailMock.mockResolvedValue(
+      new Response('<html>gateway timeout</html>', { status: 403 }),
+    );
+    const svc = buildService();
+
+    await expect(
+      svc.login({ email: EMAIL, password: 'whatever1' }, {}, new Headers()),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Request failed (403)',
+      data: undefined,
+    });
+  });
 });
 
 describe('IdentityService - RG login gate (real PG)', () => {

--- a/packages/core/src/pam/identity/service/identity.service.ts
+++ b/packages/core/src/pam/identity/service/identity.service.ts
@@ -14,6 +14,7 @@ import {
 } from '@openora/core/server';
 import { parseCookies } from 'better-auth/cookies';
 import { and, eq, isNull, sql } from 'drizzle-orm';
+import * as z from 'zod';
 import { user, session, account, verification, twoFactor } from '../schema/index.js';
 import { player } from '@openora/core/pam/schema/profile';
 import type {
@@ -146,6 +147,11 @@ const SUCCESS = { success: true as const };
 export const UserNotFoundError = makeNotFoundError('User');
 export const UsernameConflictError = makeConflictError('Username', 'Username is already in use');
 
+const BetterAuthErrorBodySchema = z.object({
+  message: z.string().optional(),
+  code: z.string().optional(),
+});
+
 // better-auth calls use `asResponse: true`, which returns an error *Response*
 // (4xx/5xx) rather than throwing. Surface those as ORPCErrors so oRPC maps them
 // to the right HTTP status instead of the handler silently returning success.
@@ -169,15 +175,20 @@ async function ensureOk(res: globalThis.Response, opts?: { genericMessage?: stri
     });
   }
   let message = `Request failed (${res.status})`;
-  try {
-    const parsed = JSON.parse(await res.text()) as { message?: string };
-    if (parsed.message) {
-      message = parsed.message;
+  let betterAuthCode: string | undefined;
+  const body = BetterAuthErrorBodySchema.safeParse(await res.json().catch(() => null));
+  if (body.success) {
+    if (body.data.message) {
+      message = body.data.message;
     }
-  } catch {
-    // non-JSON body - keep the default message
+    if (body.data.code) {
+      betterAuthCode = body.data.code;
+    }
   }
-  throw new ORPCError(code, { message });
+  throw new ORPCError(code, {
+    message,
+    ...(betterAuthCode ? { data: { code: betterAuthCode } } : {}),
+  });
 }
 
 const MINUTE_MS = 60 * 1000;


### PR DESCRIPTION
better-auth builds every error body as { message, code } (APIError.from), but ensureOk read only the message and dropped the code. A login rejected for an unverified email was therefore indistinguishable from a wrong password: both arrived as a bare FORBIDDEN/UNAUTHORIZED whose only difference was display text, which is free to change between releases. A consumer was left choosing between one catch-all message and matching on English strings.

The code now travels as data.code, so every better-auth-backed identity route - login, register, password, 2FA - hands the client something typed to branch on.

The anti-enumeration path (genericMessage) still sends no code, and an error body without one produces no data at all, so no error that clients read today changes shape.