### PR TITLE
fix(ci): ignore the hand-edited PR #109 merge subject in commitlint

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -61,6 +61,11 @@ const scopes = [
 
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  // One-off: PR #109 landed on dev as a merge commit whose GitHub-generated
+  // "Merge pull request ..." subject (which commitlint ignores by default) was
+  // hand-edited to a non-conventional string before merge. The commit is already
+  // on a protected branch, so skip just this one rather than rewrite history.
+  ignores: [(message) => message.startsWith('Fix/chat commands removal (#109)')],
   rules: {
     'scope-enum': [2, 'always', scopes],
     'body-max-line-length': [0, 'always'],


### PR DESCRIPTION
## Problem

PR #109 was merged into `dev` as a merge commit (`8babe31e`). GitHub's default subject for that kind of merge is `Merge pull request #109 from ...`, which `@commitlint/config-conventional` ignores. It was hand-edited to `Fix/chat commands removal (#109)` before merging, which is not a conventional commit and fails `type-empty` / `subject-empty`.

The commit now lives on the protected `dev` branch. The `commitlint` CI job runs `--from <base.sha> --to <head.sha>` on every PR, so any in-flight branch that pulls `dev` (#116, #119 already have) trips commitlint on a commit it didn't author.

## Fix

Add a targeted `ignores` entry for exactly that commit subject rather than rewriting public history on `dev`. All other commit rules are unchanged.

Verified: `pnpm commitlint --from 8babe31e~1 --to ff35f77f` exits 0 with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)