### PR TITLE
feat(wallet,gaming): book game wins and currency swaps to the ledger

### DIFF
--- a/.changeset/wallet-swap-and-game-win-ledger.md
+++ b/.changeset/wallet-swap-and-game-win-ledger.md
@@ -1,0 +1,5 @@
+---
+'@openora/core': minor
+---
+
+Two money paths that never reached the ledger now do. `GameAdapter.endRound` returns the round's outcome, so a settled round credits `win` through WALLET_COMMANDS and records `winAmount` (guarded on the round still being `active`, so a replay never pays twice). A new `SwapService` consumes the previously unused `SWAP_ADAPTER`: `POST /wallet/swap/quote` prices a pair, `POST /wallet/swap` holds the funds as a `processing` `swap_out` leg before calling the vendor and books the `swap_in` credit against the amount actually filled, and `POST /wallet/swap/webhook` (verified by `SWAP_WEBHOOK_VERIFIER`) settles or refunds an async fill. With no `SWAP_ADAPTER` bound the swap routes refuse - the resting state is unchanged.

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -460,6 +460,9 @@
         "wallet.reconciliation.run",
         "wallet.setActiveCurrency",
         "wallet.streamBalance",
+        "wallet.swap.execute",
+        "wallet.swap.quote",
+        "wallet.swap.webhook",
         "wallet.webhook",
         "wallet.webhookForProvider",
         "wallet.withdraw",
@@ -894,8 +897,10 @@
       "category": "swap",
       "interface": "SwapAdapter",
       "token": "SWAP_ADAPTER",
-      "status": "stub",
-      "boundIn": []
+      "status": "wired",
+      "boundIn": [
+        "packages/core/src/wallet/plugin.ts"
+      ]
     },
     {
       "category": "tag-evaluation-commands",
@@ -1048,6 +1053,7 @@
     "wallet.deposit.completed",
     "wallet.manual_adjustment.created",
     "wallet.reconciliation.alert",
+    "wallet.swap.completed",
     "wallet.withdrawal.approved",
     "wallet.withdrawal.completed",
     "wallet.withdrawal.failed",
@@ -2442,6 +2448,22 @@
     {
       "name": "SubmitKycOutputSchema",
       "file": "packages/core/src/compliance/contract/index.ts"
+    },
+    {
+      "name": "SwapInputSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "SwapQuoteInputSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "SwapQuoteSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "SwapResultSchema",
+      "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
       "name": "SystemChatMessageSchema",

--- a/docs/platform/system-design.md
+++ b/docs/platform/system-design.md
@@ -289,7 +289,7 @@ flowchart TB
 
 <!-- gen:catalog-reference -->
 
-Generated from `docs/catalog.json` - 20 modules, 254 routes, 44 adapter ports, 114 events. Edit the code, then run `pnpm gen:catalog`.
+Generated from `docs/catalog.json` - 20 modules, 257 routes, 44 adapter ports, 115 events. Edit the code, then run `pnpm gen:catalog`.
 
 | Domain                        | Modules                                                    | Tables                                                                              | Routes |
 | ----------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------ |
@@ -304,7 +304,7 @@ Generated from `docs/catalog.json` - 20 modules, 254 routes, 44 adapter ports, 1
 | `@openora/core/iam`           | iam                                                        | admin_invitation, admin_role, admin_role_assignment, admin_role_permission          | 17     |
 | `@openora/core/mail`          | mail                                                       | (owns none - reads through ports)                                                   | 0      |
 | `@openora/core/pam`           | identity · player-management · player-note · profile · tag | account, admin_trusted_device, phone_verification_session, player + 9 more          | 61     |
-| `@openora/core/wallet`        | wallet                                                     | auto_withdrawal_rule, wallet, wallet_asset, wallet_auto_withdrawal_config + 10 more | 35     |
+| `@openora/core/wallet`        | wallet                                                     | auto_withdrawal_rule, wallet, wallet_asset, wallet_auto_withdrawal_config + 10 more | 38     |
 
 <!-- /gen:catalog-reference -->
 

--- a/packages/core/src/casino/gaming/__tests__/gaming.service.int.test.ts
+++ b/packages/core/src/casino/gaming/__tests__/gaming.service.int.test.ts
@@ -5,6 +5,7 @@ import type {
   PlayEligibilityPort,
   RgLimitsPort,
   WalletCommands,
+  WalletCreditOutcome,
   WalletDebitOutcome,
 } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
@@ -17,6 +18,7 @@ import {
   GameNotFoundError,
   RgRestrictedError,
   InsufficientBalanceError,
+  WinCreditFailedError,
 } from '../service/gaming.service.js';
 
 let db: TestDb;
@@ -28,10 +30,13 @@ const eligibility = (isRestricted: boolean) =>
 
 const unrestricted = eligibility(false);
 
-function makeWalletCommands(debitResult: WalletDebitOutcome): WalletCommands {
+function makeWalletCommands(
+  debitResult: WalletDebitOutcome,
+  creditResult: WalletCreditOutcome = { ok: true, newBalance: '0' },
+): WalletCommands {
   return mock<WalletCommands>({
     debit: vi.fn().mockResolvedValue(debitResult),
-    credit: vi.fn(),
+    credit: vi.fn().mockResolvedValue(creditResult),
   });
 }
 
@@ -319,5 +324,79 @@ describe('GamingService.startRound bonus rollover completion (real PG)', () => {
       'wallet.bonus_rollover.completed',
       expect.anything(),
     );
+  });
+});
+
+async function seedRound(gameId: string, userId: string) {
+  const [row] = await db.drizzle.db
+    .insert(gameRound)
+    .values({ gameId, userId, currency: 'USD', betAmount: '10', status: 'active' })
+    .returning();
+  return row!;
+}
+
+const settlingProvider = (winAmount?: string) =>
+  mock<GameAdapter>({
+    launchGame: vi.fn(),
+    endRound: vi.fn().mockResolvedValue(winAmount === undefined ? undefined : { winAmount }),
+  });
+
+describe('GamingService.endRound (real PG)', () => {
+  const userId = '00000000-0000-0000-0000-000000000501';
+
+  it('credits the provider-reported win to the round currency and records it on the round', async () => {
+    const created = await seedGame();
+    const round = await seedRound(created.id, userId);
+    const walletCommands = makeWalletCommands({ ok: true, newBalance: '0', currency: 'USD' });
+    const svc = makeService({ provider: settlingProvider('42.50'), walletCommands });
+
+    expect(await svc.endRound(userId, round.id)).toEqual({ success: true, winAmount: '42.50' });
+
+    expect(walletCommands.credit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ userId, amount: '42.50', currency: 'USD', type: 'win' }),
+    );
+    const [settled] = await db.drizzle.db.select().from(gameRound);
+    expect(settled).toMatchObject({ status: 'completed', winAmount: '42.50' });
+  });
+
+  it('credits nothing when the provider reports no outcome', async () => {
+    const created = await seedGame();
+    const round = await seedRound(created.id, userId);
+    const walletCommands = makeWalletCommands({ ok: true, newBalance: '0', currency: 'USD' });
+    const svc = makeService({ provider: settlingProvider(), walletCommands });
+
+    expect(await svc.endRound(userId, round.id)).toEqual({ success: true, winAmount: '0' });
+
+    expect(walletCommands.credit).not.toHaveBeenCalled();
+  });
+
+  it('pays a win once - a replayed end never asks the provider or credits again', async () => {
+    const created = await seedGame();
+    const round = await seedRound(created.id, userId);
+    const walletCommands = makeWalletCommands({ ok: true, newBalance: '0', currency: 'USD' });
+    const provider = settlingProvider('7');
+    const svc = makeService({ provider, walletCommands });
+
+    await svc.endRound(userId, round.id);
+    expect(await svc.endRound(userId, round.id)).toEqual({ success: true, winAmount: '7.00' });
+
+    expect(provider.endRound).toHaveBeenCalledOnce();
+    expect(walletCommands.credit).toHaveBeenCalledOnce();
+  });
+
+  it('leaves the round open when the win credit is refused, so the payout is not lost', async () => {
+    const created = await seedGame();
+    const round = await seedRound(created.id, userId);
+    const walletCommands = makeWalletCommands(
+      { ok: true, newBalance: '0', currency: 'USD' },
+      { ok: false, reason: 'wallet not found' },
+    );
+    const svc = makeService({ provider: settlingProvider('7'), walletCommands });
+
+    await expect(svc.endRound(userId, round.id)).rejects.toBeInstanceOf(WinCreditFailedError);
+
+    const [unsettled] = await db.drizzle.db.select().from(gameRound);
+    expect(unsettled).toMatchObject({ status: 'active', winAmount: '0.00' });
   });
 });

