### PR TITLE
fix(server): let httpCache.additionalPaths extend the default cache list

### DIFF
--- a/packages/core/src/server/runtime/__tests__/create-app.test.ts
+++ b/packages/core/src/server/runtime/__tests__/create-app.test.ts
@@ -80,6 +80,68 @@ describe('createApp - streaming responses opt out of transformation', () => {
   });
 });
 
+describe('createApp - httpCache.additionalPaths extends rather than replaces the default list', () => {
+  it('keeps the built-in cache paths cacheable while adding a consumer path', async () => {
+    const saved = process.env['REDIS_URL'];
+    process.env['REDIS_URL'] = redisUrlForWorker();
+    try {
+      const created = await createApp({
+        plugins: [],
+        databaseUrl: DUMMY_DATABASE_URL,
+        httpCache: { additionalPaths: ['/email-assets'] },
+      });
+      created.app.get('/lobby/categories', (c) => c.json({ ok: true }));
+      created.app.get('/email-assets/banner.png', (c) => c.body('png'));
+      created.app.get('/wallet/balance', (c) => c.json({ ok: true }));
+
+      const builtIn = await created.app.request('/lobby/categories');
+      expect(builtIn.headers.get('cache-control')).toMatch(/^public,/);
+
+      const added = await created.app.request('/email-assets/banner.png');
+      expect(added.headers.get('cache-control')).toMatch(/^public,/);
+
+      const uncacheable = await created.app.request('/wallet/balance');
+      expect(uncacheable.headers.get('cache-control')).toBe('no-store');
+
+      await created.close();
+    } finally {
+      if (saved === undefined) {
+        delete process.env['REDIS_URL'];
+      } else {
+        process.env['REDIS_URL'] = saved;
+      }
+    }
+  });
+
+  it('lets `paths` still replace the default list wholesale, ignoring additionalPaths', async () => {
+    const saved = process.env['REDIS_URL'];
+    process.env['REDIS_URL'] = redisUrlForWorker();
+    try {
+      const created = await createApp({
+        plugins: [],
+        databaseUrl: DUMMY_DATABASE_URL,
+        httpCache: { paths: ['/only-this'], additionalPaths: ['/ignored-since-paths-is-set'] },
+      });
+      created.app.get('/lobby/categories', (c) => c.json({ ok: true }));
+      created.app.get('/ignored-since-paths-is-set', (c) => c.json({ ok: true }));
+
+      const builtIn = await created.app.request('/lobby/categories');
+      expect(builtIn.headers.get('cache-control')).toBe('no-store');
+
+      const ignored = await created.app.request('/ignored-since-paths-is-set');
+      expect(ignored.headers.get('cache-control')).toBe('no-store');
+
+      await created.close();
+    } finally {
+      if (saved === undefined) {
+        delete process.env['REDIS_URL'];
+      } else {
+        process.env['REDIS_URL'] = saved;
+      }
+    }
+  });
+});
+
 describe('createApp - service name for the Redis Streams consumer group', () => {
   const saved = { redis: process.env['REDIS_URL'], manifest: process.env['SERVICE_MANIFEST'] };
 

--- a/packages/core/src/server/runtime/create-app.ts
+++ b/packages/core/src/server/runtime/create-app.ts
@@ -52,12 +52,14 @@ import type { CoreTokenCatalog } from './core-token-catalog.js';
 // Path prefixes safe to cache at the HTTP layer: public, non-personalized reads
 // only (lobby feeds, public CMS content, the game catalogue). NOTHING
 // authenticated or per-player (wallet, profile, notifications, admin, chat) - a
-// consumer overrides this via `httpCache.paths` or disables it with `httpCache: false`.
+// consumer replaces this wholesale via `httpCache.paths`, extends it via
+// `httpCache.additionalPaths`, or disables caching entirely with `httpCache: false`.
 // This list living in the domain-agnostic engine (rather than each module
-// declaring its own cacheable routes) is accepted debt.
+// declaring its own cacheable routes) is accepted debt. Exported so a consumer
+// using `paths` to add one prefix can spread this in instead of hand-copying it.
 // '/cms/banners' is excluded on purpose: its `listBanners` route is unguarded and returns
 // inactive banners, so HTTP-caching it would leak draft banners to a shared cache.
-const PUBLIC_HTTP_CACHE_PATHS: readonly string[] = [
+export const PUBLIC_HTTP_CACHE_PATHS: readonly string[] = [
   '/lobby/categories',
   '/lobby/featured',
   '/lobby/search',
@@ -109,9 +111,10 @@ export type CreateAppConfig = {
 
   igaming?: IgamingConfig;
 
-  // GET-only, path-prefix-matched Cache-Control on PUBLIC_HTTP_CACHE_PATHS (or a
-  // supplied override). `false` disables HTTP response caching entirely.
-  httpCache?: { paths?: string[]; maxAgeSeconds?: number } | false;
+  // GET-only, path-prefix-matched Cache-Control on PUBLIC_HTTP_CACHE_PATHS. `paths`
+  // replaces that default list wholesale; `additionalPaths` extends it instead (ignored
+  // if `paths` is also given). `false` disables HTTP response caching entirely.
+  httpCache?: { paths?: string[]; additionalPaths?: string[]; maxAgeSeconds?: number } | false;
 
   disableHealthModule?: boolean;
 };
@@ -379,7 +382,10 @@ export async function createApp(
   }
 
   if (config.httpCache !== false) {
-    const cachePaths = config.httpCache?.paths ?? PUBLIC_HTTP_CACHE_PATHS;
+    const cachePaths = config.httpCache?.paths ?? [
+      ...PUBLIC_HTTP_CACHE_PATHS,
+      ...(config.httpCache?.additionalPaths ?? []),
+    ];
     const maxAgeSeconds = config.httpCache?.maxAgeSeconds ?? DEFAULT_HTTP_CACHE_MAX_AGE_SECONDS;
     const staleWhileRevalidateSeconds = config.httpCache?.maxAgeSeconds
       ? maxAgeSeconds * 2

--- a/packages/core/src/server/runtime/create-app.ts
+++ b/packages/core/src/server/runtime/create-app.ts
@@ -59,13 +59,13 @@ import type { CoreTokenCatalog } from './core-token-catalog.js';
 // using `paths` to add one prefix can spread this in instead of hand-copying it.
 // '/cms/banners' is excluded on purpose: its `listBanners` route is unguarded and returns
 // inactive banners, so HTTP-caching it would leak draft banners to a shared cache.
-export const PUBLIC_HTTP_CACHE_PATHS: readonly string[] = [
+export const PUBLIC_HTTP_CACHE_PATHS = [
   '/lobby/categories',
   '/lobby/featured',
   '/lobby/search',
   '/cms/pages',
   '/gaming/games',
-];
+] as const;
 
 const DEFAULT_HTTP_CACHE_MAX_AGE_SECONDS = 30;
 const DEFAULT_HTTP_CACHE_STALE_WHILE_REVALIDATE_SECONDS = 60;

--- a/packages/core/src/server/runtime/index.ts
+++ b/packages/core/src/server/runtime/index.ts
@@ -1,4 +1,4 @@
-export { createApp } from './create-app.js';
+export { createApp, PUBLIC_HTTP_CACHE_PATHS } from './create-app.js';
 export type { CreateAppConfig, CreatedApp } from './create-app.js';
 export type { CoreTokenCatalog } from './core-token-catalog.js';
 


### PR DESCRIPTION
## Summary

`createApp`'s `httpCache` config gains `additionalPaths`, which merges with the built-in
`PUBLIC_HTTP_CACHE_PATHS` list instead of replacing it; the list itself is now exported.

## Why

`httpCache.paths` replaces `PUBLIC_HTTP_CACHE_PATHS` wholesale, and that default list wasn't
exported. A consumer wanting to cache one path of their own on top of the defaults had no way to
reference the default list, so adding a path meant either hand-copying it (drifts silently if the
default list ever changes) or accepting that every other default path quietly loses its caching.

## Alternatives considered

- Exporting `PUBLIC_HTTP_CACHE_PATHS` alone and leaving consumers to spread it into `paths`
  themselves - still relies on remembering to spread it in; the same silent-loss bug is one typo
  away. Still done here alongside `additionalPaths`, for a consumer who wants to build their own
  list from scratch.
- Making `paths` merge with the defaults instead of replacing them - a breaking change for any
  consumer already relying on `paths` to fully override the default list.

## Risks

None. `additionalPaths` is a new, optional field; `paths` keeps its existing full-override
behavior and takes precedence when both are set.
