### PR TITLE
fix(chat-commands): survive command config written before per-currency amounts

### DIFF
--- a/packages/core/src/engagement/chat-commands/__tests__/migration-upgrade.int.test.ts
+++ b/packages/core/src/engagement/chat-commands/__tests__/migration-upgrade.int.test.ts
@@ -2,6 +2,7 @@ import { Pool } from 'pg';
 import { describe, expect, it } from 'vitest';
 import { createTestDb } from '@openora/core/testing';
 import { migrate } from '../migrate.js';
+import { CommandConfigSchema, type CommandConfig } from '../contract/index.js';
 
 const STRIPED_TRAUMA_HASH = 'a58ec63c81a4cbd62603a8381da61c5c6d85b57af5d56ba79839d090fbcf0708';
 
@@ -33,6 +34,13 @@ async function migratePreviousHead(databaseUrl: string) {
        VALUES ($1, $2)`,
       [STRIPED_TRAUMA_HASH, 1787729046139],
     );
+    // The shape the pre-per-currency release seeded: a bare decimal string with no currency.
+    await pool.query(`
+      INSERT INTO "chat_command_config" ("key", "label", "config") VALUES
+        ('gift', 'Gift', '{"minAmount":"1.00000000"}'::jsonb),
+        ('rain', 'Rain', '{"minAmount":"1.00000000","maxRecipients":50}'::jsonb),
+        ('mention', 'Mention', NULL)
+    `);
   } finally {
     await pool.end();
   }
@@ -50,6 +58,28 @@ describe('chat-command migration upgrades', () => {
       );
 
       expect(relations.rows[0]).toEqual({ config: 'chat_command_config', gift: null });
+    } finally {
+      await pool.end();
+      await db.drop();
+    }
+  });
+
+  it('drops the legacy scalar amounts a per-currency build cannot read', async () => {
+    const db = await createTestDb([migratePreviousHead, migrate]);
+    const pool = new Pool({ connectionString: db.url });
+    try {
+      const rows = await pool.query<{ key: string; config: CommandConfig | null }>(
+        'SELECT "key", "config" FROM "chat_command_config" ORDER BY "key"',
+      );
+
+      expect(rows.rows).toEqual([
+        { key: 'gift', config: null },
+        { key: 'mention', config: null },
+        { key: 'rain', config: { maxRecipients: 50 } },
+      ]);
+      for (const row of rows.rows) {
+        expect(CommandConfigSchema.nullable().safeParse(row.config).success).toBe(true);
+      }
     } finally {
       await pool.end();
       await db.drop();

--- a/packages/core/src/engagement/chat-commands/drizzle/migrations/0002_drop_legacy_scalar_command_amounts.sql
+++ b/packages/core/src/engagement/chat-commands/drizzle/migrations/0002_drop_legacy_scalar_command_amounts.sql
@@ -1,0 +1,19 @@
+-- Before per-currency amounts, `config.minAmount` / `config.maxAmount` held a bare decimal
+-- string ("1.00000000"). They now hold a currency-keyed record, and rows written by the
+-- earlier release still carry the scalar, which fails the descriptor contract and takes the
+-- whole command list down with it.
+--
+-- The scalar never recorded which currency it meant, so there is nothing to convert it into:
+-- inventing one would write a money limit no operator ever set. Both fields are optional, so
+-- the key is dropped and an admin re-sets the limit through the backoffice update route.
+UPDATE "chat_command_config"
+SET "config" = "config" - 'minAmount'
+WHERE jsonb_typeof("config" -> 'minAmount') = 'string';
+--> statement-breakpoint
+UPDATE "chat_command_config"
+SET "config" = "config" - 'maxAmount'
+WHERE jsonb_typeof("config" -> 'maxAmount') = 'string';
+--> statement-breakpoint
+UPDATE "chat_command_config"
+SET "config" = NULL
+WHERE "config" = '{}'::jsonb;

--- a/packages/core/src/engagement/chat-commands/drizzle/migrations/meta/0002_snapshot.json
+++ b/packages/core/src/engagement/chat-commands/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,83 @@
+{
+  "id": "a044e2a0-b647-493a-87a2-f74d87a8f38b",
+  "prevId": "87c4c011-02ca-4e04-a90d-f7f8f169cd28",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_command_config": {
+      "name": "chat_command_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_command_config_key_unique": {
+          "name": "chat_command_config_key_unique",
+          "columns": ["key"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/engagement/chat-commands/drizzle/migrations/meta/_journal.json
+++ b/packages/core/src/engagement/chat-commands/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1787009522084,
       "tag": "0001_sturdy_barracuda",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1788512549109,
+      "tag": "0002_drop_legacy_scalar_command_amounts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/engagement/chat-commands/service/chat-commands.service.ts
+++ b/packages/core/src/engagement/chat-commands/service/chat-commands.service.ts
@@ -20,19 +20,32 @@ import type {
   CommandConfig,
   AdminCommandSortBy,
 } from '../contract/index.js';
-import { ChatCommandTypeSchema } from '../contract/index.js';
+import { ChatCommandTypeSchema, CommandConfigSchema } from '../contract/index.js';
 import { chatCommandConfig } from '../schema/index.js';
 export const CommandDisabledError = makeNotFoundError('ChatCommand');
 
-function toDescriptor(row: typeof chatCommandConfig.$inferSelect): ChatCommandDescriptor {
+// `key` is text and `config` is jsonb, so the column types are casts Postgres never enforced:
+// a row written by an older release can hold a key this build no longer knows or a config shape
+// it no longer accepts. Both are parsed here so one stale row loses its limit, or drops out of
+// the list, instead of failing output validation and taking the whole command list down.
+function toDescriptor(row: typeof chatCommandConfig.$inferSelect): ChatCommandDescriptor | null {
+  const key = ChatCommandTypeSchema.safeParse(row.key);
+  if (!key.success) {
+    return null;
+  }
+  const config = CommandConfigSchema.safeParse(row.config);
   return {
-    key: ChatCommandTypeSchema.parse(row.key),
+    key: key.data,
     enabled: row.enabled,
     label: row.label,
     description: row.description ?? null,
-    config: row.config ?? null,
+    config: config.success ? config.data : null,
     updatedAt: row.updatedAt.toISOString(),
   };
+}
+
+function toDescriptors(rows: (typeof chatCommandConfig.$inferSelect)[]): ChatCommandDescriptor[] {
+  return rows.map(toDescriptor).filter((d) => d !== null);
 }
 
 const ADMIN_COMMAND_SORT_COLUMNS = {
@@ -56,7 +69,7 @@ export class ChatCommandsService {
       .select()
       .from(chatCommandConfig)
       .where(includeDisabled ? undefined : eq(chatCommandConfig.enabled, true));
-    return rows.map(toDescriptor);
+    return toDescriptors(rows);
   }
 
   async adminListCommands({
@@ -81,7 +94,7 @@ export class ChatCommandsService {
         .offset(pageToOffset(page, limit)),
       this.drizzle.db.select({ n: count() }).from(chatCommandConfig),
     ]);
-    return { items: rows.map(toDescriptor), total: Number(n), page, limit };
+    return { items: toDescriptors(rows), total: Number(n), page, limit };
   }
 
   async adminUpdateCommand(
@@ -116,7 +129,9 @@ export class ChatCommandsService {
       before: null,
       after: { enabled: input.enabled, config: input.config ?? null },
     });
-    return toDescriptor(row);
+    // The write just set `key` and `config` from contract-validated input, so this row cannot
+    // be the stale shape `toDescriptor` returns null for.
+    return findOneOrThrow(toDescriptors([row]), new CommandDisabledError(input.key));
   }
 
   async searchMentions({

--- a/packages/testing/src/__tests__/chat-commands-list.e2e.test.ts
+++ b/packages/testing/src/__tests__/chat-commands-list.e2e.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { loadExtensions, DRIZZLE } from '@openora/core/server';
+import { seedChatCommands } from '@openora/core/engagement/seed/chat-commands';
+import { ChatCommandDescriptorSchema } from '@openora/core/engagement/contracts/chat-commands';
+import { setupTestDb, bootTestApp, seedMinimal, type TestDb, type TestApp } from '../index.js';
+
+let db: TestDb;
+let app: TestApp;
+
+beforeAll(async () => {
+  process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
+  process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['NODE_ENV'] ??= 'test';
+
+  db = await setupTestDb();
+  const basePlugins = await loadExtensions();
+  app = await bootTestApp({ plugins: basePlugins, databaseUrl: db.url });
+  await seedMinimal(app.container, { playerCount: 0 });
+  await seedChatCommands(app.container.get(DRIZZLE).db);
+}, 90_000);
+
+afterAll(async () => {
+  await app?.close();
+  await db?.dispose();
+});
+
+describe('listCommands', () => {
+  it('returns the seeded commands', async () => {
+    const res = await app.app.request('/chat-command/commands');
+
+    expect(res.status).toBe(200);
+    const commands = ChatCommandDescriptorSchema.array().parse(await res.json());
+    expect(commands.map((c) => c.key)).toContain('gift');
+  });
+
+  // A row whose jsonb config predates a contract change must cost that row its limit, not
+  // 500 the list for every player in chat.
+  it('survives a row whose config no longer matches the contract', async () => {
+    const drizzle = app.container.get(DRIZZLE);
+    await drizzle.db.execute(
+      sql`UPDATE "chat_command_config" SET "config" = '{"minAmount":"1.00000000"}'::jsonb WHERE "key" = 'gift'`,
+    );
+
+    const res = await app.app.request('/chat-command/commands');
+
+    expect(res.status).toBe(200);
+    const commands = ChatCommandDescriptorSchema.array().parse(await res.json());
+    expect(commands.find((c) => c.key === 'gift')?.config).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`GET /chat-command/commands` returned 500 on any database seeded before amounts became per-currency, which killed the whole slash-command dropdown in chat. A data migration clears the unreadable values and the row mapper stops trusting the jsonb column's type cast. BF-545

## Why

`CommandConfigSchema.minAmount` / `maxAmount` moved from a bare decimal string to a currency-keyed record. The schema migration shipped; the data migration did not, and `seedChatCommands` uses `onConflictDoNothing`, so `gift`, `rain` and `donate` rows kept `{"minAmount":"1.00000000"}`. Three stale rows failed output validation and the route 500ed for every player.

The column type made it invisible: `config: jsonb().$type<CommandConfig>()` is a cast Postgres never enforced, so TypeScript believed a shape the database had no obligation to hold. The route also had no test, and a fresh-database test could not have caught this - CI seeds the new shape and gets it back.

Reproduced end to end against a clone of a database carrying the old rows:

| code | migration applied | result |
| --- | --- | --- |
| before | no | 500 `Output validation failed` |
| before | yes | 200 |
| after | no | 200, stale config omitted |
| after | yes | 200 |

## Alternatives considered

**Convert the scalar to `{ "USD": value }`.** Rejected: the old value never recorded a currency, so any mapping invents a money limit no operator set. Both fields are optional, so dropping the key is lossless in contract terms and an admin re-sets it through the backoffice update route. These three commands are operator-owned since the transfer surface left core, so core holding a guessed amount is worse than holding none.

**Delete the offending rows and let the seed rewrite them.** Fixes one environment by hand and re-breaks on the next database carrying old data.

**Migration only, no read-side guard.** Fixes this shape but leaves the next contract change able to 500 the same route.

## Risks

Any `minAmount` / `maxAmount` still in the pre-change shape is dropped, not converted, so an operator running those commands re-enters the limit once after deploy. Only rows whose stored value is a JSON string are touched; a value already in the new record shape is left alone.

The read-side guard degrades silently: an unreadable config now yields `null` and an unknown command key drops out of the list rather than raising. `adminListCommands` still counts filtered rows in its `total`, so a page could come back short if a database holds a key this build does not know. No such key exists today.