### PR TITLE
fix(create-openora): stop the template assuming GitLab and pointing at scripts it lacks

### DIFF
--- a/tools/templates/consumer/README.md.tpl
+++ b/tools/templates/consumer/README.md.tpl
@@ -13,7 +13,8 @@ in its own repo and talk to this api over HTTP via `@openora/react`.
 ```
 apps/
   api/          # Hono + oRPC API (:3001) - thin createApp entry + your extensions.config.ts
-.claude/agents/ # AI agents: builder, expert, qa
+.rulesync/      # source of truth for agent rules, subagents, commands, skills
+.claude/agents/ # generated AI agents
 turbo/generators/ # turbo gen: plugin, adapter
 ```
 
@@ -27,15 +28,13 @@ newest release; pin an exact version if you need reproducible installs.
 
 ```bash
 pnpm install               # pulls @openora/* from npm
-pnpm setup:mcp             # trust the MCP server + install the /start onboarding flow
-pnpm regen                 # regenerate catalog + Drizzle client (after schema changes)
 cp .env.example .env       # set DATABASE_URL + AUTH_SECRET
 pnpm db:migrate            # apply the OSS schema to your database
 pnpm dev                   # api :3001
 ```
 
-After `pnpm setup:mcp`, restart your editor and run **`/start`** in Claude Code - it asks what
-you want to build and scaffolds it for you.
+The `oss` MCP server is declared in `.mcp.json`. Approve it in your editor, restart, then run
+**`/start`** in Claude Code - it asks what you want to build and scaffolds it for you.
 
 To pull the newest platform release, re-run `pnpm install` (the pin tracks the `latest` stable tag).
 
@@ -52,10 +51,11 @@ a DI token wins).
 
 ## AI agents
 
-`.claude/agents/` ships three agents scoped to this repo:
+`.claude/agents/` ships agents scoped to this repo, generated from `.rulesync/subagents/`:
 
 - `builder` - configure extensions, swap adapters, write overlays, customize UI
 - `expert` - turn product asks into requirements + acceptance criteria
 - `qa` - write/run Playwright E2E tests and triage bugs
+- `debugger`, `deployer`, `quality-reviewer`, `security-reviewer` - root-cause, packaging, review
 
 The `oss` MCP server (`.mcp.json`) gives them read-only inspection of the platform surface.

--- a/tools/templates/consumer/__dot__rulesync/commands/doctor.md.tpl
+++ b/tools/templates/consumer/__dot__rulesync/commands/doctor.md.tpl
@@ -6,12 +6,12 @@ description: Diagnose the local dev environment - linked {{ossDir}}, node, postg
 
 Run these checks and report a pass/fail line per item with the fix command for failures. Read-only - never apply fixes without being asked.
 
