### PR TITLE
docs: state what prose owns and strip the code it was duplicating

### DIFF
--- a/.rulesync/rules/conventions.md
+++ b/.rulesync/rules/conventions.md
@@ -40,6 +40,7 @@ Use pure, composable functions and explicit typed wiring. Match local naming and
 | async seam, event, job, or realtime                     | `messaging-and-microservices`        |
 | test                                                    | `docs/standards/testing.md`          |
 | comment or JSDoc                                        | `docs/standards/comments.md`         |
+| prose doc, README, guide                                | `docs/standards/documentation.md`    |
 | hook or typed client                                    | `docs/standards/react-sdk.md`        |
 | commit or PR                                            | `docs/standards/git-delivery.md`     |
 | failing gate or lint rule                               | `docs/standards/enforcement.md`      |

--- a/docs/adapters/custody.md
+++ b/docs/adapters/custody.md
@@ -1,53 +1,52 @@
 # Custody Adapter
 
-The crypto half of the [payment port](./payment.md). Same `PaymentAdapter` interface, plus the
-optional methods a vendor that holds funds per player must implement. Read
-[`docs/standards/custody.md`](../standards/custody.md) for the money rules the caller must
-follow either way; this file is the port and the topology.
+The crypto half of the [payment port](./payment.md): the extra capabilities a vendor needs when it
+holds funds per player rather than settling a charge. Read
+[`docs/standards/custody.md`](../standards/custody.md) for the money rules the caller must follow
+either way; this file is the topology and the flow.
 
-Four vendor shapes this port has to cover, by which optional methods they implement:
+## Four vendor shapes
 
-| Vendor shape                                | issueDepositAddress | parseWebhook | sweep methods       | listTransactions             |
-| ------------------------------------------- | ------------------- | ------------ | ------------------- | ---------------------------- |
-| Synchronous fiat PSP                        | no                  | no           | no                  | optional (settlement report) |
-| Custody with per-player containers          | yes                 | yes          | yes                 | yes                          |
-| Exchange-style, one address + memo          | yes (tag)           | yes          | no (already pooled) | yes                          |
-| Crypto payment processor that pools for you | yes                 | yes          | no                  | yes                          |
+| Vendor shape                               | Issues addresses | Sends webhooks | Pools and sweeps   | Reports its transactions |
+| ------------------------------------------ | ---------------- | -------------- | ------------------ | ------------------------ |
+| Synchronous fiat processor                 | no               | no             | no                 | settlement report only   |
+| Custody with a container per player        | yes              | yes            | yes                | yes                      |
+| Exchange-style, one address plus a tag     | yes, as a tag    | yes            | no, already pooled | yes                      |
+| Crypto processor that pools on your behalf | yes              | yes            | no                 | yes                      |
 
-Sweeping is optional, reconciliation is universal - it applies to a fiat PSP settlement
-report exactly as to an on-chain ledger.
+Sweeping is optional. Reconciliation is not: it applies to a fiat processor's settlement report
+exactly as it applies to an on-chain ledger.
 
-## Why deposit-address topology differs by chain
+## Why the address topology differs by chain
 
-- **UTXO chains** - one shared container can mint unlimited receive addresses, one per
-  player. Attribution is by address alone.
-- **Account/EVM chains** - a container holds one address, so a distinct address per
-  player means one container per player. That single address also serves every token on
-  the chain, which is why a deposit event carries `network` and not just `address` -
-  `address` alone does not identify which chain (or which of several issued rows) it
-  belongs to.
-- **Tag/memo chains** - one shared address plus a per-player tag; attribution is by
-  `(address, tag)`.
+- **UTXO chains** - one container mints an unlimited number of receive addresses, one per player.
+  The address alone identifies the player.
+- **Account chains** - a container holds a single address, so a distinct address per player means a
+  container per player. That one address also serves every token on the chain, and the same string
+  repeats across sibling chains. An inbound event that carries only an address is therefore
+  ambiguous; it must carry the network too.
+- **Tag chains** - one shared address plus a per-player tag. The pair identifies the player, and
+  the tag is optional on the wire, so funds can arrive with none.
 
 ## Custody topology
 
 ```mermaid
 flowchart LR
   subgraph core["wallet module (core)"]
-    catalog["wallet_asset<br/>catalog"]
-    addr["wallet_deposit_address"]
-    ledger["ledger<br/>wallet_balance + wallet_transaction"]
+    catalog["asset catalog"]
+    addr["issued deposit addresses"]
+    ledger["ledger<br/>balances + transactions"]
     sweep["sweep job<br/>owns all policy"]
     recon["reconciliation job"]
   end
 
   subgraph overlay["overlay plugin"]
-    psp["PSP adapter"]
-    custody["custody adapter"]
+    psp["fiat processor binding"]
+    custody["custody binding"]
   end
 
   subgraph vendorside["vendor side"]
-    perplayer["per-player custody container"]
+    perplayer["container per player"]
     shared["shared container"]
     pool["pool"]
     payout["payout source"]
@@ -55,9 +54,9 @@ flowchart LR
 
   catalog --> sweep
   catalog --> recon
-  sweep -- "listSweepableBalances / sweepToPool" --> custody
-  recon -- "listTransactions / getWithdrawalStatus" --> custody
-  recon -- "listTransactions" --> psp
+  sweep -- "list balances, move to pool" --> custody
+  recon -- "list transactions, look up a payout" --> custody
+  recon -- "list settlements" --> psp
   custody -. implemented by .-> perplayer
   custody -. implemented by .-> shared
   perplayer -- sweep --> pool
@@ -70,124 +69,72 @@ flowchart LR
 ```mermaid
 sequenceDiagram
   participant P as Player
