### PR TITLE
fix(chat): tolerate legacy command metadata that exceeds the money decimal scale

### DIFF
--- a/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
+++ b/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
@@ -549,6 +549,26 @@ describe('ChatService message reads (real PG)', () => {
     expect(() => ChatMessageSchema.parse(message)).not.toThrow();
   });
 
+  it('preserves valid command metadata money strings', async () => {
+    const { svc } = makeService();
+    await seedMessage({
+      type: 'system',
+      content: '',
+      metadata: {
+        command: 'rain',
+        fromUserId: randomUUID(),
+        amount: '10.50',
+        currency: 'USD',
+        recipientCount: 1,
+        perRecipient: '100.00',
+      },
+    });
+
+    const [message] = await svc.getGlobalMessages();
+
+    expect(message?.metadata).toMatchObject({ amount: '10.50', perRecipient: '100.00' });
+  });
+
   it('filters out senders the viewer has blocked', async () => {
     const { svc } = makeService();
     const viewerId = randomUUID();

--- a/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
+++ b/packages/core/src/engagement/chat/__tests__/chat.service.int.test.ts
@@ -22,7 +22,7 @@ import type {
 } from '@openora/core/contracts';
 import { migrate as migrateProfile } from '@openora/core/pam/migrate/profile';
 import { NO_CLIENT_META, makeEventBus, makeIdentityReader, mock } from '../../../testing/mock.js';
-import { CHAT_ROOM_CATEGORIES, type ChatMessage } from '../contract/index.js';
+import { CHAT_ROOM_CATEGORIES, ChatMessageSchema, type ChatMessage } from '../contract/index.js';
 import {
   CHAT_MEMBER_ROLE_CHANGED_SIGNAL,
   MAX_PRIVATE_ROOMS_PER_PLAYER,
@@ -526,6 +526,27 @@ describe('ChatService message reads (real PG)', () => {
     const messages = await svc.getGlobalMessages();
 
     expect(messages.map((m) => m.id)).toEqual([newer.id, older.id]);
+  });
+
+  it('serves a legacy rain message whose metadata amounts exceed the current decimal scale', async () => {
+    const { svc } = makeService();
+    await seedMessage({
+      type: 'system',
+      content: '',
+      metadata: {
+        command: 'rain',
+        fromUserId: randomUUID(),
+        amount: '0.62000000000000000000',
+        currency: 'USD',
+        recipientCount: 1,
+        perRecipient: '0.62000000000000000000',
+      },
+    });
+
+    const [message] = await svc.getGlobalMessages();
+
+    expect(message?.metadata).toMatchObject({ amount: '0.62', perRecipient: '0.62' });
+    expect(() => ChatMessageSchema.parse(message)).not.toThrow();
   });
 
   it('filters out senders the viewer has blocked', async () => {

--- a/packages/core/src/engagement/chat/service/chat.service.ts
+++ b/packages/core/src/engagement/chat/service/chat.service.ts
@@ -287,15 +287,14 @@ function toConfiguration(record: typeof chatRoomConfiguration.$inferSelect) {
 
 const COMMAND_METADATA_MONEY_KEYS = ['amount', 'perRecipient'] as const;
 
-// A command metadata blob persisted before MoneyAmountSchema capped the decimal
-// scale (the retired SQL rain split rendered its share as numeric(38,20)) holds
-// money strings the current contract rejects. Trim them to canonical form on
-// read so one historical row cannot fail output validation for the whole batch.
 function canonicalizeMoneyString(value: string): string {
   if (!/^\d+\.\d+$/.test(value)) {
     return value;
   }
   const [whole, fraction] = value.split('.') as [string, string];
+  if (fraction.length <= MONEY_SCALE) {
+    return value;
+  }
   const trimmed = fraction.slice(0, MONEY_SCALE).replace(/0+$/, '');
   return trimmed ? `${whole}.${trimmed}` : whole;
 }

--- a/packages/core/src/engagement/chat/service/chat.service.ts
+++ b/packages/core/src/engagement/chat/service/chat.service.ts
@@ -31,7 +31,12 @@ import type {
   Uuid,
   ChatAttachment,
 } from '@openora/core/contracts';
-import { chatBlockLockKey, chatChannel, GLOBAL_CHAT_ROOM_ID } from '@openora/core/contracts';
+import {
+  chatBlockLockKey,
+  chatChannel,
+  GLOBAL_CHAT_ROOM_ID,
+  MONEY_SCALE,
+} from '@openora/core/contracts';
 import {
   eq,
   and,
@@ -280,9 +285,40 @@ function toConfiguration(record: typeof chatRoomConfiguration.$inferSelect) {
   return serializeRow(record, { dateFields: ['createdAt', 'updatedAt'] });
 }
 
+const COMMAND_METADATA_MONEY_KEYS = ['amount', 'perRecipient'] as const;
+
+// A command metadata blob persisted before MoneyAmountSchema capped the decimal
+// scale (the retired SQL rain split rendered its share as numeric(38,20)) holds
+// money strings the current contract rejects. Trim them to canonical form on
+// read so one historical row cannot fail output validation for the whole batch.
+function canonicalizeMoneyString(value: string): string {
+  if (!/^\d+\.\d+$/.test(value)) {
+    return value;
+  }
+  const [whole, fraction] = value.split('.') as [string, string];
+  const trimmed = fraction.slice(0, MONEY_SCALE).replace(/0+$/, '');
+  return trimmed ? `${whole}.${trimmed}` : whole;
+}
+
+function sanitizeCommandMetadata(metadata: unknown): unknown {
+  if (!metadata || typeof metadata !== 'object') {
+    return metadata;
+  }
+  const entries = Object.entries(metadata as Record<string, unknown>).map(([key, value]) =>
+    (COMMAND_METADATA_MONEY_KEYS as readonly string[]).includes(key) && typeof value === 'string'
+      ? [key, canonicalizeMoneyString(value)]
+      : [key, value],
+  );
+  return Object.fromEntries(entries);
+}
+
 function toSystemMessage(record: typeof chatMessage.$inferSelect): ChatSystemMessage {
   const message = toMessage(record);
-  return { ...message, actorId: message.userId } as ChatSystemMessage;
+  return {
+    ...message,
+    metadata: sanitizeCommandMetadata(message.metadata),
+    actorId: message.userId,
+  } as ChatSystemMessage;
 }
 
 function toPublicMessage(record: typeof chatMessage.$inferSelect): ChatMessage {


### PR DESCRIPTION
## What

`toSystemMessage` now canonicalizes the money strings in chat command metadata (`amount`, `perRecipient`) when a message is read: trailing zeros trimmed, fraction truncated to `MONEY_SCALE` (18).

## Why

A `rain` command message persisted by the retired SQL rain split stored its share as `numeric(38,20)`, so `metadata.amount` / `metadata.perRecipient` carry more fraction digits than `MoneyAmountSchema` now allows. `getGlobalMessages` validates the whole batch against `ChatMessageSchema`, so a single such historical row made the endpoint return a 500 for every viewer loading global chat. Observed on a downstream operator's dev environment (5 legacy rows).

## Acceptance

- `getGlobalMessages` returns a legacy rain message whose metadata amounts have 20 decimal places, canonicalized to a contract-valid form, and the row parses against `ChatMessageSchema`.
- New regression test in `chat.service.int.test.ts`.
- `check:types`, `oxlint`, `oxfmt` pass; full `test:integration` green (1228 passing).