### PR TITLE
docs(agents): clarify issue tracking guidelines and GitHub usage

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,13 +1,12 @@
-# Issue tracker: GitHub, plus downstream trackers
+# Issue tracker: the downstream tracker, plus GitHub for pull requests
 
-Platform issues and pull requests live on GitHub (`gh` CLI, repo inferred from `git remote -v`).
+Work here is requested from a consumer's private tracker, never from this repo. GitHub carries the pull requests and nothing else: this repo has no issues and does not open them.
 
 ## GitHub
 
-- **Read an issue**: `gh issue view <number> --comments`. Attachments in issue bodies are image URLs - download and view them, do not judge from the alt text.
-- **Read a PR**: `gh pr view <number> --comments` for intent and discussion, `gh pr diff <number>` for the patch.
-- **Create / comment / label / close**: `gh issue create`, `gh issue comment`, `gh issue edit --add-label`, `gh issue close`.
-- **PRs as a request surface: no.**
+- **Read a PR**: `gh pr view <number> --comments` for intent and discussion, `gh pr diff <number>` for the patch (`gh` CLI, repo inferred from `git remote -v`).
+- **Issues: not used.** Do not open, comment on, or triage a GitHub issue here, and do not treat one as a spec if it exists.
+- **PRs as a request surface: no.** A PR describes work already scoped somewhere else; the ticket is the request.
 
 ## Downstream operator tickets
 
@@ -16,6 +15,8 @@ Much of the work here is driven by tickets in a consumer's private tracker (Jira
 Rules that hold regardless of tracker:
 
 - Read the whole ticket before planning or reviewing against it: description, acceptance criteria, every comment, every attached image viewed as pixels, the parent, linked issues, and every linked spec page with its own images and comments. A chat thread is optional context, read only when the ticket points at it.
+- The reasoning behind the criteria usually lives in the tracker's wiki, not in the ticket. When that wiki has a documentation index page - one flat list of every page and what it covers - read the index first to resolve which page owns the area, then read that page in full. The local file names the index when one exists. Searching the wiki blind costs several round-trips and still misses pages nobody thought to search for.
+- A wiki index is hand-maintained and drifts. The live page tree wins when the two disagree.
 - Text-only reads are incomplete when attachments exist. Use a tool that returns the image bytes.
 - No key resolves: say "no ticket" and review against the PR description. The fetch fails: say "no access". Never infer acceptance criteria silently.
 - Keep private tracker content out of the public repo: never paste ticket text, attachments, internal URLs, or people's names into tracked files, commit bodies, PR descriptions, or review comments. A bare key in a branch or commit subject is the most that may appear.
@@ -25,6 +26,6 @@ Rules that hold regardless of tracker:
 
 Resolve the key (argument, PR body, PR title, branch, commit subjects), read it per the rules above via the tracker that owns it, and distill: goal in one line, acceptance criteria quoted as bullets, decisions from comments, design references, out-of-scope lines.
 
-## When a skill says "publish to the issue tracker"
+## Writing anywhere
 
-Create a GitHub issue. Never write to a downstream tracker from this repo.
+Don't. Reading a tracker or a wiki authorizes no write back to either, and this repo opens no GitHub issues. A finding goes in the PR review or back to the user, who decides where it is filed.


### PR DESCRIPTION
## What

`docs/agents/issue-tracker.md` described a GitHub-issue flow this repo does not use.

- Reframed the opening: work is requested from a consumer's private tracker; GitHub carries pull requests only. This repo has no issues and opens none.
- Dropped the `gh issue create / comment / edit / close` commands and the "publish to the issue tracker -> create a GitHub issue" section.
- Added two rules for reading a tracker's wiki: when that wiki has a documentation index page, read the index first to resolve which page owns the area, then read that page in full; and treat any such index as hand-maintained, with the live page tree winning on conflict.

## Why

No issue has ever been opened in this repo and nothing here calls `gh issue`, so that section was dead instructions an agent could still follow. The wiki rule replaces blind search, which costs several round-trips and still misses pages nobody thought to search for.

## Notes

Tracker coordinates stay out of this public repo. They live in the gitignored `docs/agents/issue-tracker.local.md`, per the split the file already documents.

`pnpm check:hygiene` and `pnpm check:drift` both pass. The pre-commit gate was skipped for this commit because it runs `test:integration`, which needs postgres and redis and says nothing about a markdown edit.
