### PR TITLE
fix(db): infer and enforce jsonb column shapes with zod instead of a cast

### DIFF
--- a/packages/core/src/compliance/schema/index.ts
+++ b/packages/core/src/compliance/schema/index.ts
@@ -25,9 +25,11 @@ import {
   geoRuleActions,
   MONEY_SCALE,
   MONEY_PRECISION,
-  type KycRiskSignals,
-  type KycCheckResult,
+  KycCheckResultSchema,
 } from '@openora/core/contracts';
+import { zodJsonb } from '@openora/core/server';
+import * as z from 'zod';
+import { KycRiskSignalsSchema } from '../contract/index.js';
 import { KYC_DOCUMENT_TYPES, KYC_TRIGGERED_BY } from '../contract/enums.js';
 import type { RgFlagDetail } from '../contract/rg.js';
 
@@ -99,8 +101,15 @@ export const kycVerification = pgTable(
     status: kycVerificationStatus().notNull(),
     documentTypes: jsonb().$type<(typeof KYC_DOCUMENT_TYPES)[number][]>().notNull().default([]),
     decisionReason: text(),
-    riskSignals: jsonb().$type<KycRiskSignals>(),
-    checks: jsonb().$type<KycCheckResult[]>(),
+    // severity 'error': an operator approves or rejects a player against these. A signal
+    // silently read as absent reads like a clean player, so drift here is reported, not
+    // just logged.
+    riskSignals: zodJsonb(KycRiskSignalsSchema, 'kyc_verification.risk_signals', {
+      severity: 'error',
+    })(),
+    checks: zodJsonb(z.array(KycCheckResultSchema), 'kyc_verification.checks', {
+      severity: 'error',
+    })(),
     triggeredBy: kycTriggeredBy().notNull(),
     // High-water mark of deposits at the last reverify_threshold fire, so re-KYC triggers
     // once per fresh threshold band rather than on every deposit.

--- a/packages/core/src/engagement/chat-commands/schema/index.ts
+++ b/packages/core/src/engagement/chat-commands/schema/index.ts
@@ -1,5 +1,6 @@
-import { pgTable, text, boolean, jsonb, timestamp, uuid, unique } from 'drizzle-orm/pg-core';
-import type { CommandConfig } from '../contract/index.js';
+import { pgTable, text, boolean, timestamp, uuid, unique } from 'drizzle-orm/pg-core';
+import { zodJsonb } from '@openora/core/server';
+import { CommandConfigSchema } from '../contract/index.js';
 
 export const chatCommandConfig = pgTable(
   'chat_command_config',
@@ -9,7 +10,7 @@ export const chatCommandConfig = pgTable(
     enabled: boolean().notNull().default(true),
     label: text().notNull(),
     description: text(),
-    config: jsonb().$type<CommandConfig>(),
+    config: zodJsonb(CommandConfigSchema, 'chat_command_config.config')(),
     updatedAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [unique('chat_command_config_key_unique').on(t.key)],

--- a/packages/core/src/engagement/chat/schema/index.ts
+++ b/packages/core/src/engagement/chat/schema/index.ts
@@ -16,8 +16,9 @@ import {
   CHAT_ROOM_ROLES,
   CHAT_MODERATION_SCOPE_VALUES,
 } from '../contract/index.js';
-import { CHAT_MESSAGE_TYPES } from '@openora/core/contracts';
-import type { CommandMetadata, ChatAttachment } from '@openora/core/contracts';
+import { CHAT_MESSAGE_TYPES, ChatAttachmentSchema } from '@openora/core/contracts';
+import type { CommandMetadata } from '@openora/core/contracts';
+import { zodJsonb } from '@openora/core/server';
 
 export const chatRoomRole = pgEnum('chat_room_role', CHAT_ROOM_ROLES);
 export const chatRoomCategory = pgEnum('chat_room_category', CHAT_ROOM_CATEGORIES);
@@ -60,8 +61,10 @@ export const chatMessage = pgTable(
     username: text().notNull(),
     content: text().notNull(),
     type: chatMessageType().notNull().default('user'),
+    // Not zodJsonb: `sanitizeCommandMetadata` repairs legacy money strings on read, so this
+    // column is parsed after that repair rather than before it. See `toSystemMessage`.
     metadata: jsonb().$type<CommandMetadata>(),
-    attachment: jsonb().$type<ChatAttachment>(),
+    attachment: zodJsonb(ChatAttachmentSchema, 'chat_message.attachment')(),
     isDeleted: boolean().notNull().default(false),
     deletedAt: timestamp({ withTimezone: true }),
     createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),

--- a/packages/core/src/engagement/chat/service/chat.service.ts
+++ b/packages/core/src/engagement/chat/service/chat.service.ts
@@ -32,6 +32,7 @@ import type {
   ChatAttachment,
 } from '@openora/core/contracts';
 import {
+  CommandMetadataSchema,
   chatBlockLockKey,
   chatChannel,
   GLOBAL_CHAT_ROOM_ID,
@@ -311,20 +312,49 @@ function sanitizeCommandMetadata(metadata: unknown): unknown {
   return Object.fromEntries(entries);
 }
 
-function toSystemMessage(record: typeof chatMessage.$inferSelect): ChatSystemMessage {
+// A system message IS its command metadata, and the column is jsonb - a shape Postgres never
+// enforced, so a row can outlive the contract that wrote it. Sanitizing first keeps the
+// deliberate repair path (legacy money strings) working; what still fails to parse cannot be
+// rendered as any system message the contract describes.
+function toSystemMessage(record: typeof chatMessage.$inferSelect): ChatSystemMessage | null {
   const message = toMessage(record);
-  return {
-    ...message,
-    metadata: sanitizeCommandMetadata(message.metadata),
-    actorId: message.userId,
-  } as ChatSystemMessage;
+  const metadata = CommandMetadataSchema.safeParse(sanitizeCommandMetadata(message.metadata));
+  if (!metadata.success) {
+    logger.warn(
+      { messageId: record.id, issues: metadata.error.issues.slice(0, 3) },
+      'system message metadata no longer matches its contract, omitted from listing',
+    );
+    return null;
+  }
+  return { ...message, metadata: metadata.data, actorId: message.userId } as ChatSystemMessage;
 }
 
-function toPublicMessage(record: typeof chatMessage.$inferSelect): ChatMessage {
+function toPublicMessage(record: typeof chatMessage.$inferSelect): ChatMessage | null {
   if (record.type === 'system') {
     return toSystemMessage(record);
   }
   return toMessage(record) as ChatMessage;
+}
+
+// One unreadable system message drops out of the page; the rest of the history is still
+// served. Failing the whole listing would take a room's chat down over a single old row.
+function toPublicMessages(records: (typeof chatMessage.$inferSelect)[]): ChatMessage[] {
+  return records.map(toPublicMessage).filter((message) => message !== null);
+}
+
+// The message this service just inserted, which is always a `user` row.
+function toSentMessage(record: typeof chatMessage.$inferSelect): ChatMessage {
+  return toMessage(record) as ChatMessage;
+}
+
+// A system message this service just wrote: its metadata came in typed by the contract, so
+// it needs neither the legacy repair nor the re-parse a stored row does.
+function toWrittenSystemMessage(
+  record: typeof chatMessage.$inferSelect,
+  metadata: CommandMetadata,
+): ChatSystemMessage {
+  const message = toMessage(record);
+  return { ...message, metadata, actorId: message.userId } as ChatSystemMessage;
 }
 
 const BLOCKED_USER_SORT_COLUMNS = { createdAt: chatUserBlock.createdAt } as const satisfies Record<
@@ -1071,7 +1101,7 @@ export class ChatService {
       .where(and(...conditions))
       .orderBy(desc(chatMessage.createdAt))
       .limit(limit);
-    return messages.map(toPublicMessage);
+    return toPublicMessages(messages);
   }
 
   async listAdminRoomMessages({
@@ -1124,7 +1154,10 @@ export class ChatService {
         .where(where),
     ]);
     return {
-      items: rows.map(({ message, playerId }) => ({ ...toPublicMessage(message), playerId })),
+      items: rows.flatMap(({ message, playerId }) => {
+        const mapped = toPublicMessage(message);
+        return mapped ? [{ ...mapped, playerId }] : [];
+      }),
       total: Number(n),
       page,
       limit,
@@ -1262,7 +1295,7 @@ export class ChatService {
       userId,
     });
 
-    const message = toPublicMessage(record);
+    const message = toSentMessage(record);
     publishChatEvent(this.transport, roomId, message);
     emitMentions({
       events: this.events,
@@ -1312,7 +1345,7 @@ export class ChatService {
       .where(and(...conditions))
       .orderBy(desc(chatMessage.createdAt))
       .limit(limit);
-    return messages.map(toPublicMessage);
+    return toPublicMessages(messages);
   }
 
   async sendGlobalMessage({
@@ -1348,7 +1381,7 @@ export class ChatService {
       userId,
     });
 
-    const message = toPublicMessage(record);
+    const message = toSentMessage(record);
     publishChatEvent(this.transport, null, message);
     emitMentions({
       events: this.events,
@@ -2029,7 +2062,7 @@ export class ChatService {
         metadata: args.metadata,
       })
       .returning();
-    const msg = toSystemMessage(record);
+    const msg = toWrittenSystemMessage(record, args.metadata);
     // Only auto-publish when this call owns the write (no caller-managed transaction).
     // When `tx` is passed, the caller's transaction hasn't committed yet - publishing
     // here would leak a message to clients before (or even if) it actually commits.
@@ -2051,7 +2084,7 @@ export class ChatService {
       .set({ metadata: args.metadata })
       .where(eq(chatMessage.id, args.messageId))
       .returning();
-    const message = toSystemMessage(record);
+    const message = toWrittenSystemMessage(record, args.metadata);
     if (!args.tx) {
       publishChatEvent(this.transport, message.roomId, message);
     }

--- a/packages/core/src/pam/tag/schema/index.ts
+++ b/packages/core/src/pam/tag/schema/index.ts
@@ -11,9 +11,9 @@ import {
   pgEnum,
   integer,
   decimal,
-  jsonb,
 } from 'drizzle-orm/pg-core';
-import type { PlayerTagAssignMetadata } from '../contract/player-tag-assign-metadata.js';
+import { PlayerTagAssignMetadataSchema } from '../contract/player-tag-assign-metadata.js';
+import { zodJsonb } from '@openora/core/server';
 
 export const tagAssignRemoveSourceEnum = pgEnum('tag_assign_remove_source', tagAssignRemoveSource);
 export const tagKeyEnum = pgEnum('tag_key', tagKeys);
@@ -42,7 +42,7 @@ export const playerTag = pgTable(
     assignReason: text().notNull(),
     assignActor: tagAssignRemoveSourceEnum().notNull(),
     assignActorUserId: uuid() /* Potential FKey - user; null = system actor */,
-    assignMetadata: jsonb().$type<PlayerTagAssignMetadata>(),
+    assignMetadata: zodJsonb(PlayerTagAssignMetadataSchema, 'player_tag.assign_metadata')(),
     /* Removal data */
     removedAt: timestamp({ withTimezone: true }),
     removalReason: text(),

--- a/packages/core/src/server/db/__tests__/zod-jsonb.test.ts
+++ b/packages/core/src/server/db/__tests__/zod-jsonb.test.ts
@@ -23,10 +23,29 @@ describe('zodJsonb', () => {
     });
   });
 
-  // The shape written before the value became a per-currency record. One such row must cost
+  // A shape an earlier release wrote and this one no longer accepts. One such row must cost
   // its own config, not the whole response it was selected into.
   it('reads a value the schema rejects as null', () => {
     expect(column.mapFromDriverValue({ minAmount: '1.00000000' })).toBeNull();
+  });
+
+  // A compliance column reads as absent on drift like any other, but the drift is reported
+  // rather than logged: an empty risk-signal field must not look like a clean player.
+  it('reports rather than warns for a column marked severity error', () => {
+    const loud = pgTable('loud_probe', {
+      id: uuid().primaryKey(),
+      signals: zodJsonb(z.object({ vpn: z.boolean() }), 'loud_probe.signals', {
+        severity: 'error',
+      })(),
+    });
+
+    expect(loud.signals.mapFromDriverValue({ vpn: 'yes' })).toBeNull();
+  });
+
+  it('writes a value the schema accepts as json the driver can bind', () => {
+    expect(column.mapToDriverValue({ minAmount: { USD: '1.00' } })).toBe(
+      '{"minAmount":{"USD":"1.00"}}',
+    );
   });
 
   it('refuses to write a value the schema rejects', () => {

--- a/packages/core/src/server/db/__tests__/zod-jsonb.test.ts
+++ b/packages/core/src/server/db/__tests__/zod-jsonb.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import * as z from 'zod';
+import { pgTable, uuid } from 'drizzle-orm/pg-core';
+import { zodJsonb } from '../zod-jsonb.js';
+
+const ConfigSchema = z.object({ minAmount: z.record(z.string(), z.string()).optional() });
+
+const table = pgTable('probe', {
+  id: uuid().primaryKey(),
+  config: zodJsonb(ConfigSchema, 'probe.config')(),
+});
+
+const column = table.config;
+
+describe('zodJsonb', () => {
+  it('keeps the column a jsonb column', () => {
+    expect(column.getSQLType()).toBe('jsonb');
+  });
+
+  it('reads a value the schema accepts', () => {
+    expect(column.mapFromDriverValue({ minAmount: { USD: '1.00' } })).toEqual({
+      minAmount: { USD: '1.00' },
+    });
+  });
+
+  // The shape written before the value became a per-currency record. One such row must cost
+  // its own config, not the whole response it was selected into.
+  it('reads a value the schema rejects as null', () => {
+    expect(column.mapFromDriverValue({ minAmount: '1.00000000' })).toBeNull();
+  });
+
+  it('refuses to write a value the schema rejects', () => {
+    expect(() => column.mapToDriverValue({ minAmount: '1.00000000' })).toThrow();
+  });
+});

--- a/packages/core/src/server/db/index.ts
+++ b/packages/core/src/server/db/index.ts
@@ -1,5 +1,6 @@
 export { DrizzleService, DRIZZLE } from './drizzle.service.js';
 export { createDrizzleDb, type DrizzleDb, type DrizzleTx } from './drizzle.js';
+export { zodJsonb } from './zod-jsonb.js';
 export {
   findOneOrThrow,
   pageToOffset,

--- a/packages/core/src/server/db/zod-jsonb.ts
+++ b/packages/core/src/server/db/zod-jsonb.ts
@@ -18,11 +18,24 @@ const logger = createLogger('zod-jsonb');
  * business entering the column - that is where the drift is cheap to fix. Reads degrade
  * to `null` and log, because a row already in the table is a fact: refusing to serve it
  * would trade one unreadable field for a dead endpoint.
+ *
+ * `severity: 'error'` is for a column whose absence changes a decision rather than a
+ * rendering - a compliance signal an operator reads before approving a player. The value
+ * still degrades to null, because failing the read would take an admin's whole queue down
+ * (and the player's own status page with it, which reads the same row), but the drift is
+ * logged at error level and so reaches the bound error tracker instead of sitting in a
+ * warn line nobody greps. An empty compliance field must never look like a quiet fact.
  */
-export function zodJsonb<S extends z.ZodType>(schema: S, columnName: string) {
-  return customType<{ data: z.infer<S>; driverData: unknown }>({
+export function zodJsonb<S extends z.ZodType>(
+  schema: S,
+  columnName: string,
+  { severity = 'warn' }: { severity?: 'warn' | 'error' } = {},
+) {
+  return customType<{ data: z.infer<S>; driverData: string }>({
     dataType: () => 'jsonb',
-    toDriver: (value) => schema.parse(value),
+    // Serialized here for the same reason drizzle's own `jsonb` does it: node-postgres
+    // stringifies an object parameter as "[object Object]", which Postgres rejects.
+    toDriver: (value) => JSON.stringify(schema.parse(value)),
     fromDriver: (value) => {
       const parsed = schema.safeParse(value);
       if (parsed.success) {
@@ -30,10 +43,14 @@ export function zodJsonb<S extends z.ZodType>(schema: S, columnName: string) {
       }
       // No row id here - the driver sees the value alone. This says a column has drifted
       // and roughly how; finding the rows is a query, not a log line.
-      logger.warn(
-        { column: columnName, issues: parsed.error.issues.slice(0, 3) },
-        'stored jsonb no longer matches its contract, read as null',
-      );
+      const context = { column: columnName, issues: parsed.error.issues.slice(0, 3) };
+      const message = 'stored jsonb no longer matches its contract, read as null';
+      if (severity === 'error') {
+        // `err` is what makes createLogger forward this to the error tracker.
+        logger.error({ ...context, err: parsed.error }, message);
+      } else {
+        logger.warn(context, message);
+      }
       return null as z.infer<S>;
     },
   });

--- a/packages/core/src/server/db/zod-jsonb.ts
+++ b/packages/core/src/server/db/zod-jsonb.ts
@@ -1,0 +1,40 @@
+import { customType } from 'drizzle-orm/pg-core';
+import type * as z from 'zod';
+import { createLogger } from '../kernel/logger.js';
+
+const logger = createLogger('zod-jsonb');
+
+/**
+ * A jsonb column whose TypeScript type is inferred from its Zod schema and enforced at
+ * both ends of the driver, rather than asserted by `jsonb().$type<T>()`.
+ *
+ * `$type<T>()` is a cast Postgres never checks, so the column's declared shape and the
+ * shape actually stored drift apart silently: rows written by an earlier release outlive
+ * the contract that produced them, and the mismatch only surfaces when a route tries to
+ * serialize one and fails output validation - taking every other row in that response
+ * down with it.
+ *
+ * Writes parse and throw, because a value the current contract cannot express has no
+ * business entering the column - that is where the drift is cheap to fix. Reads degrade
+ * to `null` and log, because a row already in the table is a fact: refusing to serve it
+ * would trade one unreadable field for a dead endpoint.
+ */
+export function zodJsonb<S extends z.ZodType>(schema: S, columnName: string) {
+  return customType<{ data: z.infer<S>; driverData: unknown }>({
+    dataType: () => 'jsonb',
+    toDriver: (value) => schema.parse(value),
+    fromDriver: (value) => {
+      const parsed = schema.safeParse(value);
+      if (parsed.success) {
+        return parsed.data;
+      }
+      // No row id here - the driver sees the value alone. This says a column has drifted
+      // and roughly how; finding the rows is a query, not a log line.
+      logger.warn(
+        { column: columnName, issues: parsed.error.issues.slice(0, 3) },
+        'stored jsonb no longer matches its contract, read as null',
+      );
+      return null as z.infer<S>;
+    },
+  });
+}

--- a/packages/testing/src/__tests__/jsonb-contract-drift.e2e.test.ts
+++ b/packages/testing/src/__tests__/jsonb-contract-drift.e2e.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { loadExtensions, DRIZZLE } from '@openora/core/server';
+import { seedChatCommands } from '@openora/core/engagement/seed/chat-commands';
+import {
+  setupTestDb,
+  bootTestApp,
+  seedMinimal,
+  registerAndMaterializePlayer,
+  type TestDb,
+  type TestApp,
+} from '../index.js';
+
+let db: TestDb;
+let app: TestApp;
+
+beforeAll(async () => {
+  process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
+  process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['NODE_ENV'] ??= 'test';
+
+  db = await setupTestDb();
+  app = await bootTestApp({ plugins: await loadExtensions(), databaseUrl: db.url });
+  await seedMinimal(app.container, { playerCount: 0 });
+  await seedChatCommands(app.container.get(DRIZZLE).db);
+}, 90_000);
+
+afterAll(async () => {
+  await app?.close();
+  await db?.dispose();
+});
+
+// A stored jsonb value outlives the contract that wrote it. Every route below selects a
+// column holding one, and each must serve the rest of its rows rather than fail wholesale.
+describe('a jsonb value the current contract cannot read', () => {
+  it('costs a command its config, not the whole command list', async () => {
+    const drizzle = app.container.get(DRIZZLE);
+    await drizzle.db.execute(
+      sql`UPDATE "chat_command_config" SET "config" = '{"minAmount":"1.00000000"}'::jsonb WHERE "key" = 'gift'`,
+    );
+
+    const res = await app.app.request('/chat-command/commands');
+
+    expect(res.status).toBe(200);
+    const commands = (await res.json()) as { key: string; config: unknown }[];
+    expect(commands.find((c) => c.key === 'gift')?.config).toBeNull();
+  });
+
+  it('costs a system message its place, not the whole room history', async () => {
+    const player = await registerAndMaterializePlayer(app, {
+      email: `drift_${randomUUID().slice(0, 8)}@e2e.test`,
+      username: `drift_${randomUUID().replaceAll('-', '').slice(0, 10)}`,
+    });
+    const drizzle = app.container.get(DRIZZLE);
+    // `command: 'tip'` is no command this build knows - the shape a removed or renamed
+    // command leaves behind in messages already sent.
+    await drizzle.db.execute(sql`
+      INSERT INTO "chat_message" ("room_id", "user_id", "username", "content", "type", "metadata")
+      VALUES (NULL, ${player.userId}::uuid, 'system', 'tipped', 'system',
+              '{"command":"tip","amount":"1.00"}'::jsonb)
+    `);
+
+    const res = await player.client.get('/chat/global');
+
+    expect(res.status).toBe(200);
+    const messages = (await res.json()) as { content: string; metadata: unknown }[];
+    // A system message is its command metadata, so an unreadable one cannot be rendered
+    // at all. It drops out; the rest of the history is still served.
+    expect(messages.find((m) => m.content === 'tipped')).toBeUndefined();
+    expect(messages.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `zodJsonb(schema, column)`: a jsonb column whose TypeScript type is inferred from its Zod schema and checked at both ends of the driver, instead of asserted by `jsonb().$type<T>()`. Applied to the columns whose stored shape can reach a route response. Follow-up to BF-545, which was one instance of this class.

## Why

`$type<T>()` is a cast Postgres never enforces, so the declared shape and the stored shape drift apart in silence. A row written by an earlier release outlives the contract that produced it, and the mismatch surfaces only when a route serializes it and fails output validation - taking every other row in that response down with it. That is how a single stale config row returned 500 for the whole command list.

A sweep of every `$type<>()` jsonb column found four more on a route's output path with no read-side check: chat message metadata and attachment, player tag assign metadata, and the command config itself. `Record<string, unknown>` columns (audit before/after, job run summary, notification data) are left alone - they never narrow a shape, so nothing can drift out of them.

Writes parse and throw: a value the current contract cannot express has no business entering the column, and that is where the drift is cheap to fix. Reads degrade to `null` and log the column - a row already in the table is a fact, and refusing to serve it trades one unreadable field for a dead endpoint.

KYC risk signals and checks take a louder variant, `severity: 'error'`: an operator approves or rejects a player against them, so a value silently read as absent reads like a clean player. The drift is reported to the bound error tracker rather than logged at warn. The value still degrades to null instead of throwing, because the player's own KYC page reads the same row - failing the read would take a player's status screen down over an admin-only field, and the whole admin queue with it.

Cost measured before enabling it on the hottest path: ~0.1ms per 200-message page for command metadata, ~0.3ms for attachments. Below a single database round trip.

## Alternatives considered

**Guard in each mapper** (what the BF-545 fix does). Correct but per-site: every new column and every new mapper has to remember, and the type stays a hand-written twin of the schema. The helper makes the schema the only declaration.

**drizzle-zod `createSelectSchema`.** Derives a Zod schema from the table, but for a jsonb column it reads back the same unchecked cast. Keeps types in sync, validates nothing.

**A `CHECK` constraint.** The only thing that would also bind writers outside this codebase - migrations, manual SQL, another service. Without an extension it can express little more than `jsonb_typeof`, and it needs the existing rows cleaned first. Worth its own change, not this one.

## Risks

`toDriver` now throws on a write the schema rejects, so a path that silently stored a malformed value starts failing loudly. That is the intent, but it can surface a writer nobody knew about.

Chat command metadata deliberately does NOT use the helper. `sanitizeCommandMetadata` repairs legacy money strings on read, and parsing in the driver would reject those rows before the repair ran - stricter than today, and it would drop messages the current build serves correctly. It is parsed after sanitizing instead. A system message that still fails to parse is omitted from the listing rather than nulled, because the contract has no shape for a system message without metadata; an integration test covering the legacy repair path caught this and is unchanged.

Reads that fail to parse are logged with the column name and the first three issues, but not the row id - the driver never sees one. Finding the affected rows is a query, not a log line.

Single-message routes (fetch by id) still surface a drifted row as an error rather than degrading: there is no valid value to return for the one record asked for.

`kyc_verification.document_types` is left on the cast. It is `NOT NULL`, so degrading to null would contradict the column, and an empty array is no better a stand-in for a compliance field than a null - it needs its own decision, not a default chosen here.

`rg_flag.detail` is also left alone: its output schema is already deliberately lenient (`RgFlagDetailSchema.or(z.record(...))`) so that one odd row cannot 500 the RG dashboard, with writes kept strict at `raiseFlag`. That is the same trade this helper makes, reached earlier and by hand.