-  participant R as Wallet router
-  participant S as WalletService
+  participant C as Wallet (core)
   participant V as Vendor
   participant J as Sweep job (cron)
 
-  P->>R: POST /wallet/deposits/address
-  R->>S: getOrCreateDepositAddress
-  S->>V: issueDepositAddress (once)
-  V-->>S: address (+ network/tag)
-  S-->>S: persist wallet_deposit_address (idempotent)
-  S-->>P: address
+  P->>C: ask for a deposit address
+  C->>V: issue one, first time only
+  V-->>C: address, with its network and any tag
+  C-->>P: address
 
-  Note over P,V: player sends funds on-chain whenever - no call to this API
+  Note over P,V: the player sends funds on-chain whenever - no call to this API
 
-  V->>R: POST /wallet/webhook/{provider}
-  R->>R: verify signature
-  R->>S: parseWebhook -> creditDepositByAddress
-  S-->>S: insert wallet_transaction (dedup on providerRefId) + credit balance
+  V->>C: webhook
+  C->>C: verify, normalise, credit once
 
-  Note over J,V: separate path, its own cron tick - no causal link to the deposit above
-  J->>V: listSweepableBalances / sweepToPool
+  Note over J,V: separate path, its own cron tick, no causal link to the deposit above
+  J->>V: list sweepable balances, move them to the pool
 ```
 
-A deposit never triggers a sweep. Crediting the player and moving the funds into the
-pool are independent code paths - the first happens on every deposit, the second on
-whatever cadence the sweep job runs, and neither waits on the other.
+A deposit never triggers a sweep. Crediting the player and moving the funds are separate paths: the
+first runs on every deposit, the second on the sweep job's own cadence, and neither waits on the
+other. A vendor outage that blocks sweeping must never delay a credit.
 
 ## Sweep cycle
 
-```mermaid
-flowchart TD
-  tick["cron tick"] --> inflight["resolve in-flight sweeps"]
-  inflight --> perprovider["for each provider"]
-  perprovider --> impl{"adapter implements<br/>listSweepableBalances?"}
-  impl -- no --> skip["skip"]
-  impl -- yes --> list["list balances"]
-  list --> perbalance["for each balance"]
-  perbalance --> catalogRow{"catalog row exists?"}
-  catalogRow -- no --> skip
-  catalogRow -- yes --> minDeposit{"amount >= minimum<br/>deposit (dust)?"}
-  minDeposit -- no --> skip
-  minDeposit -- yes --> feeMultiple{"amount >= fee x<br/>fee-multiple?"}
-  feeMultiple -- no --> skip
-  feeMultiple -- yes --> feeCeiling{"fee within ceiling,<br/>unless pool is below<br/>its liquidity floor?"}
-  feeCeiling -- no --> skip
-  feeCeiling -- yes --> noInflight{"no in-flight sweep for<br/>this (user, currency, network)?"}
-  noInflight -- no --> skip
-  noInflight -- yes --> claim["claim a row"]
-  claim --> call["call sweepToPool<br/>(outside the transaction)"]
-  call --> markAudit["mark and audit"]
-```
+Each tick resolves what is still in flight, then considers every balance the vendor reports. A
+balance is swept only when all of these hold:
+
+1. The operator's asset catalog has the currency and network. An unlisted pair is not ours to move.
+2. The amount clears the dust floor. Below it, the fee is a larger share than the funds.
+3. The amount is worth several times the current network fee, so the move is not mostly cost.
+4. The fee itself is under its ceiling - unless the pool has fallen below its liquidity floor, in
+   which case paying an expensive fee beats failing a payout.
+5. Nothing is already in flight for that player, currency and network.
+
+The vendor call happens outside the database transaction, after the row is claimed, and the result
+is audited. Every threshold is set per currency and network: the same token costs cents on one
+chain and dollars on another.
 
 ## Reconciliation
 
-```mermaid
-flowchart TD
-  A["(A) listTransactions<br/>over a window"]
-  B["(B) withdrawals stuck in<br/>processing past an age threshold"]
-  C["(C) live webhook path fails<br/>to attribute a deposit"]
+Three things start a finding.
 
