### PR TITLE
docs(agents): read the whole ticket before planning or reviewing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ CLAUDE.md
 !.github/actions/
 !.github/ISSUE_TEMPLATE/
 !.github/pull_request_template.md
+
+# Per-machine tracker overlays (private coordinates for downstream tickets). Never commit.
+docs/agents/*.local.md

--- a/.rulesync/rules/overview.md
+++ b/.rulesync/rules/overview.md
@@ -33,6 +33,7 @@ This is real-money regulated gambling. A defect here moves a player's money or b
 ## Load the right owner
 
 - Universal engineering baseline and a topical routing table: `conventions`.
+- Ticket, spec, or design context: `docs/agents/issue-tracker.md` - read the whole ticket, comments and images included, before planning or reviewing against it.
 - Events, jobs, realtime, and outbox choices: `messaging-and-microservices`.
 - Module boundaries, DI, ports, and shared helpers: `docs/standards/module-structure.md`.
 - Money, compliance, and audit: read `docs/standards/{money,compliance,audit}.md` before changing those paths.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,30 @@
+# Issue tracker: GitHub, plus downstream trackers
+
+Platform issues and pull requests live on GitHub (`gh` CLI, repo inferred from `git remote -v`).
+
+## GitHub
+
+- **Read an issue**: `gh issue view <number> --comments`. Attachments in issue bodies are image URLs - download and view them, do not judge from the alt text.
+- **Read a PR**: `gh pr view <number> --comments` for intent and discussion, `gh pr diff <number>` for the patch.
+- **Create / comment / label / close**: `gh issue create`, `gh issue comment`, `gh issue edit --add-label`, `gh issue close`.
+- **PRs as a request surface: no.**
+
+## Downstream operator tickets
+
+Much of the work here is driven by tickets in a consumer's private tracker (Jira, Linear, ...). Branch names and commit subjects may carry such a key. The coordinates and read workflow for that tracker are NOT in this public repo: they live in `docs/agents/issue-tracker.local.md`, which is gitignored and per machine. When that file exists, it owns every key it declares.
+
+Rules that hold regardless of tracker:
+
+- Read the whole ticket before planning or reviewing against it: description, acceptance criteria, every comment, every attached image viewed as pixels, the parent, linked issues, and every linked spec page with its own images and comments. A chat thread is optional context, read only when the ticket points at it.
+- Text-only reads are incomplete when attachments exist. Use a tool that returns the image bytes.
+- No key resolves: say "no ticket" and review against the PR description. The fetch fails: say "no access". Never infer acceptance criteria silently.
+- Keep private tracker content out of the public repo: never paste ticket text, attachments, internal URLs, or people's names into tracked files, commit bodies, PR descriptions, or review comments. A bare key in a branch or commit subject is the most that may appear.
+- Reading authorizes nothing: no comments, transitions, or edits on any tracker unless the user asks for that exact write.
+
+## When a skill says "fetch the relevant ticket"
+
+Resolve the key (argument, PR body, PR title, branch, commit subjects), read it per the rules above via the tracker that owns it, and distill: goal in one line, acceptance criteria quoted as bullets, decisions from comments, design references, out-of-scope lines.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue. Never write to a downstream tracker from this repo.

--- a/docs/standards/skills/delivery.md
+++ b/docs/standards/skills/delivery.md
@@ -7,7 +7,7 @@ Read-only until the plan is explicitly approved.
 
 ### Workflow
 
-1. Resolve the input and collect scoped context from the ticket, relevant ADRs, generated contract surfaces, matching standards, source, and prior design discussion.
+1. Resolve the input and collect scoped context from the ticket (read whole per `docs/agents/issue-tracker.md`: comments, images, linked spec pages), relevant ADRs, generated contract surfaces, matching standards, source, and prior design discussion.
 2. Run prompt enhancement before gathering deeply so the work remains scoped.
 3. Grill every design choice that would change the build: scope, domain and seam ownership, data-model forks, regulatory and audit requirements, reuse, in-flight collisions, and config surface.
 4. Present goal, acceptance criteria, locked decisions with sources, exact surface, boundary impact, risks, and a task breakdown mapped to roster agents.

--- a/docs/standards/skills/review.md
+++ b/docs/standards/skills/review.md
@@ -17,7 +17,7 @@ Report only unless `--fix` or `--post` is passed.
 ## Workflow
 
 1. Scope the diff from the supplied PR or `<base>...HEAD`, falling back to the working tree only when the branch diff is empty. Under `--ci` an empty diff is a GO with zero findings; otherwise ask.
-2. Gather ticket acceptance criteria and unresolved PR discussion once, then distill them to a context block of at most 30 lines. Do not expose raw ticket text, internal URLs, attachments, or people's names in review output.
+2. Gather the spec once, per `docs/agents/issue-tracker.md`: resolve the ticket from the PR body, title, branch, or commit subjects and read it whole - description, acceptance criteria, every comment, every attached image viewed (not listed), linked spec pages with their own images and comments, and a referenced chat thread only when the criteria depend on it. Add the unresolved PR discussion. Distill to a context block of at most 40 lines: goal, criteria quoted verbatim, decisions from comments, design references, out-of-scope lines. No ticket resolves: state `no ticket` and review against the PR description. The fetch fails: state `no access`. Never infer criteria silently. The PR description is the author's claim, not the spec; a contradiction between it, the ticket, and the diff is a finding. Do not expose raw ticket text, internal URLs, attachments, or people's names in review output.
 3. Group changed files by package or domain, and read each changed file and the standard governing its dimension before judging it.
 4. Assume each changed behaviour is broken until a concrete happy path and hostile path prove otherwise. Trace empty, falsy, error, unauthorized, concurrent, and repeated inputs.
 5. Run the request trace for each changed entry point and check the blast radius.
@@ -91,7 +91,7 @@ Default and `--post`: a human-readable report, and the same drafts are what `--p
 
 1. Draft comments, most important first, in conversational language without severity markers; each names its `file:line`.
 2. One `TRACE:` line per traced entry point, as below.
-3. One status line per acceptance criterion: met, not met, or not verifiable.
+3. One status line per acceptance criterion: met, not met, or not verifiable. A UI criterion backed by a design screenshot is met only after comparing the rendered UI against it. A diff that crosses the ticket's out-of-scope line, or decides an open question in code without recording it on the ticket, is a draft comment citing that line.
 4. Exactly one GO or NO-GO sentence, last.
 
 `--ci`: print exactly this block and nothing else; a CI job parses it line by line.

--- a/tools/templates/consumer/__dot__rulesync/rules/overview.md
+++ b/tools/templates/consumer/__dot__rulesync/rules/overview.md
@@ -24,6 +24,10 @@ Sibling rules (load on demand; don't reopen settled questions):
 - `oss-boundaries` - OSS core is read-only; enforced import/module boundaries.
 - `e2e-conventions` - dual-mode Playwright specs, fixtures, mocks, page objects.
 
+## Tickets and specs
+
+`docs/agents/issue-tracker.md` is the read protocol (fill in its placeholders once). Any task that names a ticket key - review, plan, build, fix - starts by reading the whole ticket: description, AC, every comment, every image viewed as pixels, parent, linked issues, and every linked wiki page with its own images and comments. Text-only reads are incomplete when attachments exist. No key: say "no ticket". Fetch failed: say "no access". Never write to the tracker unless the user asks for that exact write.
+
 ## HARD RULE: never modify OSS core
 
 `@openora/*` is a third-party dependency - treat it like any published npm package. You may READ it for reference, never write to it.

--- a/tools/templates/consumer/__dot__rulesync/skills/add-feature/SKILL.md
+++ b/tools/templates/consumer/__dot__rulesync/skills/add-feature/SKILL.md
@@ -45,16 +45,15 @@ re-implement their work. The platform-core twin is the `/add-feature` skill in t
 
 Run together; skip any source that returns nothing. Read `handoff.md` only on core-change signals.
 
-| Source        | How                                                                                             |
-| ------------- | ----------------------------------------------------------------------------------------------- |
-| Jira          | the **Atlassian** MCP - read `<KEY>-XXX`: description, AC, comments, parent epic, linked issues |
-| Confluence    | the **Atlassian** (Confluence) MCP - search the space + read pages                              |
-| Slack         | the **Slack** MCP - search public/private, read threads, read canvases                          |
-| Google Drive  | the **Google Drive** MCP - PRDs, specs                                                          |
-| Notion        | `ntn` CLI per `notion-memory` skill - prior decisions, lessons                                  |
-| Local docs    | the OSS checkout's `docs` (ADRs, `architecture.md`, `catalog.json`), repo READMEs, `CLAUDE.md`  |
-| Past sessions | grep `~/.claude/projects/**` and `~/.claude/plans` for the ticket key                           |
-| Codebase      | `oss` MCP (read-only) + Explore - map touchpoints in `apps/api`                                 |
+| Source        | How                                                                                                                                                                                                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ticket + wiki | per `docs/agents/issue-tracker.md`: `<KEY>-XXX` whole - description, AC, every comment, every image viewed, parent epic, linked issues, every linked wiki page with its images and comments (`atlassian-read` for Jira + Confluence; the MCP returns no image bytes) |
+| Slack         | the **Slack** MCP - search public/private, read threads, read canvases                                                                                                                                                                                               |
+| Google Drive  | the **Google Drive** MCP - PRDs, specs                                                                                                                                                                                                                               |
+| Notion        | `ntn` CLI per `notion-memory` skill - prior decisions, lessons                                                                                                                                                                                                       |
+| Local docs    | the OSS checkout's `docs` (ADRs, `architecture.md`, `catalog.json`), repo READMEs, `CLAUDE.md`                                                                                                                                                                       |
+| Past sessions | grep `~/.claude/projects/**` and `~/.claude/plans` for the ticket key                                                                                                                                                                                                |
+| Codebase      | `oss` MCP (read-only) + Explore - map touchpoints in `apps/api`                                                                                                                                                                                                      |
 
 ### 3. Plan + classify (the gate)
 

--- a/tools/templates/consumer/__dot__rulesync/skills/create-task/SKILL.md
+++ b/tools/templates/consumer/__dot__rulesync/skills/create-task/SKILL.md
@@ -70,7 +70,7 @@ For infra/DevOps tickets, swap **Scope** for **Provision** (AWS services as bull
 
 ## Flow
 
-1. If rewriting: read the issue via the **Atlassian** MCP (markdown) for current state + summary.
+1. If rewriting: read the issue whole per `docs/agents/issue-tracker.md` (comments and images included) - a rewrite that drops a decision buried in a comment or a screenshot is a regression.
 2. Pull any missing context the ticket references (Slack decision, sibling ticket).
 3. Draft against the template. Confirm scope splits with the user before creating
    new tickets.

--- a/tools/templates/consumer/__dot__rulesync/skills/enhance-prompt/SKILL.md
+++ b/tools/templates/consumer/__dot__rulesync/skills/enhance-prompt/SKILL.md
@@ -27,7 +27,7 @@ Match effort to the ask: a small task gets a one-line restatement, not a full br
 
 1. **Restate the intent** in one line. If your restatement might be wrong, gather context or ask - don't guess.
 2. **Classify**: build (feature / adapter / page / route) · review or audit · debug · refactor · docs · research · ops. For a **build** ask, hand off to the `enhance-intent` MCP tool (server `oss`) - it adds the platform catalog, requirements checklist, and `pnpm gen` playbook - and stop here.
-3. **Gather scoped context** - targeted, never a data dump (token budget matters). Pull only what changes the plan: your issue tracker / roadmap, product specs and design decisions, recent team-chat decisions, local `docs/` + ADRs, past sessions. Scope first (which project, epic, timeframe), then fetch. Roadmap and known-issue threads are signal; general chatter is noise.
+3. **Gather scoped context** - targeted, never a data dump (token budget matters). Pull only what changes the plan: your issue tracker / roadmap and product specs read per `docs/agents/issue-tracker.md` (comments and images included), recent team-chat decisions, local `docs/` + ADRs, past sessions. Scope first (which project, epic, timeframe), then fetch. Roadmap and known-issue threads are signal; general chatter is noise.
 4. **Surface blocking ambiguities only** - the questions whose answers change what you build. Resolve the rest with stated defaults. Don't interrogate.
 5. **Emit the brief**, sized to the task.
 

--- a/tools/templates/consumer/__dot__rulesync/skills/review/SKILL.md
+++ b/tools/templates/consumer/__dot__rulesync/skills/review/SKILL.md
@@ -34,13 +34,16 @@ Checklist - tick as you go:
 
 `git diff <base>...HEAD --name-only`; if empty, fall back to `git status -s`; if still empty, ask. Group changed files by app/package so reviewers and any file-split share the same map. Note the total changed-line count - it picks the mode in §4.
 
-## 2b. Collect task context
+## 2b. Collect task context (mandatory - this is the spec axis)
 
-Distill everything here into ONE context block of at most ~30 lines; it is the only task context reviewers receive.
+Distill everything here into ONE context block of at most ~40 lines; it is the only task context reviewers receive.
 
-- **Ticket.** Extract the BF key from the branch name / MR title. Fetch it (Atlassian MCP or REST) and distill: goal in one line + acceptance criteria as bullets. No key or no access: skip silently.
+- **Ticket - read it whole, per `docs/agents/issue-tracker.md`.** Resolve the `<KEY>-n` key from the MR description (`Closes <KEY>-n`), MR title, branch, or commit subjects. Read: description + AC, every comment, every attached image viewed as pixels, parent epic, linked issues, and every wiki page the ticket links (their images and comments too). Use a reader that returns image bytes (for Jira + Confluence: the `atlassian-read` skill, or REST); the Atlassian MCP returns none, so it is never enough on its own. A chat thread is optional: read it only when the ticket or MR points at one and the AC depend on it.
+- **Distill:** goal in one line; AC quoted verbatim as bullets (a `CRITERION:` line needs the exact bullet); decisions and open questions from comments (who, when); design references (which screenshot shows what); out-of-scope lines.
 - **MR discussion.** If reviewing an MR: `glab mr view <n>` + unresolved discussion threads. Distill to stated intent + open reviewer asks, so the review doesn't repeat or contradict them. No MR: use branch commit subjects as intent.
-- The AC bullets feed the verdict (§7) - a finding "AC not met" needs a specific bullet.
+- **No key** -> write `no ticket` in the report and judge against the MR description only. **Fetch failed** -> write `no access`. Never skip silently, never invent AC.
+- A UI change whose ticket carries design screenshots is judged against them: compare the rendered UI with the reference when the stack is up; when you cannot, the criterion is `not verifiable`, never `met`.
+- The MR description is the author's claim, not the spec. Where it contradicts the ticket or the diff, that contradiction is a finding.
 
 ## 3. Ground every reviewer (mandatory)
 
@@ -85,6 +88,8 @@ Dedup by `file:line`, group by dimension, order BLOCK -> WARN -> INFO. Each line
 
 Severities: `[BLOCK]` must fix before merge (core edit, boundary break, authz/secret/PII risk, broken extension wiring); `[WARN]` should fix (convention violation, missing test, weak validation); `[INFO]` FYI / hardening.
 
+After the findings, one `CRITERION: <acceptance criterion> - <met|not met|not verifiable>` line per AC bullet from §2b; an unmet AC forces CHANGES REQUESTED. Spec findings cite the ticket the way code findings cite a rule doc: a diff that crosses a ticket's out-of-scope line, answers an open question in code without recording it on the ticket, or ships behavior no AC asked for is a `[WARN]` with the ticket line quoted as evidence.
+
 If `--fix`: apply BLOCK + WARN fixes in the working tree (smallest diff satisfying the cited rule), run `/check`, report green/red. Leave INFO untouched. Never commit or push.
 
 ## 8. Post to the MR (`--post`)
@@ -106,6 +111,7 @@ Post BLOCK + WARN as inline threads; include INFO only if it maps to a concrete 
 ## Constraints
 
 - Reviewers report; only the orchestrator edits, and only under `--fix` (working tree only - no commit, no push).
+- Never `git stash`, never `git checkout` another branch in the working tree: read MR sources with `git fetch` + `git show <sha>:<path>` / `git diff <base> <head>`. The stash stack and the worktree are shared with other sessions.
 - NEVER edit `@openora/*` core or `node_modules`.
 - Every finding cites a rule doc - no ungrounded opinions.
 - Cap at 5 parallel reviewers.

--- a/tools/templates/consumer/docs/agents/issue-tracker.md
+++ b/tools/templates/consumer/docs/agents/issue-tracker.md
@@ -1,0 +1,36 @@
+# Issue tracker
+
+Work for this operator is tracked in `<your-tracker>` (Jira project `<KEY>`, Linear team, GitHub issues, ...). Requirements and reasoning live in `<your-wiki>` (a Confluence space, Notion, ...). Decisions that never made it into a ticket live in `<your-team-channel>`. Code review happens on the repo's merge requests.
+
+Fill in the placeholders above once; every skill that says "fetch the relevant ticket" reads this file.
+
+## Keys and where they appear
+
+- Ticket key: `<KEY>-<n>`. `<KEY>-0` means "no ticket" (chores).
+- Branch: `<type>/<KEY>-<n>/<slug>`. MR description ends with `Closes <KEY>-<n>`.
+- Resolve the key from, in order: the argument the user gave, the MR description, the MR title, the branch name, commit subjects.
+
+## What "read the ticket" means
+
+A ticket is read when ALL of this has been seen - never from the description alone:
+
+1. Description and acceptance criteria.
+2. Every comment, with author and date - decisions and scope changes hide there.
+3. Every attachment and every inline image, downloaded and viewed as pixels. Filenames, thumbnails and metadata prove nothing.
+4. Parent epic and linked issues named by the AC.
+5. Every wiki page the ticket links - its body, its images, its comments. The AC are the spec; the page behind them is the reasoning.
+6. A chat thread, only when the ticket or MR says the design or decision lives there. Optional otherwise.
+
+How: use a reader that returns the image bytes. For Jira + Confluence that is the `atlassian-read` skill (`read.py issue <KEY>-<n>`, then `page <id>` per linked page) or the REST API with an API token: Jira `GET /rest/api/3/issue/<KEY>-<n>?fields=summary,status,description,attachment,comment,issuelinks,parent` and `GET /rest/api/3/attachment/content/<id>`; Confluence `GET /wiki/api/v2/pages/<id>?body-format=atlas_doc_format`, `/attachments`, `/footer-comments`, `/inline-comments`. Bodies are ADF: `text` nodes carry prose, `media` nodes carry images (`attrs.alt` is the Jira attachment filename; on Confluence `attrs.id` is the attachment `fileId`). The Atlassian MCP is fine for search, text and writes, but returns no image bytes - it is never sufficient on its own when attachments exist.
+
+Credentials are personal and come from a local, untracked env file. Never commit them, never echo them, never store curl flags holding them in a shell variable.
+
+## When a skill says "fetch the relevant ticket"
+
+Run the protocol above and distill: goal in one line, AC quoted as bullets, decisions from comments (who, when), design references (which screenshot shows what), out-of-scope lines. Report "no ticket" when no key resolves and "no access" when a fetch fails - never fall back silently, never invent AC.
+
+## Writing
+
+- Never comment on, transition, or edit a ticket or wiki page unless the user asks for that exact write. Reading authorizes nothing.
+- MR comments go through the repo's CLI (`review --post`), draft-and-confirm.
+- Chat: draft only, never send.


### PR DESCRIPTION
## Summary

Adds `docs/agents/issue-tracker.md` as the tracker read protocol - GitHub for platform issues, a gitignored `issue-tracker.local.md` overlay for a downstream operator's private tracker - and makes the `review` and `add-feature` workflows read the ticket whole (description, acceptance criteria, every comment, every attached image viewed, linked spec pages) before judging a diff. A review with no ticket says `no ticket`, a failed fetch says `no access`, neither skips silently.

## Why

The PR review workflow said "gather ticket acceptance criteria" without saying how, so in practice reviews ran against the PR body alone. The body is the author's claim, not the spec, and text-only reads miss design screenshots entirely. Downstream ticket coordinates could not go into a public doc, hence the gitignored overlay.

## Alternatives considered

Putting the downstream tracker details straight into the public doc - rejected, that is exactly what `chore/strip-client-ticket-refs` is removing. A per-repo script for fetching - rejected, the fetch tooling is personal and credentialed, so it stays user-level and the doc only carries the protocol.

## Risks

None. Docs and one `.gitignore` line; the generated mirrors are untracked.