--- a/packages/core/src/casino/gaming/adapters/mock/mock-game-adapter.ts
+++ b/packages/core/src/casino/gaming/adapters/mock/mock-game-adapter.ts
@@ -8,6 +8,8 @@ export class MockGameAdapter implements GameAdapter {
   }
 
   async endRound(_externalRoundId: string) {
-    // no-op for mock provider
+    // no-op for mock provider: it reports no outcome, so no round it closes ever pays a
+    // win. Deliberate - this adapter is the default GAME_ADAPTER binding in every ring,
+    // and a fabricated `winAmount` here would credit real balances.
   }
 }

--- a/packages/core/src/casino/gaming/contract/index.ts
+++ b/packages/core/src/casino/gaming/contract/index.ts
@@ -60,7 +60,9 @@ export const EndRoundInputSchema = z.object({
 
 export const EndRoundOutputSchema = z.object({
   success: z.literal(true),
-  outcome: z.unknown().optional(),
+  // What the round paid, in its own currency - '0' for a losing round. The provider's
+  // number: the player never sends it and cannot influence it.
+  winAmount: MoneyAmountSchema,
 });
 
 export const gamingContract = {

--- a/packages/core/src/casino/gaming/service/gaming.service.ts
+++ b/packages/core/src/casino/gaming/service/gaming.service.ts
@@ -31,6 +31,12 @@ export const InsufficientBalanceError = createDomainError<[available: string, re
   'InsufficientBalanceError',
   (available, requested) => `Insufficient balance: available ${available}, requested ${requested}`,
 );
+// Thrown inside the settlement transaction, so the round stays `active` and the win can be
+// settled again rather than being lost silently.
+export const WinCreditFailedError = createDomainError<[roundId: string, reason: string]>(
+  'WinCreditFailedError',
+  (roundId, reason) => `win credit failed for round ${roundId}: ${reason}`,
+);
 
 function toGame(record: typeof game.$inferSelect) {
   return {
@@ -141,9 +147,9 @@ export class GamingService {
   async endRound(
     userId: User['id'],
     roundId: GameRound['id'],
-  ): Promise<{ success: true; outcome?: unknown }> {
+  ): Promise<{ success: true; winAmount: string }> {
     // Without RLS (ADR-0026, single-tenant) this userId filter is the sole access guard.
-    findOneOrThrow(
+    const round = findOneOrThrow(
       await this.drizzle.db
         .select()
         .from(gameRound)
@@ -151,12 +157,49 @@ export class GamingService {
       new GameRoundNotFoundError(roundId),
     );
 
-    await this.provider.endRound(roundId);
+    // A round that already closed reports what it paid and stops here - re-calling the
+    // provider would ask a settled round for its outcome a second time.
+    if (round.status !== 'active') {
+      return { success: true, winAmount: round.winAmount };
+    }
 
-    await this.drizzle.db
-      .update(gameRound)
-      .set({ status: 'completed', endedAt: new Date() })
-      .where(and(eq(gameRound.id, roundId), eq(gameRound.userId, userId)));
+    const outcome = await this.provider.endRound(roundId);
+    // The provider's number, never the caller's: the win is credited off this alone.
+    const winAmount = outcome?.winAmount ?? '0';
+
+    const paid = await this.drizzle.db.transaction(async (tx) => {
+      // `status = 'active'` is the payout guard: two concurrent end-round calls both
+      // reach here, only one updates a row, so the win is credited exactly once.
+      const settled = await tx
+        .update(gameRound)
+        .set({ status: 'completed', endedAt: new Date(), winAmount })
+        .where(
+          and(
+            eq(gameRound.id, roundId),
+            eq(gameRound.userId, userId),
+            eq(gameRound.status, 'active'),
+          ),
+        )
+        .returning({ id: gameRound.id });
+      if (settled.length === 0) {
+        return false;
+      }
+      if (Number(winAmount) > 0) {
+        // The bet already opened this currency's balance, so `allowNewCurrency` only
+        // covers a player whose active currency moved between start and settlement.
+        const credited = await this.walletCommands.credit(tx, {
+          userId,
+          amount: winAmount,
+          currency: round.currency,
+          type: 'win',
+          allowNewCurrency: true,
+        });
+        if (!credited.ok) {
+          throw new WinCreditFailedError(roundId, credited.reason);
+        }
+      }
+      return true;
+    });
 
     this.events.emit('gaming.round.ended', {
       roundId,
@@ -164,7 +207,7 @@ export class GamingService {
       playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
     });
 
-    return { success: true };
+    return { success: true, winAmount: paid ? winAmount : round.winAmount };
   }
 
   async getUserRounds(userId: User['id']) {

--- a/packages/core/src/contracts/adapters/game.ts
+++ b/packages/core/src/contracts/adapters/game.ts
@@ -4,13 +4,20 @@
  */
 import { createToken, type Token } from './token.js';
 
+/**
+ * What the provider reports when a round closes. `winAmount` is a decimal string in the
+ * round's own currency and is the only number the win credit may use - never a client's.
+ * A void return, or an omitted `winAmount`, is a round that paid nothing.
+ */
+export type RoundOutcome = { winAmount?: string };
+
 export type GameAdapter = {
   launchGame(
     gameId: string,
     userId: string,
     currency: string,
   ): Promise<{ launchUrl: string; token: string }>;
-  endRound(externalRoundId: string): Promise<void>;
+  endRound(externalRoundId: string): Promise<RoundOutcome | void>;
 };
 
 export const GAME_ADAPTER: Token<GameAdapter> = createToken('GAME_ADAPTER');

--- a/packages/core/src/contracts/adapters/index.ts
+++ b/packages/core/src/contracts/adapters/index.ts
@@ -99,7 +99,7 @@ export {
   ACCESS_REVOKED_SIGNAL,
 } from './realtime.js';
 
-export type { GameAdapter } from './game.js';
+export type { GameAdapter, RoundOutcome } from './game.js';
 export { GAME_ADAPTER } from './game.js';
 
 export type {

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -352,6 +352,18 @@ export const domainEventSchemas = {
     playerId: UuidSchema.nullable(),
   }),
 
+  // A currency swap filled: the player's `fromCurrency` balance was debited and
+  // `toCurrency` credited, as two ledger legs. `toAmount` is what the vendor actually
+  // filled, never the quoted number.
+  'wallet.swap.completed': z.object({
+    userId: UuidSchema,
+    transactionId: UuidSchema,
+    fromCurrency: CurrencyTickerSchema,
+    fromAmount: MoneyAmountSchema,
+    toCurrency: CurrencyTickerSchema,
+    toAmount: MoneyAmountSchema,
+  }),
+
   'wallet.bonus_rollover.completed': z.object({
     userId: UuidSchema,
     creditId: UuidSchema,

--- a/packages/core/src/wallet/__tests__/swap.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/swap.service.int.test.ts
@@ -6,8 +6,8 @@ import type { SwapAdapter } from '@openora/core/contracts';
 import { createTestDb, type TestDb } from '@openora/core/testing';
 import { mock, makeEventBus } from '../../testing/mock.js';
 import { migrate } from '../migrate.js';
-import { wallet, walletBalance, walletTransaction } from '../schema/index.js';
-import { InsufficientBalanceError } from '../service/wallet.service.js';
+import { wallet, walletBalance, walletBonusCredit, walletTransaction } from '../schema/index.js';
+import { BonusRolloverLockedError, InsufficientBalanceError } from '../service/wallet.service.js';
 import { SwapPairUnsupportedError, SwapService } from '../service/swap.service.js';
 
 let db: TestDb;
@@ -85,7 +85,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await db.drizzle.db.execute(
-    sql`TRUNCATE ${walletTransaction}, ${walletBalance}, ${wallet} RESTART IDENTITY CASCADE`,
+    sql`TRUNCATE ${walletTransaction}, ${walletBonusCredit}, ${walletBalance}, ${wallet} RESTART IDENTITY CASCADE`,
   );
 });
 
@@ -188,6 +188,35 @@ describe('SwapService (real PG)', () => {
     expect(adapter.execute).not.toHaveBeenCalled();
     expect(await legs(w.id)).toEqual([]);
     expect(await balancesOf(w.id)).toEqual({ USD: 10 });
+  });
+
+  it('names the bonus rollover, not a missing balance, when locked funds block the swap', async () => {
+    const w = await seedWallet();
+    await db.drizzle.db.insert(walletBonusCredit).values({
+      walletId: w.id,
+      userId: w.userId,
+      currency: 'USD',
+      sourceType: 'gift',
+      creditedAmount: '100',
+      rolloverMultiplier: '1',
+      rolloverRequired: '100',
+      rolloverProgress: '0',
+      status: 'active',
+    });
+    const adapter = makeAdapter();
+
+    await expect(
+      makeService(adapter).swap({
+        userId: w.userId,
+        fromCurrency: 'USD',
+        toCurrency: 'BTC',
+        fromAmount: '100',
+        idempotencyKey: randomUUID(),
+      }),
+    ).rejects.toBeInstanceOf(BonusRolloverLockedError);
+
+    expect(adapter.execute).not.toHaveBeenCalled();
+    expect(await balancesOf(w.id)).toEqual({ USD: 100 });
   });
 
   it('trades once for a replayed idempotency key', async () => {

--- a/packages/core/src/wallet/__tests__/swap.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/swap.service.int.test.ts
@@ -90,6 +90,34 @@ beforeEach(async () => {
 });
 
 describe('SwapService (real PG)', () => {
+  it('prices a pair through the bound desk', async () => {
+    const w = await seedWallet();
+    const adapter = makeAdapter();
+
+    await expect(
+      makeService(adapter).quote({
+        userId: w.userId,
+        fromCurrency: 'USD',
+        toCurrency: 'BTC',
+        fromAmount: '100',
+      }),
+    ).resolves.toMatchObject({ toAmount: '0.00152' });
+  });
+
+  it('refuses to price a pair the desk does not make', async () => {
+    const w = await seedWallet();
+    const adapter = makeAdapter({ supportsPair: vi.fn().mockReturnValue(false) });
+
+    await expect(
+      makeService(adapter).quote({
+        userId: w.userId,
+        fromCurrency: 'USD',
+        toCurrency: 'BTC',
+        fromAmount: '100',
+      }),
+    ).rejects.toBeInstanceOf(SwapPairUnsupportedError);
+  });
+
   it('books both legs and moves both balances on a filled swap', async () => {
     const w = await seedWallet();
     const events = makeEventBus();

--- a/packages/core/src/wallet/__tests__/swap.service.int.test.ts
+++ b/packages/core/src/wallet/__tests__/swap.service.int.test.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { findOneOrThrow } from '@openora/core/server';
+import type { SwapAdapter } from '@openora/core/contracts';
+import { createTestDb, type TestDb } from '@openora/core/testing';
+import { mock, makeEventBus } from '../../testing/mock.js';
+import { migrate } from '../migrate.js';
+import { wallet, walletBalance, walletTransaction } from '../schema/index.js';
+import { InsufficientBalanceError } from '../service/wallet.service.js';
+import { SwapPairUnsupportedError, SwapService } from '../service/swap.service.js';
+
+let db: TestDb;
+
+const QUOTE = {
+  quoteId: 'q1',
+  fromCurrency: 'USD',
+  toCurrency: 'BTC',
+  fromAmount: '100',
+  toAmount: '0.00152',
+  rate: '0.0000153',
+  fee: '0.0000153',
+  feeCurrency: 'BTC',
+  asOf: '2026-01-01T00:00:00.000Z',
+  expiresAt: '2026-01-01T00:15:00.000Z',
+};
+
+function makeAdapter(overrides: Partial<SwapAdapter> = {}) {
+  return mock<SwapAdapter>({
+    getQuote: vi.fn().mockResolvedValue(QUOTE),
+    execute: vi
+      .fn()
+      .mockResolvedValue({ externalId: 'ext-1', status: 'completed', toAmount: '0.00152' }),
+    ...overrides,
+  });
+}
+
+function makeService(adapter: SwapAdapter = makeAdapter(), events = makeEventBus()) {
+  return new SwapService({ drizzle: db.drizzle, events, adapter });
+}
+
+async function seedWallet(balances: Record<string, string> = { USD: '100' }) {
+  const row = findOneOrThrow(
+    await db.drizzle.db
+      .insert(wallet)
+      .values({ userId: randomUUID(), currency: 'USD' })
+      .returning(),
+    new Error('seedWallet: query returned no row'),
+  );
+  for (const [currency, amount] of Object.entries(balances)) {
+    await db.drizzle.db.insert(walletBalance).values({ walletId: row.id, currency, amount });
+  }
+  return row;
+}
+
+async function balancesOf(walletId: string) {
+  const rows = await db.drizzle.db
+    .select({ currency: walletBalance.currency, amount: walletBalance.amount })
+    .from(walletBalance)
+    .where(eq(walletBalance.walletId, walletId));
+  return Object.fromEntries(rows.map((r) => [r.currency, Number(r.amount)]));
+}
+
+async function legs(walletId: string) {
+  const rows = await db.drizzle.db
+    .select()
+    .from(walletTransaction)
+    .where(eq(walletTransaction.walletId, walletId));
+  return rows.map((r) => ({
+    type: r.type,
+    amount: Number(r.amount),
+    currency: r.currency,
+    status: r.status,
+    direction: r.direction,
+  }));
+}
+
+beforeAll(async () => {
+  db = await createTestDb([migrate]);
+});
+
+afterAll(async () => {
+  await db.drop();
+});
+
+beforeEach(async () => {
+  await db.drizzle.db.execute(
+    sql`TRUNCATE ${walletTransaction}, ${walletBalance}, ${wallet} RESTART IDENTITY CASCADE`,
+  );
+});
+
+describe('SwapService (real PG)', () => {
+  it('books both legs and moves both balances on a filled swap', async () => {
+    const w = await seedWallet();
+    const events = makeEventBus();
+
+    const result = await makeService(makeAdapter(), events).swap({
+      userId: w.userId,
+      fromCurrency: 'USD',
+      toCurrency: 'BTC',
+      fromAmount: '100',
+      idempotencyKey: randomUUID(),
+    });
+
+    expect(result).toMatchObject({ status: 'completed', toAmount: '0.00152' });
+    expect(await balancesOf(w.id)).toEqual({ USD: 0, BTC: 0.00152 });
+    expect(await legs(w.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'swap_out',
+          currency: 'USD',
+          status: 'completed',
+          direction: 'debit',
+        }),
+        expect.objectContaining({
+          type: 'swap_in',
+          currency: 'BTC',
+          status: 'completed',
+          direction: 'credit',
+        }),
+      ]),
+    );
+    expect(events.emit).toHaveBeenCalledWith(
+      'wallet.swap.completed',
+      expect.objectContaining({ userId: w.userId, toCurrency: 'BTC', toAmount: '0.00152' }),
+    );
+  });
+
+  it('credits the filled amount, never the quoted one', async () => {
+    const w = await seedWallet();
+    const adapter = makeAdapter({
+      execute: vi
+        .fn()
+        .mockResolvedValue({ externalId: 'ext-2', status: 'completed', toAmount: '0.001' }),
+    });
+
+    await makeService(adapter).swap({
+      userId: w.userId,
+      fromCurrency: 'USD',
+      toCurrency: 'BTC',
+      fromAmount: '100',
+      idempotencyKey: randomUUID(),
+    });
+
+    expect(await balancesOf(w.id)).toEqual({ USD: 0, BTC: 0.001 });
+  });
+
+  it('holds the funds before the vendor is called and returns them when it refuses', async () => {
+    const w = await seedWallet();
+    const adapter = makeAdapter({
+      execute: vi.fn().mockImplementation(async () => {
+        // Mid-flight: the hold must already be committed and the balance gone.
+        expect(await balancesOf(w.id)).toEqual({ USD: 0 });
+        throw new Error('desk unavailable');
+      }),
+    });
+
+    await expect(
+      makeService(adapter).swap({
+        userId: w.userId,
+        fromCurrency: 'USD',
+        toCurrency: 'BTC',
+        fromAmount: '100',
+        idempotencyKey: randomUUID(),
+      }),
+    ).rejects.toThrow('desk unavailable');
+
+    expect(await balancesOf(w.id)).toEqual({ USD: 100 });
+    expect(await legs(w.id)).toEqual([
+      expect.objectContaining({ type: 'swap_out', status: 'failed' }),
+    ]);
+  });
+
+  it('refuses a swap the balance cannot cover, without writing a hold', async () => {
+    const w = await seedWallet({ USD: '10' });
+    const adapter = makeAdapter();
+
+    await expect(
+      makeService(adapter).swap({
+        userId: w.userId,
+        fromCurrency: 'USD',
+        toCurrency: 'BTC',
+        fromAmount: '100',
+        idempotencyKey: randomUUID(),
+      }),
+    ).rejects.toBeInstanceOf(InsufficientBalanceError);
+
+    expect(adapter.execute).not.toHaveBeenCalled();
+    expect(await legs(w.id)).toEqual([]);
+    expect(await balancesOf(w.id)).toEqual({ USD: 10 });
+  });
+
+  it('trades once for a replayed idempotency key', async () => {
+    const w = await seedWallet();
+    const adapter = makeAdapter();
+    const svc = makeService(adapter);
+    const idempotencyKey = randomUUID();
+    const args = {
+      userId: w.userId,
+      fromCurrency: 'USD',
+      toCurrency: 'BTC',
+      fromAmount: '100',
+      idempotencyKey,
+    };
+
+    await svc.swap(args);
+    const replay = await svc.swap(args);
+
+    expect(replay.status).toBe('completed');
+    expect(adapter.execute).toHaveBeenCalledOnce();
+    expect(await balancesOf(w.id)).toEqual({ USD: 0, BTC: 0.00152 });
+  });
+
+  it('leaves an async fill processing until the vendor webhook settles it', async () => {
+    const w = await seedWallet();
+    const adapter = makeAdapter({
+      execute: vi.fn().mockResolvedValue({ externalId: 'ext-3', status: 'processing' }),
+    });
+    const svc = makeService(adapter);
+
+    const result = await svc.swap({
+      userId: w.userId,
+      fromCurrency: 'USD',
+      toCurrency: 'BTC',
+      fromAmount: '100',
+      idempotencyKey: randomUUID(),
+    });
+
+    expect(result).toMatchObject({ status: 'processing', toAmount: null });
+    expect(await balancesOf(w.id)).toEqual({ USD: 0 });
+
+    await svc.reconcileSwapStatus({
+      kind: 'swap',
+      externalId: 'ext-3',
+      status: 'completed',
+      toAmount: '0.0014',
+    });
+
+    expect(await balancesOf(w.id)).toEqual({ USD: 0, BTC: 0.0014 });
+    // A duplicate delivery must not credit the fill twice.
+    await svc.reconcileSwapStatus({
+      kind: 'swap',
+      externalId: 'ext-3',
+      status: 'completed',
+      toAmount: '0.0014',
+    });
+    expect(await balancesOf(w.id)).toEqual({ USD: 0, BTC: 0.0014 });
+  });
+
+  it('returns the held funds when the vendor reports the swap failed', async () => {
+    const w = await seedWallet();
+    const adapter = makeAdapter({
+      execute: vi.fn().mockResolvedValue({ externalId: 'ext-4', status: 'processing' }),
+    });
+    const svc = makeService(adapter);
+    await svc.swap({
+      userId: w.userId,
+      fromCurrency: 'USD',
+      toCurrency: 'BTC',
+      fromAmount: '100',
+      idempotencyKey: randomUUID(),
+    });
+
+    await svc.reconcileSwapStatus({ kind: 'swap', externalId: 'ext-4', status: 'failed' });
+
+    expect(await balancesOf(w.id)).toEqual({ USD: 100 });
+    expect(await legs(w.id)).toEqual([
+      expect.objectContaining({ type: 'swap_out', status: 'failed' }),
+    ]);
+  });
+
+  it('refuses a pair the vendor does not make and a swap into the same currency', async () => {
+    const w = await seedWallet();
+    const adapter = makeAdapter({ supportsPair: vi.fn().mockReturnValue(false) });
+    const args = {
+      userId: w.userId,
+      fromCurrency: 'USD',
+      toCurrency: 'BTC',
+      fromAmount: '100',
+      idempotencyKey: randomUUID(),
+    };
+
+    await expect(makeService(adapter).swap(args)).rejects.toBeInstanceOf(SwapPairUnsupportedError);
+    await expect(makeService().swap({ ...args, toCurrency: 'usd' })).rejects.toBeInstanceOf(
+      SwapPairUnsupportedError,
+    );
+  });
+});

--- a/packages/core/src/wallet/contract/index.ts
+++ b/packages/core/src/wallet/contract/index.ts
@@ -90,7 +90,12 @@ export const WalletBalancesSchema = z.object({
 // stale number on screen with no self-correction. This shape only tells the client WHAT
 // changed; the client re-fetches getBalance(s)/listTransactions, which is cheap and
 // always internally consistent.
-export const WalletBalanceChangeReasonSchema = z.enum(['deposit', 'withdrawal', 'adjustment']);
+export const WalletBalanceChangeReasonSchema = z.enum([
+  'deposit',
+  'withdrawal',
+  'adjustment',
+  'swap',
+]);
 export type WalletBalanceChangeReason = z.infer<typeof WalletBalanceChangeReasonSchema>;
 
 export const WalletBalanceUpdateSchema = z.object({
@@ -361,6 +366,43 @@ export const ApproveWithdrawalInputSchema = z.object({ withdrawalId: UuidSchema 
 export const RejectWithdrawalInputSchema = z.object({
   withdrawalId: UuidSchema,
   reason: z.string().min(1),
+});
+
+// A vendor quote id is the vendor's own string, not a uuid we mint - bounded, never parsed.
+const SwapQuoteIdSchema = z.string().trim().min(1).max(128);
+
+export const SwapQuoteInputSchema = z.object({
+  fromCurrency: WalletCurrencyInputSchema,
+  toCurrency: WalletCurrencyInputSchema,
+  fromAmount: PositiveMoneyAmountSchema,
+});
+
+// `toAmount` is what the player receives, net of `fee`, and is the only binding number -
+// `rate` is informational and must never be multiplied out to reach an amount.
+export const SwapQuoteSchema = z.object({
+  quoteId: SwapQuoteIdSchema,
+  fromCurrency: WalletCurrencyCodeSchema,
+  toCurrency: WalletCurrencyCodeSchema,
+  fromAmount: MoneyAmountSchema,
+  toAmount: MoneyAmountSchema,
+  rate: MoneyAmountSchema,
+  fee: MoneyAmountSchema,
+  feeCurrency: WalletCurrencyCodeSchema,
+  asOf: TimestampSchema,
+  expiresAt: TimestampSchema,
+});
+
+export const SwapInputSchema = SwapQuoteInputSchema.extend({
+  // Optional: a vendor that does not hold quotes prices the swap at execution time.
+  quoteId: SwapQuoteIdSchema.optional(),
+  idempotencyKey: UuidSchema,
+});
+
+export const SwapResultSchema = z.object({
+  transactionId: UuidSchema,
+  status: WalletTransactionStatusSchema,
+  // Null until the vendor reports a fill - an async desk settles by webhook.
+  toAmount: MoneyAmountSchema.nullable(),
 });
 
 export const PaymentWebhookInputSchema = z.record(z.string(), z.unknown());
@@ -702,6 +744,25 @@ export const walletContract = {
       .route({ method: 'PATCH', path: '/backoffice/wallet/bonus-rollover-config' })
       .input(SetBonusRolloverConfigInputSchema)
       .output(BonusRolloverConfigSchema),
+  },
+
+  swap: {
+    quote: oc
+      .route({ method: 'POST', path: '/wallet/swap/quote', summary: 'Price a currency swap' })
+      .input(SwapQuoteInputSchema)
+      .output(SwapQuoteSchema),
+
+    execute: oc
+      .route({ method: 'POST', path: '/wallet/swap', summary: 'Swap between own balances' })
+      .input(SwapInputSchema)
+      .output(SwapResultSchema),
+
+    // Unauthenticated like the payment webhook, and verified by its own SWAP_WEBHOOK_VERIFIER
+    // - a swap desk signs with a different key than the PSP.
+    webhook: oc
+      .route({ method: 'POST', path: '/wallet/swap/webhook' })
+      .input(PaymentWebhookInputSchema)
+      .output(PaymentWebhookOutputSchema),
   },
 
   webhook: oc

--- a/packages/core/src/wallet/plugin.ts
+++ b/packages/core/src/wallet/plugin.ts
@@ -19,6 +19,8 @@ import {
   TAG_EVALUATION_COMMANDS,
   PLAY_ELIGIBILITY,
   RG_LIMITS,
+  SWAP_ADAPTER,
+  SWAP_WEBHOOK_VERIFIER,
   AUDIT_WRITER,
   JOB_QUEUE,
   UuidSchema,
@@ -41,6 +43,7 @@ import { createWalletRouter, walletBalanceChannel } from './router/index.js';
 import { MockPaymentAdapter } from './adapters/mock/mock-payment-adapter.js';
 import { HmacPaymentWebhookVerifier } from './adapters/hmac-payment-webhook-verifier.js';
 import { ReconciliationService } from './service/reconciliation.service.js';
+import { SwapService } from './service/swap.service.js';
 
 const logger = createLogger('wallet');
 
@@ -135,6 +138,16 @@ export default {
         'withdrawal',
         envelope.eventId,
       );
+    });
+    // Both sides of a swap moved, so both currencies get a signal - a client watching
+    // only its active currency would otherwise miss the leg it swapped out of.
+    ctx.events.on('wallet.swap.completed', (payload, envelope) => {
+      const parsed = domainEventSchemas['wallet.swap.completed'].safeParse(payload);
+      if (!parsed.success || !envelope) {
+        return;
+      }
+      publishBalanceChanged(parsed.data.userId, parsed.data.fromCurrency, 'swap', envelope.eventId);
+      publishBalanceChanged(parsed.data.userId, parsed.data.toCurrency, 'swap', envelope.eventId);
     });
     ctx.events.on('wallet.manual_adjustment.created', (payload, envelope) => {
       const parsed = domainEventSchemas['wallet.manual_adjustment.created'].safeParse(payload);
@@ -275,6 +288,29 @@ export default {
           .catch((err) => logger.error({ err }, 'wallet-reconciliation schedule failed'));
       }
 
+      // No SWAP_ADAPTER bound is the resting state (core binds none) - the swap routes
+      // then refuse rather than the module failing to load.
+      const swapAdapter = c.has(SWAP_ADAPTER) ? c.get(SWAP_ADAPTER) : undefined;
+      const swapVerifier = c.has(SWAP_WEBHOOK_VERIFIER) ? c.get(SWAP_WEBHOOK_VERIFIER) : undefined;
+      const swap = swapAdapter
+        ? new SwapService({
+            drizzle: c.get(DRIZZLE),
+            events: c.get(EVENT_BUS),
+            adapter: swapAdapter,
+            platformConfig,
+            limiter: c.get(RATE_LIMITER),
+          })
+        : undefined;
+      // A webhook needs BOTH: an adapter that parses the vendor's format and that same
+      // vendor's verifier. One without the other leaves the route refusing everything.
+      const swapWebhook =
+        swapAdapter?.parseWebhook && swapVerifier
+          ? {
+              verify: swapVerifier.verify.bind(swapVerifier),
+              parse: swapAdapter.parseWebhook.bind(swapAdapter),
+            }
+          : undefined;
+
       return createWalletRouter({
         wallet: walletService,
         adminGuard: c.get(ADMIN_GUARD),
@@ -285,6 +321,8 @@ export default {
         reconciliationQueue: WALLET_RECONCILIATION_QUEUE,
         realtime: realtimeTransport,
         limiter: c.get(RATE_LIMITER),
+        swap,
+        swapWebhook,
       });
     });
   },

--- a/packages/core/src/wallet/router/index.ts
+++ b/packages/core/src/wallet/router/index.ts
@@ -21,6 +21,7 @@ import {
   type RateLimiterAdapter,
   type RateLimitKey,
   type RealtimeTransport,
+  type SwapWebhookEvent,
   type User,
 } from '@openora/core/contracts';
 import { walletContract, type WalletBalanceUpdate } from '../contract/index.js';
@@ -56,6 +57,11 @@ import {
   WithdrawalAddressAlreadyExistsError,
   WithdrawalAddressLimitReachedError,
 } from '../service/wallet.service.js';
+import {
+  SwapService,
+  SwapPairUnsupportedError,
+  SwapUnavailableError,
+} from '../service/swap.service.js';
 import {
   ReconciliationService,
   ReconciliationFindingNotFoundError,
@@ -134,6 +140,22 @@ export type WalletRouterDeps = {
   reconciliationQueue: QueueName;
   realtime: RealtimeTransport;
   limiter?: RateLimiterAdapter<RateLimitKey>;
+  /** Absent when no SWAP_ADAPTER is bound - every swap route then refuses. */
+  swap?: SwapService;
+  swapWebhook?: SwapWebhookPort;
+};
+
+/** The verifier/parser pair for an inbound swap webhook, bound together for the same reason
+ * the payment one is: never verify with one vendor's key and parse with another's format. */
+export type SwapWebhookPort = {
+  verify(
+    rawBody: string,
+    headers: Record<string, string | string[] | undefined>,
+  ): boolean | Promise<boolean>;
+  parse(
+    rawBody: string,
+    headers: Record<string, string | string[] | undefined>,
+  ): SwapWebhookEvent | null;
 };
 
 export function createWalletRouter({
@@ -146,6 +168,8 @@ export function createWalletRouter({
   reconciliationQueue,
   realtime,
   limiter,
+  swap,
+  swapWebhook,
 }: WalletRouterDeps) {
   const os = implement(walletContract).$context<OssContext>();
 
@@ -155,6 +179,15 @@ export function createWalletRouter({
       makeRateLimitKey(RATE_LIMIT_KEYS.WALLET_WEBHOOK, context.clientMeta.ip ?? 'unknown'),
       WALLET_WEBHOOK_RATE_LIMIT,
     );
+
+  // Every swap route funnels through this, so an operator with no swap vendor bound gets
+  // one consistent refusal instead of a 500 from an undefined service.
+  const requireSwap = (): SwapService => {
+    if (!swap) {
+      throw new SwapUnavailableError();
+    }
+    return swap;
+  };
 
   return os.router({
     getBalance: os.getBalance.handler(({ context }) => wallet.getBalance(getUserId(context))),
@@ -479,6 +512,48 @@ export function createWalletRouter({
           userAgent,
         } = await adminGuard.assert(context, 'bonus-rollover-config', 'update');
         return wallet.setBonusRolloverConfig(adminId, input, { ip, userAgent });
+      }),
+    },
+
+    swap: {
+      quote: os.swap.quote.handler(({ input }) =>
+        mapErrors({ CONFLICT: [SwapUnavailableError, SwapPairUnsupportedError] }, () =>
+          requireSwap().quote(input),
+        ),
+      ),
+
+      execute: os.swap.execute.handler(({ input, context }) =>
+        mapErrors(
+          {
+            NOT_FOUND: WalletNotFoundError,
+            CONFLICT: [SwapUnavailableError, SwapPairUnsupportedError, IdempotencyKeyReuseError],
+            BAD_REQUEST: InsufficientBalanceError,
+            // SwapFillAmountMissingError is deliberately unmapped: the vendor filled but
+            // would not say how much, which is a 500 on our side of the seam, not a 4xx
+            // the caller can act on.
+          },
+          () => requireSwap().swap({ userId: getUserId(context), ...input }),
+        ),
+      ),
+
+      webhook: os.swap.webhook.handler(async ({ context }) => {
+        await throttleWebhook(context);
+        // A missing binding, a bad signature and an unparseable body all answer the same
+        // way - the endpoint must never confirm which vendor is bound.
+        const rawBody = context.rawBody;
+        if (
+          !swap ||
+          !swapWebhook ||
+          rawBody === undefined ||
+          !(await swapWebhook.verify(rawBody, context.request.headers))
+        ) {
+          throw new ORPCError('UNAUTHORIZED', { message: 'Invalid swap webhook signature' });
+        }
+        const event = swapWebhook.parse(rawBody, context.request.headers);
+        if (event) {
+          await swap.reconcileSwapStatus(event);
+        }
+        return { ok: true as const };
       }),
     },
 

--- a/packages/core/src/wallet/router/index.ts
+++ b/packages/core/src/wallet/router/index.ts
@@ -516,9 +516,9 @@ export function createWalletRouter({
     },
 
     swap: {
-      quote: os.swap.quote.handler(({ input }) =>
+      quote: os.swap.quote.handler(({ input, context }) =>
         mapErrors({ CONFLICT: [SwapUnavailableError, SwapPairUnsupportedError] }, () =>
-          requireSwap().quote(input),
+          requireSwap().quote({ userId: getUserId(context), ...input }),
         ),
       ),
 

--- a/packages/core/src/wallet/router/index.ts
+++ b/packages/core/src/wallet/router/index.ts
@@ -526,7 +526,12 @@ export function createWalletRouter({
         mapErrors(
           {
             NOT_FOUND: WalletNotFoundError,
-            CONFLICT: [SwapUnavailableError, SwapPairUnsupportedError, IdempotencyKeyReuseError],
+            CONFLICT: [
+              SwapUnavailableError,
+              SwapPairUnsupportedError,
+              IdempotencyKeyReuseError,
+              BonusRolloverLockedError,
+            ],
             BAD_REQUEST: InsufficientBalanceError,
             // SwapFillAmountMissingError is deliberately unmapped: the vendor filled but
             // would not say how much, which is a 500 on our side of the seam, not a 4xx

--- a/packages/core/src/wallet/service/swap.service.ts
+++ b/packages/core/src/wallet/service/swap.service.ts
@@ -110,11 +110,21 @@ export class SwapService {
     this.limiter = deps.limiter;
   }
 
-  async quote(input: {
+  /**
+   * Player-scoped even though a price is not player-specific: a quote is a vendor call the
+   * desk bills for, so it is behind the session and the same per-player throttle the swap
+   * itself takes rather than an open pricing endpoint.
+   */
+  async quote({
+    userId,
+    ...input
+  }: {
+    userId: User['id'];
     fromCurrency: string;
     toCurrency: string;
     fromAmount: string;
   }): Promise<SwapQuote> {
+    await this.rateLimit(userId);
     this.assertPair(input.fromCurrency, input.toCurrency);
     const quote = await this.adapter.getQuote(input);
     if (!quote) {

--- a/packages/core/src/wallet/service/swap.service.ts
+++ b/packages/core/src/wallet/service/swap.service.ts
@@ -1,0 +1,413 @@
+import {
+  assertRateLimit,
+  createDomainError,
+  createLogger,
+  findOneOrThrow,
+  makeConflictError,
+  type DrizzleService,
+  type EventBus,
+  type DrizzleTx,
+} from '@openora/core/server';
+import {
+  makeRateLimitKey,
+  RATE_LIMIT_KEYS,
+  type PlatformConfig,
+  type RateLimitKey,
+  type RateLimiterAdapter,
+  type SwapAdapter,
+  type SwapExecution,
+  type SwapQuote,
+  type SwapWebhookEvent,
+  type User,
+} from '@openora/core/contracts';
+import { and, eq } from 'drizzle-orm';
+import * as z from 'zod';
+import { wallet, walletTransaction, type Wallet, type WalletTransaction } from '../schema/index.js';
+import {
+  InsufficientBalanceError,
+  IdempotencyKeyReuseError,
+  WalletNotFoundError,
+  balanceKey,
+  creditWalletBalance,
+  debitWithdrawableBalance,
+  railFor,
+  readWalletBalance,
+} from './wallet.service.js';
+
+const logger = createLogger('wallet-swap');
+
+// Same policy as the other money mutations - a swap is one, and it also costs a vendor call.
+const SWAP_RATE_LIMIT = { limit: 30, windowMs: 60 * 1000 };
+
+export const SwapUnavailableError = makeConflictError(
+  'SwapUnavailableError',
+  'no swap vendor is configured',
+);
+
+export const SwapPairUnsupportedError = createDomainError<[from: string, to: string]>(
+  'SwapPairUnsupportedError',
+  (from, to) => `swap pair ${from}->${to} is not supported`,
+);
+
+// The vendor reported a fill but not what it filled. Nothing may be credited off a
+// missing number, so the swap stays `processing` for the webhook (or an operator) to
+// finish rather than guessing at the quoted amount.
+export const SwapFillAmountMissingError = createDomainError<[externalId: string]>(
+  'SwapFillAmountMissingError',
+  (externalId) => `swap ${externalId} completed without a fill amount`,
+);
+
+/**
+ * The out-leg carries what the in-leg will need once the vendor settles - the ledger has
+ * no column for a swap's other side, and a webhook arriving hours later has nothing but
+ * this row to work from.
+ */
+const SwapLegMetadataSchema = z.object({
+  toCurrency: z.string(),
+  quoteId: z.string().optional(),
+});
+
+export type SwapResult = {
+  transactionId: WalletTransaction['id'];
+  status: WalletTransaction['status'];
+  /** What was credited, once the vendor filled. Null while the swap is still `processing`. */
+  toAmount: string | null;
+};
+
+/**
+ * Currency swaps between a player's own balances, booked as two ledger legs: a `swap_out`
+ * debit written (and the funds held) before the vendor is called, and a `swap_in` credit
+ * written only against a number the vendor actually filled. The vendor call never runs
+ * inside a transaction - the hold commits first, exactly like a withdrawal, so a slow or
+ * hanging desk cannot pin a row lock.
+ *
+ * A vendor that fills asynchronously leaves the out-leg `processing` until its webhook
+ * lands (`reconcileSwapStatus`). Nothing sweeps those: the wallet reconciliation cycle
+ * only looks at withdrawals, so a vendor that never calls back leaves the player's funds
+ * held. Add a poll over `getSwapStatus` when a real desk with async fills is bound.
+ */
+export class SwapService {
+  private readonly drizzle: DrizzleService;
+  private readonly events: EventBus;
+  private readonly adapter: SwapAdapter;
+  private readonly platformConfig?: PlatformConfig;
+  private readonly limiter?: RateLimiterAdapter<RateLimitKey>;
+
+  constructor(deps: {
+    drizzle: DrizzleService;
+    events: EventBus;
+    adapter: SwapAdapter;
+    platformConfig?: PlatformConfig;
+    limiter?: RateLimiterAdapter<RateLimitKey>;
+  }) {
+    this.drizzle = deps.drizzle;
+    this.events = deps.events;
+    this.adapter = deps.adapter;
+    this.platformConfig = deps.platformConfig;
+    this.limiter = deps.limiter;
+  }
+
+  async quote(input: {
+    fromCurrency: string;
+    toCurrency: string;
+    fromAmount: string;
+  }): Promise<SwapQuote> {
+    this.assertPair(input.fromCurrency, input.toCurrency);
+    const quote = await this.adapter.getQuote(input);
+    if (!quote) {
+      throw new SwapPairUnsupportedError(input.fromCurrency, input.toCurrency);
+    }
+    return quote;
+  }
+
+  async swap({
+    userId,
+    fromCurrency,
+    toCurrency,
+    fromAmount,
+    quoteId,
+    idempotencyKey,
+  }: {
+    userId: User['id'];
+    fromCurrency: string;
+    toCurrency: string;
+    fromAmount: string;
+    quoteId?: SwapQuote['quoteId'];
+    idempotencyKey: NonNullable<WalletTransaction['idempotencyKey']>;
+  }): Promise<SwapResult> {
+    await this.rateLimit(userId);
+    this.assertPair(fromCurrency, toCurrency);
+
+    // Phase one: hold the player's funds and commit. A `processing` out-leg is the record
+    // that money left the balance, so a crash before the vendor answers is visible rather
+    // than a silent gap.
+    const { row, replayed } = await this.drizzle.db.transaction(async (txn) => {
+      const current = findOneOrThrow(
+        await txn.select().from(wallet).where(eq(wallet.userId, userId)).for('update'),
+        new WalletNotFoundError(userId),
+      );
+
+      const existing = await this.findByIdempotencyKey(txn, current.id, idempotencyKey);
+      if (existing) {
+        this.assertReplayMatches(existing, fromAmount, fromCurrency);
+        return { row: existing, replayed: true };
+      }
+
+      const [inserted] = await txn
+        .insert(walletTransaction)
+        .values({
+          walletId: current.id,
+          type: 'swap_out',
+          amount: fromAmount,
+          currency: balanceKey(fromCurrency),
+          status: 'processing',
+          direction: 'debit',
+          rail: railFor(fromCurrency, this.platformConfig?.wallet?.cryptoCurrencies),
+          idempotencyKey,
+          metadata: JSON.stringify({ toCurrency: balanceKey(toCurrency), quoteId }),
+        })
+        .onConflictDoNothing()
+        .returning();
+
+      // Lost the race on the (walletId, idempotencyKey) unique index: the winner's row is
+      // the swap, and this request is a replay of it.
+      if (!inserted) {
+        const winner = findOneOrThrow(
+          await this.findByIdempotencyKeyRows(txn, current.id, idempotencyKey),
+          new IdempotencyKeyReuseError(),
+        );
+        this.assertReplayMatches(winner, fromAmount, fromCurrency);
+        return { row: winner, replayed: true };
+      }
+
+      const debited = await debitWithdrawableBalance(txn, current.id, fromCurrency, fromAmount);
+      if (debited.length !== 1) {
+        throw new InsufficientBalanceError(
+          await readWalletBalance(txn, current.id, fromCurrency),
+          fromAmount,
+        );
+      }
+
+      return { row: inserted, replayed: false };
+    });
+
+    if (replayed) {
+      return this.toResult(row);
+    }
+
+    // Phase two, outside the transaction. The out-leg's id is the idempotency key the
+    // vendor must dedupe on, so a retried execute returns the original trade.
+    let execution;
+    try {
+      execution = await this.adapter.execute({
+        quoteId,
+        fromCurrency,
+        toCurrency,
+        fromAmount,
+        idempotencyKey: row.id,
+      });
+    } catch (err) {
+      // No trade the vendor will honour - return the held funds before rethrowing.
+      await this.refund(row);
+      throw err;
+    }
+
+    if (execution.status === 'failed') {
+      await this.refund(row, execution.externalId);
+      return { transactionId: row.id, status: 'failed', toAmount: null };
+    }
+
+    if (execution.status === 'processing') {
+      await this.drizzle.db
+        .update(walletTransaction)
+        .set({ providerRefId: execution.externalId })
+        .where(eq(walletTransaction.id, row.id));
+      return { transactionId: row.id, status: 'processing', toAmount: null };
+    }
+
+    return this.settle(row, execution.externalId, execution.toAmount);
+  }
+
+  /** Vendor-driven settlement of a swap its `execute` left `processing`. */
+  async reconcileSwapStatus(event: SwapWebhookEvent): Promise<void> {
+    const [row] = await this.drizzle.db
+      .select()
+      .from(walletTransaction)
+      .where(eq(walletTransaction.providerRefId, event.externalId));
+    if (!row || row.type !== 'swap_out') {
+      logger.warn(
+        { externalId: event.externalId },
+        'swap webhook: no matching swap for externalId',
+      );
+      return;
+    }
+    if (row.status !== 'processing') {
+      return;
+    }
+    if (event.status === 'completed') {
+      await this.settle(row, event.externalId, event.toAmount);
+      return;
+    }
+    if (event.status === 'failed') {
+      await this.refund(row, event.externalId);
+    }
+  }
+
+  // Credits the in-leg against the filled amount and closes the out-leg, in one
+  // transaction. The `status = 'processing'` guard is the payout guard: an execute
+  // response and a webhook racing on the same fill credit the player once.
+  private async settle(
+    out: WalletTransaction,
+    externalId: SwapExecution['externalId'],
+    toAmount: string | undefined,
+  ): Promise<SwapResult> {
+    if (toAmount === undefined || Number(toAmount) <= 0) {
+      throw new SwapFillAmountMissingError(externalId);
+    }
+    const toCurrency = this.toCurrencyOf(out);
+
+    const settled = await this.drizzle.db.transaction(async (txn) => {
+      const flipped = await txn
+        .update(walletTransaction)
+        .set({ status: 'completed', providerRefId: externalId })
+        .where(and(eq(walletTransaction.id, out.id), eq(walletTransaction.status, 'processing')))
+        .returning({ id: walletTransaction.id });
+      if (flipped.length === 0) {
+        return false;
+      }
+
+      await creditWalletBalance(txn, out.walletId, toCurrency, toAmount);
+      await txn.insert(walletTransaction).values({
+        walletId: out.walletId,
+        type: 'swap_in',
+        amount: toAmount,
+        currency: balanceKey(toCurrency),
+        status: 'completed',
+        direction: 'credit',
+        rail: railFor(toCurrency, this.platformConfig?.wallet?.cryptoCurrencies),
+        // Not providerRefId: that column is globally unique, and the vendor's id already
+        // belongs to the out-leg. The in-leg points back at its own pair instead.
+        metadata: JSON.stringify({ swapTransactionId: out.id, externalId }),
+      });
+      return true;
+    });
+
+    if (settled) {
+      this.events.emit('wallet.swap.completed', {
+        userId: await this.userIdForWallet(out.walletId),
+        transactionId: out.id,
+        fromCurrency: out.currency,
+        fromAmount: out.amount,
+        toCurrency: balanceKey(toCurrency),
+        toAmount,
+      });
+    }
+
+    return { transactionId: out.id, status: 'completed', toAmount };
+  }
+
+  // Returns the held funds and closes the out-leg as `failed`. Guarded on `processing`
+  // so a refund can never run twice for one hold.
+  private async refund(
+    out: WalletTransaction,
+    externalId?: SwapExecution['externalId'],
+  ): Promise<void> {
+    await this.drizzle.db.transaction(async (txn) => {
+      const flipped = await txn
+        .update(walletTransaction)
+        .set({ status: 'failed', ...(externalId ? { providerRefId: externalId } : {}) })
+        .where(and(eq(walletTransaction.id, out.id), eq(walletTransaction.status, 'processing')))
+        .returning({ id: walletTransaction.id });
+      if (flipped.length === 0) {
+        return;
+      }
+      await creditWalletBalance(txn, out.walletId, out.currency, out.amount);
+    });
+  }
+
+  private assertPair(fromCurrency: string, toCurrency: string): void {
+    if (balanceKey(fromCurrency) === balanceKey(toCurrency)) {
+      throw new SwapPairUnsupportedError(fromCurrency, toCurrency);
+    }
+    if (this.adapter.supportsPair && !this.adapter.supportsPair(fromCurrency, toCurrency)) {
+      throw new SwapPairUnsupportedError(fromCurrency, toCurrency);
+    }
+  }
+
+  // Written by this service one insert earlier, so a malformed value is a bug here, not
+  // untrusted input - but it still comes back from the DB as a string, so it is parsed
+  // rather than cast.
+  private toCurrencyOf(out: WalletTransaction): string {
+    const parsed = SwapLegMetadataSchema.safeParse(
+      out.metadata ? (JSON.parse(out.metadata) as unknown) : null,
+    );
+    if (!parsed.success) {
+      throw new Error(`wallet swap: transaction ${out.id} has no target currency recorded`);
+    }
+    return parsed.data.toCurrency;
+  }
+
+  private toResult(row: WalletTransaction): SwapResult {
+    return { transactionId: row.id, status: row.status, toAmount: null };
+  }
+
+  private assertReplayMatches(
+    existing: WalletTransaction,
+    fromAmount: string,
+    fromCurrency: string,
+  ): void {
+    if (
+      existing.type !== 'swap_out' ||
+      Number(existing.amount) !== Number(fromAmount) ||
+      existing.currency !== balanceKey(fromCurrency)
+    ) {
+      throw new IdempotencyKeyReuseError();
+    }
+  }
+
+  private async findByIdempotencyKey(
+    txn: DrizzleTx,
+    walletId: Wallet['id'],
+    idempotencyKey: NonNullable<WalletTransaction['idempotencyKey']>,
+  ): Promise<WalletTransaction | undefined> {
+    const [row] = await this.findByIdempotencyKeyRows(txn, walletId, idempotencyKey);
+    return row;
+  }
+
+  private findByIdempotencyKeyRows(
+    txn: DrizzleTx,
+    walletId: Wallet['id'],
+    idempotencyKey: NonNullable<WalletTransaction['idempotencyKey']>,
+  ) {
+    return txn
+      .select()
+      .from(walletTransaction)
+      .where(
+        and(
+          eq(walletTransaction.walletId, walletId),
+          eq(walletTransaction.idempotencyKey, idempotencyKey),
+        ),
+      );
+  }
+
+  private async userIdForWallet(walletId: Wallet['id']): Promise<User['id']> {
+    const [row] = await this.drizzle.db
+      .select({ userId: wallet.userId })
+      .from(wallet)
+      .where(eq(wallet.id, walletId));
+    if (!row) {
+      throw new WalletNotFoundError(walletId);
+    }
+    return row.userId;
+  }
+
+  private rateLimit(userId: User['id']) {
+    return this.limiter
+      ? assertRateLimit(
+          this.limiter,
+          makeRateLimitKey(RATE_LIMIT_KEYS.WALLET_MUTATION, userId),
+          SWAP_RATE_LIMIT,
+        )
+      : Promise.resolve();
+  }
+}

--- a/packages/core/src/wallet/service/swap.service.ts
+++ b/packages/core/src/wallet/service/swap.service.ts
@@ -4,6 +4,7 @@ import {
   createLogger,
   findOneOrThrow,
   makeConflictError,
+  moneyToNumber,
   type DrizzleService,
   type EventBus,
   type DrizzleTx,
@@ -24,6 +25,7 @@ import { and, eq } from 'drizzle-orm';
 import * as z from 'zod';
 import { wallet, walletTransaction, type Wallet, type WalletTransaction } from '../schema/index.js';
 import {
+  BonusRolloverLockedError,
   InsufficientBalanceError,
   IdempotencyKeyReuseError,
   WalletNotFoundError,
@@ -31,6 +33,7 @@ import {
   creditWalletBalance,
   debitWithdrawableBalance,
   railFor,
+  readLockedBonusAmount,
   readWalletBalance,
 } from './wallet.service.js';
 
@@ -180,12 +183,20 @@ export class SwapService {
         return { row: winner, replayed: true };
       }
 
+      // Bonus-locked funds are not swappable, same as they are not withdrawable. The two
+      // refusals are told apart the way `withdraw` does it: a balance that covers the amount
+      // but a debit that did not land means rollover held it, and telling the player
+      // "insufficient balance" against a balance they can see would be a lie.
       const debited = await debitWithdrawableBalance(txn, current.id, fromCurrency, fromAmount);
       if (debited.length !== 1) {
-        throw new InsufficientBalanceError(
-          await readWalletBalance(txn, current.id, fromCurrency),
-          fromAmount,
-        );
+        const [available, locked] = await Promise.all([
+          readWalletBalance(txn, current.id, fromCurrency),
+          readLockedBonusAmount(txn, current.id, fromCurrency),
+        ]);
+        if (moneyToNumber(available) < moneyToNumber(fromAmount)) {
+          throw new InsufficientBalanceError(available, fromAmount);
+        }
+        throw new BonusRolloverLockedError(locked);
       }
 
       return { row: inserted, replayed: false };

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -488,7 +488,7 @@ export function debitWithdrawableBalance(
     .returning({ amount: walletBalance.amount });
 }
 
-async function readLockedBonusAmount(
+export async function readLockedBonusAmount(
   txn: DrizzleDb,
   walletId: Wallet['id'],
   currency: string,


### PR DESCRIPTION
`win`, `swap_in` and `swap_out` are declared `wallet_transaction` types that no code path ever wrote. A player's history showed the bet but never the payout, and a swap not at all - the `SWAP_ADAPTER` port had no consumer.

## Wins

`GameAdapter.endRound` now reports the round's outcome (`RoundOutcome | void`, so existing adapters still compile). Settling a round credits `win` through `WALLET_COMMANDS` and records `winAmount` on the round, in one transaction. The update is guarded on the round still being `active`, so a replayed or concurrent end-round pays exactly once and does not ask the provider twice. A refused credit throws, leaving the round open rather than losing the payout.

`MockGameAdapter` still reports nothing on purpose - it is the default `GAME_ADAPTER` binding in every ring, and a fabricated win there would credit real balances.

## Swaps

New `SwapService` in the wallet module, with three routes:

- `POST /wallet/swap/quote` - prices a pair through the adapter.
- `POST /wallet/swap` - holds the funds as a `processing` `swap_out` leg and commits, then calls the vendor outside the transaction (same two-phase shape as `withdraw`). The `swap_in` credit is booked against the amount the vendor actually filled, never the quoted one. A vendor throw or a `failed` fill refunds the hold once.
- `POST /wallet/swap/webhook` - settles or refunds an async fill, verified by `SWAP_WEBHOOK_VERIFIER` (its own token, not the payment verifier). Duplicate deliveries are no-ops.

With no `SWAP_ADAPTER` bound - which is core's resting state - every swap route refuses and nothing else changes. A swap left `processing` by a vendor that never calls back is not swept; the service doc comment says where to add the `getSwapStatus` poll when a real desk is bound.

`wallet.swap.completed` publishes a balance-changed signal for both currencies, since both legs moved.

## Test steps

```
pnpm dev
```

Swap needs an overlay binding `SWAP_ADAPTER` (betfeel's `swap-stub` does): `POST /wallet/swap/quote` then `POST /wallet/swap`, and check `GET /wallet/transactions` shows the `swap_out`/`swap_in` pair and both balances moved. Without that binding the routes 409.

Wins need a `GameAdapter` whose `endRound` returns a `winAmount`; the bundled mock reports none, so the covered behaviour is in `gaming.service.int.test.ts` and `swap.service.int.test.ts`.