-  A --> depositEvent["deposit event"]
-  depositEvent --> hasRow{"matching ledger row?"}
-  hasRow -- no --> findingCredit["finding<br/>(NEVER auto-credit)"]
-  hasRow -- yes --> amountCheck{"amount / currency match?"}
-  amountCheck -- no --> findingMismatch["finding"]
-  amountCheck -- yes --> reconciled["reconciled"]
+- **The scheduled sweep of vendor transactions.** Every deposit the vendor reports is matched
+  against the ledger. No matching row, or a row whose amount or currency disagrees, is a finding.
+- **Payouts that have waited too long.** Anything still unsettled past an age threshold gets a
+  targeted status lookup. A vendor that reports a final state closes it; a vendor that knows
+  nothing about it is a finding.
+- **The live path failing to attribute a deposit.** Funds arrived and no player could be resolved.
 
-  A --> withdrawalEvent["withdrawal event"]
-  withdrawalEvent --> idempotentRecon["existing idempotent<br/>status reconciliation"]
-
-  B --> lookup["targeted status lookup<br/>(getWithdrawalStatus)"]
-  lookup -- terminal --> idempotentRecon
-  lookup -- null --> findingStuck["finding"]
-
-  C --> findingCredit
-
-  findingCredit --> threshold{"findings over threshold?"}
-  findingMismatch --> threshold
-  findingStuck --> threshold
-  threshold -- yes --> alert["alert"]
-  threshold --> report["admin report"]
-  report --> manual["manual credit by an admin"]
-```
+Findings are reported, never auto-credited. Crediting one is an admin action with an actor and a
+reason, and both the run and the resolution go to the audit log. Findings past a threshold raise an
+alert, because a rising count means the live path is broken, not that the reconciler is working.
 
 ## Policy lives in core, topology lives in the overlay
 
-Core learns the _shape_ of custody - per-player containers, pooling, on-chain fees, a
-provider's transaction list - never a vendor's name. Which chains are UTXO, account-based,
-or tag-based is vendor topology, not policy; it belongs in the overlay adapter, not in
-core.
-
-## Routes this port backs
-
-| Route                                      | Does                                                      | Permission                      |
-| ------------------------------------------ | --------------------------------------------------------- | ------------------------------- |
-| `POST /wallet/webhook/{provider}`          | Routes an inbound webhook to the named provider's adapter | none (signature-verified)       |
-| `POST /wallet/deposits/address`            | Issues (once) and returns the player's deposit address    | player session                  |
-| `POST /wallet/custody/sweep/run`           | Enqueues one sweep cycle on demand                        | `wallet-custody:run`            |
-| `GET /wallet/reconciliation`               | Lists open findings                                       | `wallet-reconciliation:view`    |
-| `POST /wallet/reconciliation/{id}/resolve` | Resolves a finding, including a manual credit             | `wallet-reconciliation:resolve` |
-| `POST /wallet/reconciliation/run`          | Enqueues one reconciliation pass on demand                | `wallet-reconciliation:run`     |
+Core learns the shape of custody - containers per player, pooling, on-chain fees, a vendor's
+transaction list - and never a vendor's name. Which chains are UTXO, account-based or tag-based is
+vendor topology and belongs in the overlay.
 
 ## Running more than one vendor
 
-```mermaid
-flowchart LR
-  tx["transaction"] --> provider["asset catalog's<br/>provider name"]
-  provider --> registry["provider registry"]
-  registry -- "no name bound" --> default["default single binding<br/>(PAYMENT_ADAPTER / PAYMENT_WEBHOOK_VERIFIER)"]
-  registry -- "named vendor" --> named["named vendor's<br/>adapter + verifier pair"]
-```
+The adapter and the webhook verifier are each a single binding, and the last registration wins, so
+two overlays that both bind them would clobber each other. Running a fiat processor and a crypto
+custodian at once therefore goes through a provider registry: the asset catalog names a provider
+per pair, and the registry maps that name to one adapter-and-verifier pair. Core only looks a name
+up; it never discovers vendors by itself, so the operator composes the map in their own plugin.
 
-`PAYMENT_ADAPTER` and `PAYMENT_WEBHOOK_VERIFIER` are single DI bindings, and
-`Container.register` is last-wins - two overlays each rebinding them would clobber each other.
-Running a fiat PSP and a crypto custodian at once therefore goes through `PAYMENT_PROVIDERS`,
-which maps `wallet_asset.providerName` to one `{ adapter, webhookVerifier }` pair. Core only
-looks a name up there; it never discovers vendors itself, so the operator composes that map in
-their own plugin.
-
-The webhook route resolves the verifier and the adapter from the **same** entry, so a body can
-never be verified against one vendor's key and parsed in another's format.
+The webhook route resolves the verifier and the adapter from the **same** entry. A body can never
+be verified against one vendor's key and then parsed in another's format.

--- a/docs/adapters/payment.md
+++ b/docs/adapters/payment.md
@@ -1,133 +1,70 @@
 # Payment Adapter
 
-## Interface
+The seam between the wallet ledger and whoever actually holds or moves the money. Core never
+learns a vendor's name; it learns the shape of what a vendor can do.
 
-Source of truth: [`packages/core/src/contracts/adapters/payment.ts`](../../packages/core/src/contracts/adapters/payment.ts) - `PaymentAdapter`, `PaymentWebhookEvent`, `PaymentWebhookVerifier`, and the `PAYMENT_ADAPTER` / `PAYMENT_WEBHOOK_VERIFIER` tokens.
+Contract: [`packages/core/src/contracts/adapters/payment.ts`](../../packages/core/src/contracts/adapters/payment.ts).
+Read it for the exact method names and shapes. This file covers what the port is for and how a
+binding has to behave. The money rules the caller must follow are in
+[`docs/standards/custody.md`](../standards/custody.md); a vendor that holds funds per player also
+reads [`custody.md`](./custody.md).
 
-This file covers the port and how to bind a synchronous PSP. A vendor that holds funds per player also implements the optional pooling/sweeping methods - see [`custody.md`](./custody.md). The money rules the caller must follow either way are in [`docs/standards/custody.md`](../standards/custody.md).
+## Two vendor shapes
 
-`issueDepositAddress` and `parseWebhook` are optional - present only on address-based/async vendors, omitted by a synchronous PSP (see the two vendor shapes below).
+**A synchronous processor** - card, bank transfer, e-wallet. It takes a charge or a payout and
+answers in the same call with a final outcome. The ledger finalises the transaction immediately.
+It issues no addresses and sends no webhooks, so it implements only the two money-moving
+capabilities.
 
-## Default binding
+**An asynchronous, address-issuing vendor** - a crypto custody rail. Deposits are inbound: the
+player is handed an address once and sends funds whenever, with no further call to this API. A
+payout leaves in a non-final state and settles later. Both directions are confirmed by webhook,
+so this shape also issues addresses and normalises the vendor's webhook payloads.
 
-The `wallet` module ships `MockPaymentAdapter` (synchronous, always returns
-`{ externalId, status: 'completed' }` for both deposits and withdrawals) as the default
-`PAYMENT_ADAPTER` binding, and `HmacPaymentWebhookVerifier` as the default
-`PAYMENT_WEBHOOK_VERIFIER` binding - both wired in `wallet/src/plugin.ts`. This is
-intentionally permissive for local dev; neither talks to a real payment rail.
+Everything beyond those two - pooling, sweeping, transaction listing, address whitelisting - is
+optional. A binding declares what it supports by implementing it; core skips what is absent
+rather than failing.
 
-## Two vendor shapes this port covers
+## What a binding must guarantee
 
-**Synchronous PSP** (card/bank/e-wallet): `processDeposit`/`processWithdrawal` return an
-already-terminal `status` (`'completed'`/`'failed'`) in the same call. The wallet module
-finalizes the transaction immediately - this is `MockPaymentAdapter`'s shape, and the
-one most PSP integrations use. `issueDepositAddress`/`parseWebhook` are omitted
-entirely.
+- **Fail closed on an unverified webhook.** A missing header, an unknown signing key, or a key
+  fetch that failed all mean reject. Never fall through to processing the body.
+- **Verify against the raw bytes.** Parsing the body before verifying changes whitespace and key
+  order, and the signature will not match.
+- **Normalise, never interpret.** The adapter translates a vendor payload into the shared event
+  shape. Deciding whether to credit anyone is the ledger's job, not the adapter's.
+- **Carry an idempotency key on every state-changing call.** A thrown call and a lost response
+  look identical from here, and the retry must not move funds twice.
+- **Return the vendor's own settlement identifier.** It is what makes crediting idempotent, and
+  what an auditor traces.
+- **Say which pairs you serve.** The asset catalog asks the binding whether it can handle a
+  currency and network before an operator saves the pair, so an unsupported pair fails in an
+  admin form rather than on a player's deposit screen.
+- **Do not hold a transaction open across a vendor call.** Network calls belong outside the
+  database transaction; persist a recoverable state first.
 
-**Custody/address-issuing vendor** (a crypto MPC/custody rail): deposits are inbound and
-address-based - a player is handed a deposit address (`issueDepositAddress`) and sends
-funds whenever; the vendor confirms asynchronously via webhook. Withdrawals go through
-multiple intermediate states (`processWithdrawal` returns a non-terminal `status`, eg
-`'submitted'`) before reaching a terminal one, also reported via webhook. Both paths
-resolve through `parseWebhook` -> the wallet's webhook route (`POST /wallet/webhook`) ->
-`WalletService.creditDepositByAddress` / `reconcileWithdrawalStatus`.
+## Deposit flow, address-based vendor
 
-## Binding a real vendor
+1. The player asks for a deposit address. Core issues one through the binding on the first ask and
+   persists it, so a second ask returns the stored address without another vendor call.
+2. The player sends funds on-chain at some later time. Nothing calls this API.
+3. The vendor posts a webhook. Core verifies the signature, asks the binding to normalise the
+   payload, resolves the address back to a player, and credits the ledger once - deduplicated on
+   the vendor's settlement identifier.
 
-1. Create an overlay plugin (or extend an existing one):
+A payout runs the same way in reverse: core submits, the vendor answers "accepted, not final", and
+a later webhook moves the transaction to its final state. A replayed webhook, or one for a
+transaction already finished, does nothing.
 
-```bash
-/scaffold-plugin custody-payment
-```
+## Binding a vendor
 
-2. Implement `PaymentAdapter` against the vendor's API. For a synchronous PSP, only
-   `processDeposit`/`processWithdrawal` are needed. For a custody/address-issuing
-   vendor, add `issueDepositAddress` and `parseWebhook`:
+An overlay plugin in the consumer's repo binds the adapter, and a matching verifier when the
+vendor does not use the default signature scheme. Scaffold it with `/scaffold-plugin`, and
+register it after the wallet module so its binding wins.
 
-```ts
-// extensions/custody-payment/src/custody-payment-adapter.ts
-import type { PaymentAdapter, PaymentWebhookEvent } from '@openora/core/contracts';
+Core ships a mock binding that settles everything instantly. It exists so local development runs
+with no vendor account, and it talks to no real rail. Never let it reach an environment that holds
+real money.
 