-1. **Node version**: `node -v` matches `.nvmrc` (26). Fix: `nvm use`.
-2. **OSS checkout linked**: `{{ossDir}}` exists and `node --input-type=module -e "import {createRequire} from 'node:module'; console.log(createRequire(process.cwd()+'/').resolve('@openora/core/react'))"` resolves. Fix: clone the OSS repo side by side at `{{ossDir}}`, `pnpm link:oss`, `pnpm install`.
-3. **OSS built**: the resolved path above points into a `dist/` that exists and is newer than `{{ossDir}}/packages/*/src`. Fix: `pnpm build:oss`.
+1. **Node version**: `node -v` matches the major in `.nvmrc` (read the file, don't assume a number). Fix: `nvm use`.
+2. **OSS checkout linked** (only in repos that link a local platform checkout - a stock scaffold installs `@openora/*` from npm and skips this and the next check): `{{ossDir}}` exists and `node --input-type=module -e "import {createRequire} from 'node:module'; console.log(createRequire(process.cwd()+'/').resolve('@openora/core/react'))"` resolves. Fix: clone the OSS repo side by side at `{{ossDir}}`, run the repo's link script if it ships one (`pnpm link:oss`), then `pnpm install`.
+3. **OSS built**: the resolved path above points into a `dist/` that exists and is newer than `{{ossDir}}/packages/*/src`. Fix: rebuild the linked checkout with the repo's build script if it ships one (`pnpm build:oss`), otherwise build it from `{{ossDir}}`.
 4. **Database**: postgres reachable on :5432 (`nc -z localhost 5432`). Fix: `dev:infra` MCP tool (server `oss`) or the compose stack.
-5. **Services**: ports 3001 (api), 3000 (web), 3002 (backoffice) - report which are up. Fix: `pnpm dev`.
-6. **Stale bundler cache**: if a build error persists after a fix, `rm -rf apps/*/.next` and rebuild (Turbopack caches across the link boundary).
+5. **Services**: port 3001 (api), plus 3000 (web) and 3002 (backoffice) in repos that have those apps - report which are up. Fix: `pnpm dev`.
+6. **Stale bundler cache**: if this repo has a Next app and a build error persists after a fix, `rm -rf apps/*/.next` and rebuild (Turbopack caches across the link boundary).
 7. **Generated agent files**: `pnpm gen:agents` runs clean (regenerates from `.rulesync/`).
 
 If everything passes but a build still fails, hand off to the `debugger` agent with the verbatim error - it owns the deeper resolution table (turbopack.root, symlinked tsconfig, externalDir).

--- a/tools/templates/consumer/__dot__rulesync/commands/start.md
+++ b/tools/templates/consumer/__dot__rulesync/commands/start.md
@@ -8,4 +8,4 @@ Call the `start` MCP tool (server `oss`) with no arguments, then follow the scri
 
 The returned script will have you: confirm the MCP server is connected, run a thorough requirements interview, call `enhance-intent`, then delegate the implementation to the `expert`, `builder`, and `qa` agents (via the Task tool). You gather requirements and orchestrate; you do not write feature code yourself, and you never modify `@openora/*` core.
 
-If the `start` tool is not available, the `oss` MCP server is not connected - tell the user to run `pnpm setup:mcp` and restart the editor.
+If the `start` tool is not available, the `oss` MCP server is not connected - tell the user to approve the `oss` server declared in `.mcp.json` (or run the repo's MCP setup script if it ships one) and restart the editor.

--- a/tools/templates/consumer/__dot__rulesync/rules/e2e-conventions.md
+++ b/tools/templates/consumer/__dot__rulesync/rules/e2e-conventions.md
@@ -9,6 +9,8 @@ description: Playwright E2E conventions - specs run against the real stack; mock
 
 # E2E conventions (`apps/e2e`)
 
+Applies once this repo has an `apps/e2e` Playwright suite; a repo without one is not covered by this rule, and adding the suite is what turns it on.
+
 Two kinds of spec live here:
 
 - **Browser specs** (`tests/<app>/**`) - a player or admin journey through the UI.

--- a/tools/templates/consumer/__dot__rulesync/rules/frontend-conventions.md.tpl
+++ b/tools/templates/consumer/__dot__rulesync/rules/frontend-conventions.md.tpl
@@ -6,10 +6,12 @@ globs:
   - 'apps/web/**'
   - 'apps/backoffice/**'
   - 'packages/ui/**'
-description: React/UI conventions (component library, theming, i18n, permission gating, modular architecture) for apps/web, apps/backoffice, packages/ui - the always-on core; full detail in docs/standards/frontend.md.
+description: React/UI conventions (component library, theming, i18n, permission gating, modular architecture) for apps/web, apps/backoffice, packages/ui - applies once those apps exist; full detail in docs/standards/frontend.md.
 ---
 
 # Frontend conventions
+
+Applies once this repo has UI apps (`apps/web`, `apps/backoffice`, `packages/ui`); an api-only repo has none of those paths and this rule is inert there.
 
 UI-specific rules for `apps/web`, `apps/backoffice`, and `packages/ui`. Stack-agnostic rules (naming, types, functions, comments, errors, testing, git) live in `conventions`. Styling, i18n, and the modular architecture are specified in `docs/standards/frontend.md` - read it before touching a component, page, or module. The rules below are the ones that file does not state.
 

--- a/tools/templates/consumer/__dot__rulesync/rules/oss-boundaries.md.tpl
+++ b/tools/templates/consumer/__dot__rulesync/rules/oss-boundaries.md.tpl
@@ -47,7 +47,7 @@ Enforced by `pnpm check:lint` (oxlint, per-edit), the pre-commit hook, CI, and t
 - Every import resolves; every npm package used is declared in that package's own `package.json`; no package sits in two dependency sections (a library's devDependency + peerDependency pair is the exception).
 - Production code imports no devDependency and no test/mock/fixture file.
 
-### Structure checks (`pnpm check:shape`)
+### Structure checks (`pnpm check:shape`, in repos that ship it)
 
 Runs the checks a dependency graph cannot make, because they are about files that do not exist or edges that do not exist:
 
@@ -55,6 +55,6 @@ Runs the checks a dependency graph cannot make, because they are about files tha
 - The barrel re-exports only; the single side effect it may carry is `import './locales'`.
 - Every file under a module's `pages|components|hooks|utils` is reachable from the barrel, and every `packages/ui/src` file from the `{{scope}}/ui` barrel - otherwise it is dead code.
 
-Each app/package owns its own `.dependency-cruiser.cjs` (its own tsconfig for `@/*` alias resolution) built on the shared rule/option helpers in `.dependency-cruiser.shared.cjs`. `pnpm gen:boundaries-graph` renders each package's graph (needs Graphviz).
+Each app/package owns its own `.dependency-cruiser.cjs` (its own tsconfig for `@/*` alias resolution) built on the shared rule/option helpers in `.dependency-cruiser.shared.cjs`. Where the repo ships `pnpm gen:boundaries-graph`, it renders each package's graph (needs Graphviz).
 
 The shared options keep npm packages in the graph on purpose - a dependency-type rule can only judge a package that is a node - so build output is excluded per workspace path, never as a bare `/dist/`.

--- a/tools/templates/consumer/__dot__rulesync/skills/add-feature/SKILL.md.tpl
+++ b/tools/templates/consumer/__dot__rulesync/skills/add-feature/SKILL.md.tpl
@@ -17,7 +17,7 @@ Feature-delivery orchestrator for this consumer repo: one Jira key in; a deliver
 ## Coordinates
 
 - Jira: the **Atlassian** MCP, cloudId `{{jiraCloudId}}`, project `{{trackerKey}}` (ticket keys look like `{{trackerKey}}-XXX`). Request/render content as markdown (`contentFormat` + `responseContentFormat: "markdown"`).
-- GitLab: `{{gitRemotePath}}`, MR target `{{mrTarget}}`, `glab` CLI.
+- Code forge: `{{gitRemotePath}}`, default target `{{mrTarget}}` - CLI and commands in `docs/agents/forge.md`.
 - Slack: `{{teamChannel}}`, draft only.
 - Repo: `apps/api` (Hono entry + extensions) consumes `@openora/*` upstream; UI apps, when present, sit beside it under `apps/`.
 - **Hard rule:** `{{ossDir}}` (the linked OSS checkout) is read-only (guard-core hook + permission deny). Extend from the outside; core changes hand off - see `handoff.md`.
@@ -77,7 +77,7 @@ Cheap gates first, prove it works, only then spend review on working code:
 
 ### 6. Open the MR
 
-Run **create-pr**: it commits (`feat({{trackerKey}}-XXX): ...`), reports the SHA, asks for "yes push", pushes, and `glab mr create`s targeting `{{mrTarget}}` with the CODEOWNERS for the changed paths as reviewers. Never bypass its push-consent gate.
+Run **create-pr**: it commits (`feat({{trackerKey}}-XXX): ...`), reports the SHA, asks for "yes push", pushes, and opens the pull request against `{{mrTarget}}` per `docs/agents/forge.md`, with the CODEOWNERS for the changed paths as reviewers. Never bypass its push-consent gate.
 
 ### 7. Jira status transition (NOT comments)
 

--- a/tools/templates/consumer/__dot__rulesync/skills/create-pr/SKILL.md.tpl
+++ b/tools/templates/consumer/__dot__rulesync/skills/create-pr/SKILL.md.tpl
@@ -1,37 +1,24 @@
 ---
 name: create-pr
 targets: ['*']
-description: Commit, push, and open a GitLab Merge Request following this repo's promotion chain ({{mrTarget}} -> stage -> prod). Use on "create pr", "create mr", "open a pr/mr", "/create-pr", or "promote <branch>".
+description: Commit, push, and open a pull request on this repo's forge, targeting the branch `docs/agents/forge.md` names. Use on "create pr", "create mr", "open a pr/mr", "/create-pr", or "promote <branch>".
 ---
 
 # create-pr ({{name}})
 
-This repo is on **GitLab** (`{{gitRemotePath}}`). "PR" = Merge Request. Use the `glab` CLI (already installed). Environment branches are promoted along a fixed chain - never open an MR straight to `prod` from a feature branch.
-
-## Promotion chain
-
-- Topic branch (`feat/*`, `fix/*`, `{{trackerKey}}-*`) -> `{{mrTarget}}`: feature/ticket work merges into `{{mrTarget}}` first.
-- `{{mrTarget}}` (default working) -> `stage`: promote accumulated work to the staging env.
-- `stage` -> `prod`: promote staging -> production.
-
-If the current branch isn't in the list, target `{{mrTarget}}`.
+`docs/agents/forge.md` is the source of truth for this repo's forge: which CLI to use, how to open and read a pull request, and where a change lands. Read it first - the steps below never hardcode a forge command.
 
 ## Steps
 
-1. **Determine source + target.** `git branch --show-current` -> look it up in the table above to get the target.
+1. **Determine source + target.** `git branch --show-current`, then take the target from the "Where a change lands" section of `docs/agents/forge.md`.
 2. **Scope the commit.** `git status -s`. Commit ONLY changes that belong to this unit of work. If unrelated/pre-existing edits are present, do NOT bundle them - stage your files explicitly and tell the user what you left out. Never `git add -A` blindly when foreign changes are in the tree.
 3. **Commit.** Conventional-commit message (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`); for ticket work prefix the ticket key (e.g. `feat({{trackerKey}}-123): ...`). No "Co-Authored-By" / "Generated with" trailers.
 4. **Verify before pushing** (cheap insurance): run `/check` (typecheck + lint + unit). Don't push a red tree.
 5. **Push** the current branch - but STOP and get an explicit per-action "yes push" from the user FIRST. Report the commit SHA, then ask. Invoking this skill is NOT push authorization. Pushing to a shared/env branch (`{{mrTarget}}`, `stage`, `prod`) without that explicit yes is forbidden. Only after the yes: `git push -u origin <current>`.
-6. **Open the MR** with glab (only after the push is confirmed + done):
-   ```
-   glab mr create --source-branch <current> --target-branch <target> \
-     --title "<type>: <summary>" --description "<body>" --yes --remove-source-branch=false
-   ```
-   For a long-lived env branch (`{{mrTarget}}`, `stage`, `prod`) NEVER pass `--remove-source-branch`. Reuse an existing open MR for the same source->target instead of creating a duplicate (`glab mr list --source-branch <current> --target-branch <target>`).
-7. **Report** the MR URL back to the user.
+6. **Open the pull request** using the command in `docs/agents/forge.md` (only after the push is confirmed and done). Reuse an open request for the same source -> target instead of creating a duplicate, and never delete a long-lived branch on merge.
+7. **Report** the pull-request URL back to the user.
 
-## MR description
+## Pull-request description
 
 - State the user-facing change and its reason briefly.
 - Add short, reproducible local test steps for the changed behavior (for example, `pnpm dev` then the relevant URLs or user flow).
@@ -42,4 +29,4 @@ If the current branch isn't in the list, target `{{mrTarget}}`.
 
 - NEVER push without an explicit per-action "yes push" from the user. Invoking this skill does NOT authorize a push. Report the commit SHA, ask, then push only on yes.
 - The repo check must pass before the push.
-- Keep the MR scoped to one concern; split unrelated changes into separate MRs.
+- Keep the pull request scoped to one concern; split unrelated changes into separate ones.

--- a/tools/templates/consumer/__dot__rulesync/skills/create-ui-module/SKILL.md.tpl
+++ b/tools/templates/consumer/__dot__rulesync/skills/create-ui-module/SKILL.md.tpl
@@ -2,15 +2,17 @@
 name: create-ui-module
 targets: ['*']
 description: >
-  Create a frontend feature module in apps/backoffice or apps/web following ADR-0001's
-  modular architecture: standard folder shape, co-located locales, DI hooks, pure
-  components, barrel entry, route wiring. Use on "create module", "new feature module",
+  Create a frontend feature module in apps/backoffice or apps/web following the modular
+  architecture in the `frontend-conventions` rule: standard folder shape, co-located
+  locales, DI hooks, pure components, barrel entry, route wiring. Use on "create module", "new feature module",
   "add a backoffice/web module", "/create-ui-module <app> <name>".
 ---
 
 # create-ui-module ({{name}})
 
-Scaffold a feature module under `src/modules/<name>/` per ADR-0001 (`docs/adr/0001-modular-architecture.md`). The shape is lint-enforced (`tools/oxlint-module-structure.mjs`: folder structure, `use-` hook naming, kebab-case files, client-component naming). Copy an existing module as the reference - `apps/backoffice/src/modules/roles/` is canonical.
+Applies once this repo has UI apps (`apps/web` / `apps/backoffice`); an api-only repo has no `src/modules/` to scaffold into.
+
+Scaffold a feature module under `src/modules/<name>/` per the modular architecture in `frontend-conventions` and `docs/standards/frontend.md`. Where the repo ships a module-structure lint rule, it enforces the shape (folder structure, `use-` hook naming, kebab-case files, client-component naming). Copy an existing module in the same app as the reference.
 
 ## 1. Resolve input
 
@@ -43,16 +45,16 @@ Components use `useTranslation(ns)`; no hardcoded copy. Non-`en` files mirror `e
 
 ## 3. Wire the route
 
-- backoffice: `src/routes/_authed/<name>.tsx` -> `createFileRoute` with `component` imported from `@/modules/<name>` (see `src/routes/_authed/roles.tsx`).
+- backoffice: `src/routes/_authed/<name>.tsx` -> `createFileRoute` with `component` imported from `@/modules/<name>`; mirror a sibling route file.
 - web: the App Router page under `app/(shell)/<name>/` imports from `@/modules/<name>`; client components get `'use client'` line 1 + `.client.tsx` suffix.
 
 ## 4. Non-negotiables
 
 - No cross-module imports - cross-module effects go through query cache invalidation, never a direct import.
 - Outside code imports ONLY the barrel via `@/modules/<name>`; inside the module use relative paths.
-- Hooks take their clients (oRPC/API) as parameters (see `roles/hooks/use-iam-client-deps.ts`) so they're testable without global mocks.
-- Follow `.claude/rules/frontend-conventions.md` + `docs/standards/frontend.md` (daisyUI, theme tokens, hoisted `styles` const, React Compiler - no manual memo).
+- Hooks take their clients (oRPC/API) as parameters via a `use-<domain>-client-deps.ts` hook so they're testable without global mocks.
+- Follow the `frontend-conventions` rule + `docs/standards/frontend.md` (daisyUI, theme tokens, hoisted `styles` const, React Compiler - no manual memo).
 
 ## 5. Verify
 
-`/check` green (the structure lint runs inside `pnpm check:lint`); route renders (`pnpm dev`). Hand to `review` before an MR.
+`/check` green (any structure lint runs inside `pnpm check:lint`); route renders (`pnpm dev`). Hand to `review` before an MR.

--- a/tools/templates/consumer/__dot__rulesync/skills/review/SKILL.md.tpl
+++ b/tools/templates/consumer/__dot__rulesync/skills/review/SKILL.md.tpl
@@ -1,7 +1,7 @@
 ---
 name: review
 targets: ['*']
-description: Multi-agent code review of the working branch against this repo's conventions, OSS-core boundaries, frontend rules, security, and operator-domain fit. Fans out a configurable number of parallel reviewers, each grounded in the rule docs, then synthesizes one verdict. Use on "review this", "code review", "/review", optionally "--agents N", "--base <ref>", "--fix", "--post" (publish findings to the MR as inline comments + a summary verdict), "--yes" (post without confirming), "--ci" (non-interactive, exit code from the verdict), a GitLab MR number, or paths.
+description: Multi-agent code review of the working branch against this repo's conventions, OSS-core boundaries, frontend rules, security, and operator-domain fit. Fans out a configurable number of parallel reviewers, each grounded in the rule docs, then synthesizes one verdict. Use on "review this", "code review", "/review", optionally "--agents N", "--base <ref>", "--fix", "--post" (publish findings to the pull request as inline comments + a summary verdict), "--yes" (post without confirming), "--ci" (non-interactive, exit code from the verdict), a pull-request number, or paths.
 ---
 
 # review ({{name}})
@@ -25,10 +25,10 @@ Checklist - tick as you go:
 
 - `--agents N` - parallel reviewers (1-5); default one per applicable dimension.
 - `--base <ref>` - diff base; default `{{mrTarget}}`.
-- `<number>` - a GitLab MR: `glab mr diff <n>` for the patch, `glab mr view <n>` for intent.
+- `<number>` - a pull request: read its patch and intent with the commands in `docs/agents/forge.md`.
 - paths - restrict review to those files/dirs.
 - `--fix` - apply BLOCK/WARN fixes after the review; default report-only.
-- `--post` - publish findings to the GitLab MR as inline diff-line comments + a one-line summary verdict (§8). Requires an MR number. Draft-and-confirm by default.
+- `--post` - publish findings to the pull request as inline diff-line comments + a one-line summary verdict (§8). Requires a pull-request number. Draft-and-confirm by default.
 - `--yes` - with `--post`, skip the confirmation and publish straight away.
 - `--ci` - non-interactive: never ask, never post, never fix; print only the §7 machine block. The model cannot set the process exit code; the CI job derives it from the last line, e.g. `claude -p '/review --ci' | tee review.txt | grep -q '^VERDICT: APPROVED'`. An empty diff is APPROVED with zero findings.
 
@@ -42,7 +42,7 @@ Distill everything here into ONE context block of at most ~40 lines; it is the o
 
 - **Ticket - read it whole, per `docs/agents/issue-tracker.md`.** Resolve the `{{trackerKey}}-n` key from the MR description (`Closes {{trackerKey}}-n`), MR title, branch, or commit subjects. Read: description + AC, every comment, every attached image viewed as pixels, parent epic, linked issues, and every wiki page the ticket links (their images and comments too). Use a reader that returns image bytes (for Jira + Confluence: the `atlassian-read` skill - `read.py issue {{trackerKey}}-n`, then `page <id>` per linked page - or REST); the Atlassian MCP returns none, so it is never enough on its own. A chat thread is optional: read it (via `slack-reader` when available) only when the ticket or MR points at one ("shared in chat", a Slack link) and the AC depend on it.
 - **Distill:** goal in one line; AC quoted verbatim as bullets (a `CRITERION:` line needs the exact bullet); decisions and open questions from comments (who, when); design references (which screenshot shows what); out-of-scope lines.
-- **MR discussion.** If reviewing an MR: `glab mr view <n>` + unresolved discussion threads. Distill to stated intent + open reviewer asks, so the review doesn't repeat or contradict them. No MR: use branch commit subjects as intent.
+- **Pull-request discussion.** If reviewing one: read its intent and unresolved threads per `docs/agents/forge.md`. Distill to stated intent + open reviewer asks, so the review doesn't repeat or contradict them. No pull request: use branch commit subjects as intent.
 - **No key** -> write `no ticket` in the report and judge against the MR description only. **Fetch failed** -> write `no access`. Never skip silently, never invent AC.
 - A UI change whose ticket carries design screenshots is judged against them: compare the rendered UI (`playwright-cli` screenshot when the stack is up) with the reference; when you cannot, the CRITERION is `not verifiable`, never `met`.
 - The MR description is the author's claim, not the spec. Where it contradicts the ticket or the diff, that contradiction is a finding.
@@ -144,20 +144,16 @@ Severities: `[BLOCK]` must fix before merge (core edit, boundary break, authz/se
 
 If `--fix`: apply BLOCK + WARN fixes in the working tree (smallest diff satisfying the cited rule), run `/check`, report green/red. Leave INFO untouched. Never commit or push.
 
-## 8. Post to the MR (`--post`)
+## 8. Post to the pull request (`--post`)
 
-Only when `--post` is set and the target is an MR number. Turns findings into terse review comments: one line each, brief why, backtick every identifier.
+Only when `--post` is set and the target is a pull-request number. Turns findings into terse review comments: one line each, brief why, backtick every identifier.
 
 Post BLOCK + WARN as inline threads; include INFO only if it maps to a concrete `file:line`. One comment per finding, one line each.
 
-1. **Draft.** Rewrite each finding as a terse comment keyed to its `file:line`. Compose the summary as ONE sentence stating whether the changes block prod/push, e.g. `Not a blocker for push - a few cleanups worth doing.` or `Blocker: BLOCK finding in `x.ts` must be fixed before we push.`
+1. **Draft.** Rewrite each finding as a terse comment keyed to its `file:line`. Compose the summary as ONE sentence stating whether the changes block prod/push, e.g. `Not a blocker for push - a few cleanups worth doing.` or `Blocker: the finding in `x.ts` must be fixed before we push.`
 2. **Confirm.** Show all drafted comments + the summary and stop for approval - UNLESS `--yes`, then skip straight to posting.
-3. **Post inline comments** as positional discussions on the diff. Mechanics + gotchas:
-   - Diff SHAs from `glab api "projects/<project>/merge_requests/<n>" | jq .diff_refs`, where `<project>` is `{{gitRemotePath}}` with `/` encoded as `%2F`.
-   - Anchor on the NEW-file line of an added (`+`) line (`git show <src-branch>:<file> | grep -n`).
-   - POST JSON (build with Python `json.dumps` to dodge quoting) to `.../merge_requests/<n>/discussions` with a `position` object; `glab api -H "Content-Type: application/json" ... --input -`. Do NOT use `-f "position[...]"` - nested params silently drop the position.
-   - Verify each response's `.notes[0].position.new_line`; if null it fell back to a general note - delete (`glab api -X DELETE .../notes/<id>`) and retry.
-4. **Post the summary** as one general MR note (`glab mr note <n> -m "<one sentence>"`).
+3. **Post inline comments** anchored to the diff, using the "Inline review comments" command in `docs/agents/forge.md`. Anchor on the NEW-file line of an added (`+`) line (`git show <src-branch>:<file> | grep -n`), and verify each response actually carries a line anchor - an unanchored fallback comment must be deleted and retried, never left behind.
+4. **Post the summary** as one general comment on the pull request, per the same file.
 5. Report back the count posted + the summary verdict. Never resolve threads; never push.
 
 ## Constraints

--- a/tools/templates/consumer/__dot__rulesync/subagents/debugger.md.tpl
+++ b/tools/templates/consumer/__dot__rulesync/subagents/debugger.md.tpl
@@ -34,15 +34,15 @@ Decide from where the error appears. Never reach for Chrome DevTools on a build 
 Reproduce with a build, not the dev server (dev caches and lies):
 
 ```bash
-pnpm -C apps/web exec next build   # or apps/backoffice
 pnpm check:types
+pnpm -C apps/web exec next build   # or apps/backoffice, in repos that have those apps
 ```
 
-Known consumer-side causes (this stack links `@openora/*` from `{{ossDir}}`):
+Known consumer-side causes (the link-boundary ones apply only in repos that link a local platform checkout at `{{ossDir}}`; a stock scaffold resolves `@openora/*` from npm):
 
 - `Module not found: Can't resolve '@openora/core/...'` while Node resolves it -> the bundler won't compile across the link boundary (packages live outside the project root): point its root at the common ancestor of both repos and allow imports from outside it - Next.js `turbopack.root` + `experimental.externalDir: true` (see `apps/web/next.config.ts`).
 - `extends "@openora/core/tsconfig/..." doesn't resolve` -> `extends` chain through a symlinked tsconfig; those configs must be self-contained.
-- Resolves but won't import -> `@openora/*` not built: `pnpm build:oss`.
+- Resolves but won't import -> the linked `@openora/*` checkout is not built: rebuild it (`pnpm build:oss` in repos that ship that script, otherwise build from `{{ossDir}}`).
 - Stale error after a fix -> Turbopack cache: `rm -rf apps/*/.next` and rebuild.
 
 Confirm bundler-vs-dependency with:
@@ -74,7 +74,7 @@ The release tag is the short commit SHA, so an issue maps straight back to a com
 
 - Consumer config (next.config, tsconfig, extensions.config, env) -> fix it yourself and verify.
 - Consumer overlay/plugin (fails only with this operator's plugins/adapters active) -> `builder` (hand over cause + repro + file/line).
-- OSS core (reproduces in a clean consumer scaffolded via `pnpm create:app` with no overlays) -> report upstream; do NOT patch `node_modules/@openora/**` or `{{ossDir}}`.
+- OSS core (reproduces in a clean consumer scaffold with no overlays) -> report upstream; do NOT patch `node_modules/@openora/**` or `{{ossDir}}`.
 - Domain rule wrong (consistent behavior that violates igaming rules) -> `expert`.
 
 After a runtime bug is fixed, spawn `qa` for a regression test so it stays fixed.

--- a/tools/templates/consumer/__dot__rulesync/subagents/qa.md.tpl
+++ b/tools/templates/consumer/__dot__rulesync/subagents/qa.md.tpl
@@ -38,7 +38,7 @@ Debug and verify with the **Playwright CLI** first (`pnpm -F {{scope}}/e2e test 
 
 Is the bug in OSS core or the operator's overlay?
 
-- Fails in a fresh consumer scaffolded via `pnpm create:app` / with no overlays active -> OSS core -> report upstream.
+- Fails in a fresh consumer scaffold / with no overlays active -> OSS core -> report upstream.
 - Fails only with this operator's plugins/adapters -> `builder`.
 - Technically consistent but violates igaming rules -> `expert`.
 

--- a/tools/templates/consumer/__dot__rulesync/sync.json.tpl
+++ b/tools/templates/consumer/__dot__rulesync/sync.json.tpl
@@ -15,6 +15,7 @@
   "consumerOwned": [
     ".rulesync/rules/overview.md",
     ".rulesync/mcp.json",
-    ".rulesync/sync.json"
+    ".rulesync/sync.json",
+    "docs/agents/forge.md"
   ]
 }

--- a/tools/templates/consumer/docs/agents/forge.md.tpl
+++ b/tools/templates/consumer/docs/agents/forge.md.tpl
@@ -1,0 +1,48 @@
+# Code forge: GitHub
+
+Code review for `{{gitRemotePath}}` happens on GitHub pull requests, driven by the [`gh`](https://cli.github.com) CLI. Every skill that opens, reads, or comments on a pull request reads this file instead of hardcoding commands, so a repo on a different forge rewrites this one file and the skills keep working.
+
+Swapping forge: keep the headings below and replace the commands. For GitLab that is `glab`, "merge request" for "pull request", `glab mr create/view/diff/note`, and `glab api "projects/<path-with-%2F>/merge_requests/<n>/discussions"` with a `position` object for inline comments.
+
+## Coordinates
+
+- Repo: `{{gitRemotePath}}`. CLI: `gh` (authenticate once with `gh auth login`).
+- Noun: pull request, "PR" for short. The default target branch is `{{mrTarget}}`.
+
+## Where a change lands
+
+- Topic branch (`feat/*`, `fix/*`, `{{trackerKey}}-*`) -> `{{mrTarget}}`.
+- A repo that promotes through environment branches adds them here (for example `{{mrTarget}}` -> `stage` -> `prod`) and never opens a PR straight from a topic branch to the last one.
+- If the current branch is not listed, target `{{mrTarget}}`.
+
+## Open a pull request
+
+```
+gh pr create --base <target> --head <current> --title "<type>: <summary>" --body "<body>"
+```
+
+Reuse an open PR for the same head -> base instead of opening a duplicate: `gh pr list --head <current> --base <target>`. Never delete a long-lived branch on merge.
+
+## Read a pull request
+
+- Intent and discussion: `gh pr view <n> --comments`
+- Patch: `gh pr diff <n>`
+- Unresolved threads: `gh api "repos/{{gitRemotePath}}/pulls/<n>/comments"`
+- CI: `gh pr checks <n>`
+
+## Inline review comments
+
+Anchor each comment to a line of the diff on the head commit:
+
+```
+gh api "repos/{{gitRemotePath}}/pulls/<n>/comments" \
+  -f body="<comment>" -f commit_id="<head-sha>" -f path="<file>" -F line=<new-line> -f side=RIGHT
+```
+
+Take `<head-sha>` from `gh pr view <n> --json headRefOid`. Anchor on the NEW-file line of an added line. Verify the response carries a non-null `line`; if it came back as a plain issue comment, delete it and retry rather than leaving an unanchored note. Post the verdict itself as one summary comment: `gh pr comment <n> --body "<one sentence>"`.
+
+## Rules
+
+- Never push without an explicit per-action confirmation from the user.
+- Never merge a pull request unless the user asks for that exact action.
+- Never resolve someone else's review thread.

--- a/tools/templates/consumer/docs/agents/issue-tracker.md.tpl
+++ b/tools/templates/consumer/docs/agents/issue-tracker.md.tpl
@@ -1,6 +1,6 @@
 # Issue tracker: Jira (project `{{trackerKey}}`) + Confluence + Slack
 
-Work for this operator is tracked in Jira project `{{trackerKey}}` on `{{jiraSite}}`. Requirements and reasoning live in Confluence space `{{wikiSpace}}`. Decisions that never made it into a ticket live in Slack `{{teamChannel}}`. Code review happens on GitLab `{{gitRemotePath}}` merge requests (`glab`).
+Work for this operator is tracked in Jira project `{{trackerKey}}` on `{{jiraSite}}`. Requirements and reasoning live in Confluence space `{{wikiSpace}}`. Decisions that never made it into a ticket live in Slack `{{teamChannel}}`. Code review happens on `{{gitRemotePath}}` - see `docs/agents/forge.md`.
 
 Every skill that says "fetch the relevant ticket" reads this file.
 
@@ -37,5 +37,5 @@ Run the protocol above and distill: goal in one line, AC quoted as bullets, deci
 ## Writing
 
 - Never comment on, transition, or edit a Jira issue or Confluence page unless the user asks for that exact write. Reading authorizes nothing.
-- MR comments go through `glab` (`review --post`), draft-and-confirm.
+- Review comments go through `review --post`, draft-and-confirm, using the commands in `docs/agents/forge.md`.
 - Slack: draft only, never send.

--- a/tools/templates/consumer/docs/standards/enforcement.md
+++ b/tools/templates/consumer/docs/standards/enforcement.md
@@ -3,8 +3,8 @@
 Read this before working around a failing gate or adding a lint rule.
 
 - `pnpm check:types` + `pnpm check:lint` (oxlint) + `pnpm test:unit` is the fast gate;
-  `pnpm check:boundaries` (dependency-cruiser) is the whole-graph boundary/cycle check, also run
-  by the pre-commit hook and CI.
+  In repos that ship `pnpm check:boundaries` (dependency-cruiser), that is the whole-graph
+  boundary/cycle check, also run by the pre-commit hook and CI.
 - oxlint extends the platform's shared config (`./node_modules/@openora/core/oxlint/oxlintrc.json`)
   - add local rules on top, never fork it.
 - Don't work around a lint/boundary violation - fix the import.


### PR DESCRIPTION
## Summary

Adds `docs/agents/forge.md` - consumer-owned, GitHub-flavoured by default, with swap instructions at the top - and makes `create-pr`, `review` and `add-feature` delegate to it instead of hardcoding `glab`. Separately, stops the scaffold instructing runs of scripts it does not ship, reads the Node major from `.nvmrc`, and scopes the frontend, e2e and `create-ui-module` rules to repos that actually have those apps.

## Why

The template was written against the first consumer, which is on GitLab, so a scaffolded GitHub repo got unusable review and PR skills. Related debt surfaced in the same review: eight `pnpm` scripts named as if they exist (`link:oss`, `build:oss`, `create:app`, `setup:mcp`, `gen:boundaries-graph`, `check:boundaries`, `check:shape`, `test:e2e`), a `doctor` asserting Node 26 against an `.nvmrc` of 22, and UI/E2E rules globbing `apps/web`, `apps/backoffice` and `apps/e2e` in an api-only scaffold, several of them pointing at files the template has no copy of.

## Alternatives considered

Parameterising the forge as `{{prCli}}` / `{{prNoun}}`. Rejected: the difference is structural, not lexical - a GitLab positional discussion needs a `position` object built from `diff_refs`, which has no GitHub equivalent - so a templated paragraph would read correctly and be wrong on both forges. Deleting the frontend and e2e rules from the api-only scaffold was also rejected: established consumers rely on them, and they are now simply inert until those apps exist.

## Risks

`docs/agents/forge.md` is consumer-owned, so an existing consumer that already has one keeps it and must update its own skills references; the only consumer today is doing that in a parallel MR. Nothing else changes behaviour - the rest is documentation accuracy.