-export class CustodyPaymentAdapter implements PaymentAdapter {
-  async processDeposit(amount: string, currency: string, metadata: Record<string, unknown>) {
-    // Not called for an address-based vendor - deposits arrive via webhook instead.
-    throw new Error('use issueDepositAddress + the webhook path for deposits');
-  }
-
-  async processWithdrawal(amount: string, currency: string, metadata: Record<string, unknown>) {
-    // POST to the vendor's payout/transaction API; the vendor confirms async.
-    // Return a non-terminal status - the wallet module leaves the transaction
-    // `processing` and relies on the webhook for the eventual completed/failed.
-    return { externalId: 'vendor-tx-id', status: 'processing' };
-  }
-
-  async issueDepositAddress(userId: string, currency: string) {
-    // POST to the vendor's address/session API for this asset.
-    return { address: 'vendor-issued-address' };
-  }
-
-  parseWebhook(
-    rawBody: string,
-    headers: Record<string, string | string[] | undefined>,
-  ): PaymentWebhookEvent | null {
-    // Normalize the vendor's raw webhook payload into the shared shape.
-    const body = JSON.parse(rawBody);
-    if (body.type === 'deposit') {
-      return {
-        kind: 'deposit',
-        address: body.destinationAddress,
-        amount: body.amount,
-        currency: body.asset,
-        txHash: body.txHash,
-        externalId: body.id,
-      };
-    }
-    if (body.type === 'withdrawal') {
-      return { kind: 'withdrawal', externalId: body.id, status: body.status };
-    }
-    return null;
-  }
-}
-```
-
-3. Bind the adapter (and, if the vendor uses its own signature scheme rather than
-   HMAC-SHA256, a matching `PaymentWebhookVerifier`) in the plugin, AFTER `wallet` in
-   `extensions.config.ts` (last registration wins):
-
-```ts
-// extensions/custody-payment/plugin.ts
-import { PAYMENT_ADAPTER, PAYMENT_WEBHOOK_VERIFIER } from '@openora/core/contracts';
-import type { CoreTokenCatalog, Plugin } from '@openora/core/server';
-import { CustodyPaymentAdapter } from './src/custody-payment-adapter.js';
-
-export default {
-  id: 'custody-payment',
-  dependsOn: ['wallet'],
-  register(ctx) {
-    ctx.provide(PAYMENT_ADAPTER, () => new CustodyPaymentAdapter());
-    // Omit this line to keep the default HmacPaymentWebhookVerifier (PAYMENT_WEBHOOK_SECRET env var).
-  },
-} as const satisfies Plugin<CoreTokenCatalog>;
-```
-
-4. Register in `extensions.config.ts` **after** the `wallet` entry.
-
-## Webhook recipe: create/issue -> webhook reconciles
-
-The address-based/async recipe is the same shape regardless of vendor:
-
-1. Player calls `POST /wallet/deposits/address` (`{ currency }`) -> `getOrCreateDepositAddress`
-   calls `issueDepositAddress` once and persists the result in `wallet_deposit_address`
-   (idempotent - a second call for the same user/asset returns the stored address
-   without a second vendor call).
-2. The vendor sends funds to that address whenever the player deposits, then POSTs a
-   webhook to `POST /wallet/webhook`.
-3. The route verifies the raw body against `PAYMENT_WEBHOOK_VERIFIER` (fail closed on a
-   missing/invalid signature), calls `parseWebhook`, and dispatches: a `deposit` event
-   resolves the address back to a userId and credits the wallet (idempotent on the
-   vendor's `externalId` via the `wallet_transaction.provider_ref_id` unique index); a
-   `withdrawal` event transitions a `processing` transaction to its terminal state
-   (idempotent - a replayed or stray webhook for an already-terminal/unmatched row
-   no-ops).
-
-See the wallet contract and service for the exact route behavior.
+Running a fiat processor and a crypto custodian at the same time goes through the provider
+registry - see [`custody.md`](./custody.md#running-more-than-one-vendor).

--- a/docs/modules/wallet.md
+++ b/docs/modules/wallet.md
@@ -1,35 +1,39 @@
 # Wallet
 
-The money module: what it owns, and the invariants that are easy to break. The rules that
-apply to any balance change are in `docs/standards/money.md`; the crypto-rail rules are in
+The money module: what it owns, and the invariants that are easy to break. The rules for any
+balance change are in `docs/standards/money.md`; the crypto-rail rules are in
 `docs/standards/custody.md`. `packages/core/src/wallet/AGENTS.md` routes between them.
+
+`docs/catalog.json` is the exhaustive list of this module's tables, routes and events. This file
+does not repeat it.
 
 ## What this module owns
 
-- The ledger. A player's balance is `wallet_balance`, and `wallet_transaction` is its
-  immutable history. No chain and no vendor holds a per-player balance.
-- The asset catalog (`wallet_asset`): the `(currency, network)` pairs the operator accepts,
-  each pair's provider asset id, minimums, fee, and independent deposit/withdrawal toggles.
-- Issued deposit addresses, saved payout addresses, per-player provider containers, the
-  custody sweep, reconciliation findings, and the withdrawal approval path.
-
-`docs/catalog.json` is the exhaustive table and route list; this file does not repeat it.
+- **The ledger.** A player's balance is a row here, and its transaction history is immutable. No
+  chain and no vendor holds a per-player balance.
+- **The asset catalog.** The currency-and-network pairs the operator accepts, and for each pair the
+  vendor's own asset identifier, the minimums, the fee, and independent switches for deposit and
+  withdrawal. Which pairs exist is operator configuration, not code.
+- **The custody surface.** Issued deposit addresses, saved payout destinations, per-player vendor
+  containers, the sweep, reconciliation findings, and the withdrawal approval path.
 
 ## Rules that are easy to get wrong here
 
-- A currency does not identify a chain. Anything that reconciles, prices, or limits works on
-  `(currency, network)`. Only a fiat rail and an internal transaction type carry a null network.
-- Every ledger row records its direction explicitly. Do not infer direction from the type: a
-  social transfer writes the same type for the sender's debit and the recipient's credit.
-- Cross-module money moves through `WALLET_COMMANDS` with the caller's transaction. Never
-  import wallet tables from another module and never settle a transfer over an event.
-- A vendor call is not transactional. Persist a recoverable state first, make each settlement
+- **A currency does not identify a chain.** Anything that reconciles, prices, or limits works on
+  the currency and the network together. Only a fiat rail and an internal movement have no network.
+- **Every ledger row records its direction explicitly.** Direction is never inferred from the kind
+  of transaction: a player-to-player transfer writes the same kind for the sender's debit and the
+  recipient's credit.
+- **Cross-module money moves through the wallet's command port, inside the caller's transaction.**
+  Another module never reads or writes wallet tables directly, and a transfer is never settled over
+  an event.
+- **A vendor call is not transactional.** Persist a recoverable state first, make every settlement
   transition idempotent, and compensate a failed held withdrawal exactly once.
-- The balance stream publishes a change signal with no amount. A dropped frame must not be
-  able to leave a stale number on screen; the client refetches. Wire a publish for every event
-  that moves a settled balance, both legs of a social transfer included.
-- Admin routes assert `AdminGuard` on the handler's first line. A manual adjustment, an
-  approval, a rejection, a catalog edit and a resolved finding each write an audit entry with
-  actor and reason.
-- The webhook route resolves the verifier and the adapter from the same provider registry
-  entry, and fails closed when either is missing.
+- **The balance stream carries a signal, not an amount.** A dropped frame must not be able to leave
+  a stale number on screen, so the client refetches. Every event that moves a settled balance
+  publishes one, both legs of a player-to-player transfer included.
+- **Admin actions are guarded and audited.** The guard is the first line of the handler. A manual
+  adjustment, an approval, a rejection, a catalog edit and a resolved finding each write an audit
+  entry naming the actor and the reason.
+- **The webhook path resolves the verifier and the adapter from the same provider entry,** and
+  fails closed when either is missing.

--- a/docs/standards/custody.md
+++ b/docs/standards/custody.md
@@ -11,9 +11,9 @@ inbound deposit.
 
 ## Attribution
 
-- Key on `(address, network)`, never the address alone. One account-chain address serves every
-  token on that chain and repeats across sibling chains, so an address maps to many issued rows.
-  A unique index enforces this.
+- Key on the address **and** its network, never the address alone. One account-chain address
+  serves every token on that chain and repeats across sibling chains, so an address alone maps to
+  many issued rows. The database enforces the pair.
 - A tag is optional on the wire, so funds can arrive with no tag or the wrong one. Persist the
   tag with the issued address, and read the **destination** tag on an inbound event.
 - Never attribute by amount and time. An unattributable deposit becomes a reconciliation
@@ -40,7 +40,7 @@ inbound deposit.
 - Moving a token on an account chain needs that chain's native asset in the same container.
   Either top each container up or relay the fee from one funding container - never both on the
   same chain, which funds it twice and strands the surplus.
-- Set limits per `(currency, network)`. The same token costs cents on one chain and dollars on
+- Set limits per currency **and** network. The same token costs cents on one chain and dollars on
   another, so one currency-wide floor is either too high for the cheap chain or below the fee
   on the expensive one.
 
@@ -49,7 +49,7 @@ inbound deposit.
 - Debit inside the transaction that creates the withdrawal row, and refund in full on rejection.
 - Register a payout destination with the vendor on the address-book write path, not at payout
   time: approval can need a human quorum, which must not sit inside a withdrawal already
-  holding a player's funds. Registration is idempotent on `(userId, currency, network, address)`.
+  holding a player's funds. Registering the same destination twice is a no-op.
 - Auto-approval fails closed. A missing risk or KYC signal goes to manual review.
 - Pay from the pool, never from a player's deposit container, and across more than one payout
   container. An account chain serializes on a per-account sequence number and a UTXO chain caps
@@ -59,8 +59,8 @@ inbound deposit.
 
 ## Reconciliation
 
-- The webhook is a signal, not a guarantee. Deliveries are retried and the retries run out, so
-  a ledger with no second source keeps a withdrawal in `processing` forever.
+- The webhook is a signal, not a guarantee. Deliveries are retried, and the retries run out. A
+  ledger with no second source leaves a payout waiting on the vendor forever.
 - Findings are surfaced, never auto-credited. Crediting one is an admin action with an actor
   and a reason, and the run and its findings go to the audit log.
 

--- a/docs/standards/documentation.md
+++ b/docs/standards/documentation.md
@@ -1,0 +1,41 @@
+# Documentation
+
+A prose doc states the business rule, the flow, and the decision. It does not restate the code.
+
+## What owns what
+
+| Question                                                           | Answer lives in                  |
+| ------------------------------------------------------------------ | -------------------------------- |
+| What is the exact route, table, column, event, enum, or port name? | `docs/catalog.json` and the code |
+| What is a function's signature?                                    | the contract or schema file      |
+| What must be true for the money to be right?                       | `docs/standards/`                |
+| Why does the system work this way?                                 | `docs/adr/`                      |
+| What does this module own, and what breaks it?                     | `docs/modules/`                  |
+| What does a vendor have to provide, and how do the pieces move?    | `docs/adapters/`                 |
+
+The catalog is generated on every `pnpm regen`, so it is never stale. A name copied into prose is
+stale the moment someone renames it, and nothing fails when it happens.
+
+## Rules
+
+- **Name the capability, not the symbol.** "the vendor reports its sweepable balances" survives a
+  rename; the method name does not. Where a reader needs the exact symbol, link the contract file
+  once and let them read it there.
+- **No code samples that duplicate a shipped file.** Link the real implementation or the template
+  the generator emits. A sample in prose is a second copy that no test covers.
+- **No enum values, status strings, permission strings, or column names in prose.** Describe the
+  state ("a withdrawal still waiting on the vendor"), not its spelling.
+- **No route tables.** The catalog has every route with its permission.
+- **No file-path inventories.** A table of "which file owns what" is a map of today's tree, and the
+  tree moves. Point at the directory.
+- **Describe the target, not only the present.** A doc may describe behaviour the code has not
+  reached yet, as long as it says so plainly. The code is then adjusted to the doc, not the other
+  way round. Mark anything unbuilt so nobody reads it as a description of what ships.
+- **A vendor's own operational rules are business content, not code.** Quorum requirements, fee
+  economics, key handling, and rate limits belong in prose, because no generated artifact carries
+  them.
+
+## When a doc and the code disagree
+
+Fix the code, or change the doc deliberately and say why. Do not quietly rewrite the doc to match
+whatever the code happens to do; that is how a standard turns into a changelog.


### PR DESCRIPTION
## Summary

Add `docs/standards/documentation.md`, which draws the line between what the generated catalog owns and what prose owns, then apply it to the wallet, custody and payment docs.

## Why

Several docs restated the code: exact route paths with permission strings, adapter method names inside diagrams, table and column names, literal status values, and a sixty-line TypeScript adapter sample. None of that is verified by anything, and all of it goes stale on the first rename. `docs/catalog.json` already carries that surface exactly, and it is regenerated on every `pnpm regen`.

The standard also permits a doc to describe a target the code has not reached, provided it says so. The intent is that the code is adjusted to the doc rather than the doc being quietly rewritten to match whatever shipped.

Applied:

- `adapters/payment.md` - drops the adapter sample and the signatures around it; 133 lines to 70. Now covers the two vendor shapes, the guarantees a binding must give, and the deposit flow, with one link to the contract as the source of truth.
- `adapters/custody.md` - route table removed, method names out of the diagrams, and the sweep cycle rewritten as the five business conditions instead of a flowchart of code branches.
- `standards/custody.md`, `modules/wallet.md` - remaining table, token and enum references removed.

## Alternatives considered

Leaving the adapter sample as executable documentation. Rejected: no test covers it, so it is a second implementation that drifts silently. The generator template and the contract file both stay accurate for free.

## Risks

None. Documentation only, no code or contract change.