### PR TITLE
feat(identity): add withdrawal pin set/change/remove (BF-519)

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -287,6 +287,8 @@
         "identity.resetPassword",
         "identity.security.loginWithdrawalAlerts",
         "identity.security.me",
+        "identity.security.removeWithdrawalPin",
+        "identity.security.setWithdrawalPin",
         "identity.sendEmailVerification",
         "identity.sessions.list",
         "identity.sessions.listAll",
@@ -1002,6 +1004,8 @@
     "identity.phone_otp.requested",
     "identity.profile.updated",
     "identity.security.login_withdrawal_alerts.updated",
+    "identity.security.withdrawal_pin.removed",
+    "identity.security.withdrawal_pin.set",
     "identity.session.fingerprint_mismatch",
     "identity.session.revoked",
     "identity.sessions.revoked_all",
@@ -2416,6 +2420,10 @@
       "file": "packages/core/src/wallet/contract/index.ts"
     },
     {
+      "name": "SetWithdrawalPinInputSchema",
+      "file": "packages/core/src/contracts/schemas/identity.ts"
+    },
+    {
       "name": "SignedMoneyAmountSchema",
       "file": "packages/core/src/contracts/schemas/common.ts"
     },
@@ -2658,6 +2666,10 @@
     {
       "name": "WithdrawalAddressSchema",
       "file": "packages/core/src/wallet/contract/index.ts"
+    },
+    {
+      "name": "WithdrawalPinSchema",
+      "file": "packages/core/src/contracts/schemas/identity.ts"
     },
     {
       "name": "WithdrawalQueueFilterSchema",

--- a/docs/platform/system-design.md
+++ b/docs/platform/system-design.md
@@ -289,7 +289,7 @@ flowchart TB
 
 <!-- gen:catalog-reference -->
 
-Generated from `docs/catalog.json` - 20 modules, 254 routes, 44 adapter ports, 114 events. Edit the code, then run `pnpm gen:catalog`.
+Generated from `docs/catalog.json` - 20 modules, 256 routes, 44 adapter ports, 116 events. Edit the code, then run `pnpm gen:catalog`.
 
 | Domain                        | Modules                                                    | Tables                                                                              | Routes |
 | ----------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------ |
@@ -303,7 +303,7 @@ Generated from `docs/catalog.json` - 20 modules, 254 routes, 44 adapter ports, 1
 | `fx`                          | exchange-rate                                              | exchange_rate_quote                                                                 | 2      |
 | `@openora/core/iam`           | iam                                                        | admin_invitation, admin_role, admin_role_assignment, admin_role_permission          | 17     |
 | `@openora/core/mail`          | mail                                                       | (owns none - reads through ports)                                                   | 0      |
-| `@openora/core/pam`           | identity · player-management · player-note · profile · tag | account, admin_trusted_device, phone_verification_session, player + 9 more          | 61     |
+| `@openora/core/pam`           | identity · player-management · player-note · profile · tag | account, admin_trusted_device, phone_verification_session, player + 9 more          | 63     |
 | `@openora/core/wallet`        | wallet                                                     | auto_withdrawal_rule, wallet, wallet_asset, wallet_auto_withdrawal_config + 10 more | 35     |
 
 <!-- /gen:catalog-reference -->

--- a/packages/core/.env.example
+++ b/packages/core/.env.example
@@ -6,6 +6,7 @@ S3_SECRET_KEY=minioadmin
 S3_BUCKET=oss-casino
 OPENROUTER_API_KEY=
 AUTH_SECRET=change-me-in-production-min-32-chars
+WITHDRAWAL_PIN_HMAC_SECRET=change-me-in-production-min-32-chars
 SENTRY_DSN=
 PORT_API=3001
 PORT_WS=3002

--- a/packages/core/src/audit/plugin.ts
+++ b/packages/core/src/audit/plugin.ts
@@ -787,6 +787,33 @@ export async function mapEventToRecord(
     };
   }
 
+  if (topic === 'identity.security.withdrawal_pin.set') {
+    const playerId = p['playerId'];
+    return {
+      ...base,
+      actorType: playerId ? 'player' : 'admin',
+      actorId: playerId ? str(playerId) : str(p['userId']),
+      resourceType: 'user',
+      resourceId: str(p['userId']),
+      // Booleans only - the PIN and its hash never reach the audit trail.
+      before: { withdrawalPinSet: p['wasAlreadySet'] ?? null },
+      after: { withdrawalPinSet: true },
+    };
+  }
+
+  if (topic === 'identity.security.withdrawal_pin.removed') {
+    const playerId = p['playerId'];
+    return {
+      ...base,
+      actorType: playerId ? 'player' : 'admin',
+      actorId: playerId ? str(playerId) : str(p['userId']),
+      resourceType: 'user',
+      resourceId: str(p['userId']),
+      before: { withdrawalPinSet: true },
+      after: { withdrawalPinSet: false },
+    };
+  }
+
   // Shared identity self-action topics: the same `/identity/*` endpoints serve
   // both player and admin accounts, so playerId only resolves for a player. A
   // null playerId means the account has no player row - attribute to the
@@ -849,6 +876,8 @@ const SUBSCRIBED_TOPICS: DomainEventName[] = [
   'identity.email.verified',
   'identity.phone.verified',
   'identity.security.login_withdrawal_alerts.updated',
+  'identity.security.withdrawal_pin.set',
+  'identity.security.withdrawal_pin.removed',
   'identity.profile.updated',
   'identity.user.deactivated',
   'identity.user.reactivated',

--- a/packages/core/src/contracts/adapters/rate-limit.ts
+++ b/packages/core/src/contracts/adapters/rate-limit.ts
@@ -18,6 +18,7 @@ export const RATE_LIMIT_KEYS = {
   PASSWORD_RESET_VERIFY: 'pwreset-verify',
   PASSWORD_RESET: 'pwreset',
   CHANGE_PASSWORD: 'change-password',
+  WITHDRAWAL_PIN_MUTATION: 'withdrawal-pin-mutation',
   EMAIL_VERIFICATION: 'email-verify',
   VERIFY_EMAIL: 'verify-email',
   WALLET_MUTATION: 'wallet-mutation',

--- a/packages/core/src/contracts/schemas/events.ts
+++ b/packages/core/src/contracts/schemas/events.ts
@@ -261,6 +261,15 @@ export const domainEventSchemas = {
     previousEnabled: z.boolean(),
     enabled: z.boolean(),
   }),
+  'identity.security.withdrawal_pin.set': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+    wasAlreadySet: z.boolean(),
+  }),
+  'identity.security.withdrawal_pin.removed': authContextBase.extend({
+    userId: UuidSchema,
+    playerId: UuidSchema.nullable(),
+  }),
   'identity.profile.updated': authContextBase.extend({
     userId: UuidSchema,
     playerId: UuidSchema.nullable(),

--- a/packages/core/src/contracts/schemas/identity.ts
+++ b/packages/core/src/contracts/schemas/identity.ts
@@ -192,9 +192,26 @@ export const SecurityControlsSchema = z.object({
   phoneVerified: z.boolean(),
   twoFactorEnabled: z.boolean(),
   loginWithdrawalAlertsEnabled: z.boolean(),
+  withdrawalPinSet: z.boolean(),
 });
 
 export const SetLoginWithdrawalAlertsInputSchema = z.object({ enabled: z.boolean() });
+
+export const WithdrawalPinSchema = z.string().regex(/^[0-9]{4}$/);
+
+// Set and Change share this one shape - Change asks for a fresh password/TOTP the same
+// as Set, never the current PIN (matches the product's identical Set/Change UX).
+export const SetWithdrawalPinInputSchema = z
+  .object({
+    pin: WithdrawalPinSchema,
+    confirmPin: WithdrawalPinSchema,
+    currentPassword: z.string().min(8),
+    totpCode: TotpStepUpCodeSchema.optional(),
+  })
+  .refine((v) => v.pin === v.confirmPin, {
+    message: 'PIN and confirmation must match.',
+    path: ['confirmPin'],
+  });
 
 export const PhoneVerificationRequestInputSchema = z.object({
   phone: E164PhoneSchema,
@@ -292,6 +309,7 @@ export type PhoneLoginRequestOutput = z.infer<typeof PhoneLoginRequestOutputSche
 export type PhoneLoginVerifyInput = z.infer<typeof PhoneLoginVerifyInputSchema>;
 export type SecurityControls = z.infer<typeof SecurityControlsSchema>;
 export type SetLoginWithdrawalAlertsInput = z.infer<typeof SetLoginWithdrawalAlertsInputSchema>;
+export type SetWithdrawalPinInput = z.infer<typeof SetWithdrawalPinInputSchema>;
 export type PhoneVerificationRequestInput = z.infer<typeof PhoneVerificationRequestInputSchema>;
 export type PhoneVerificationRequestOutput = z.infer<typeof PhoneVerificationRequestOutputSchema>;
 export type PhoneVerificationConfirmInput = z.infer<typeof PhoneVerificationConfirmInputSchema>;

--- a/packages/core/src/pam/identity/__tests__/withdrawal-pin.service.int.test.ts
+++ b/packages/core/src/pam/identity/__tests__/withdrawal-pin.service.int.test.ts
@@ -1,0 +1,293 @@
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import {
+  createTestDb,
+  createTestRedis,
+  seedUser as insertUser,
+  type TestDb,
+  type TestRedis,
+} from '@openora/core/testing';
+import { migrate as migrateIdentity } from '@openora/core/pam/migrate/identity';
+import { RedisRateLimiter, type Auth } from '@openora/core/server';
+import { SetWithdrawalPinInputSchema, type RateLimiterAdapter } from '@openora/core/contracts';
+import { account, user } from '../schema/index.js';
+import { WithdrawalPinService } from '../service/withdrawal-pin.service.js';
+import { makeEventBus, makeIdentityReader, mock, NO_CLIENT_META } from '../../../testing/mock.js';
+
+const PASSWORD = 'current-password';
+const HMAC_SECRET = 'a'.repeat(32);
+const PIN = '1234';
+
+let db: TestDb;
+
+const allowLimiter = (): RateLimiterAdapter =>
+  mock<RateLimiterAdapter>({
+    consume: vi.fn().mockResolvedValue({ allowed: true, retryAfterMs: 0 }),
+    reset: vi.fn(),
+  });
+
+function build({
+  passwordMatches = true,
+  limiter,
+}: { passwordMatches?: boolean; limiter?: RateLimiterAdapter } = {}) {
+  const events = makeEventBus();
+  const auth = mock<Auth>({
+    $context: Promise.resolve({
+      password: { verify: vi.fn().mockResolvedValue(passwordMatches) },
+    }),
+    api: { verifyTOTP: vi.fn().mockResolvedValue(new Response(null, { status: 200 })) },
+  });
+  const svc = new WithdrawalPinService({
+    drizzle: db.drizzle,
+    events,
+    limiter: limiter ?? allowLimiter(),
+    auth,
+    identityReader: makeIdentityReader(),
+    hmacSecret: HMAC_SECRET,
+  });
+  return { svc, events, auth };
+}
+
+async function seedAuthenticatedUser(
+  overrides: { role?: string; email?: string; twoFactorEnabled?: boolean } = {},
+) {
+  const accountUser = await insertUser(db, {
+    name: 'A',
+    email: overrides.email ?? `withdrawal-pin-${randomUUID()}@test.dev`,
+    ...(overrides.role ? { role: overrides.role } : {}),
+    ...(overrides.twoFactorEnabled !== undefined
+      ? { twoFactorEnabled: overrides.twoFactorEnabled }
+      : {}),
+  });
+  await db.drizzle.db.insert(account).values({
+    userId: accountUser.id,
+    accountId: accountUser.id,
+    providerId: 'credential',
+    password: 'stored-password-hash',
+  });
+  return accountUser;
+}
+
+async function readUser(userId: string) {
+  const [row] = await db.drizzle.db.select().from(user).where(eq(user.id, userId));
+  return row;
+}
+
+beforeAll(async () => {
+  db = await createTestDb([migrateIdentity]);
+});
+
+afterAll(async () => {
+  await db.drop();
+});
+
+beforeEach(async () => {
+  await db.drizzle.db.execute(sql`TRUNCATE ${user}, ${account} RESTART IDENTITY CASCADE`);
+});
+
+describe('WithdrawalPinService (real PG)', () => {
+  it('refuses a non-player role, leaves the row untouched, and audits the denial', async () => {
+    const accountUser = await seedAuthenticatedUser({ role: 'admin' });
+    const { svc, events } = build();
+
+    await expect(
+      svc.set(
+        accountUser.id,
+        { pin: PIN, confirmPin: PIN, currentPassword: PASSWORD },
+        {},
+        NO_CLIENT_META,
+      ),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    expect((await readUser(accountUser.id))?.withdrawalPinHash).toBeNull();
+    expect(events.emit).toHaveBeenCalledWith(
+      'identity.user.unauthorized_access',
+      expect.objectContaining({
+        userId: accountUser.id,
+        resource: 'identity.security.withdrawal_pin',
+        action: 'set',
+        role: 'admin',
+      }),
+    );
+  });
+
+  it('sets a PIN for the first time', async () => {
+    const accountUser = await seedAuthenticatedUser();
+    const { svc, events } = build();
+
+    const controls = await svc.set(
+      accountUser.id,
+      { pin: PIN, confirmPin: PIN, currentPassword: PASSWORD },
+      {},
+      NO_CLIENT_META,
+    );
+
+    expect(controls.withdrawalPinSet).toBe(true);
+    const row = await readUser(accountUser.id);
+    expect(row?.withdrawalPinHash).not.toBeNull();
+    expect(row?.withdrawalPinSetAt).not.toBeNull();
+    expect(events.emit).toHaveBeenCalledWith(
+      'identity.security.withdrawal_pin.set',
+      expect.objectContaining({ userId: accountUser.id, wasAlreadySet: false }),
+    );
+  });
+
+  it('changes an existing PIN, overwriting the hash and flagging wasAlreadySet', async () => {
+    const accountUser = await seedAuthenticatedUser();
+    const { svc, events } = build();
+    await svc.set(
+      accountUser.id,
+      { pin: PIN, confirmPin: PIN, currentPassword: PASSWORD },
+      {},
+      NO_CLIENT_META,
+    );
+    const firstHash = (await readUser(accountUser.id))?.withdrawalPinHash;
+
+    await svc.set(
+      accountUser.id,
+      { pin: '5678', confirmPin: '5678', currentPassword: PASSWORD },
+      {},
+      NO_CLIENT_META,
+    );
+
+    const secondHash = (await readUser(accountUser.id))?.withdrawalPinHash;
+    expect(secondHash).not.toEqual(firstHash);
+    expect(events.emit).toHaveBeenCalledWith(
+      'identity.security.withdrawal_pin.set',
+      expect.objectContaining({ userId: accountUser.id, wasAlreadySet: true }),
+    );
+  });
+
+  it('rejects a wrong current password, leaves the row untouched, and emits nothing', async () => {
+    const accountUser = await seedAuthenticatedUser();
+    const { svc, events } = build({ passwordMatches: false });
+
+    await expect(
+      svc.set(
+        accountUser.id,
+        { pin: PIN, confirmPin: PIN, currentPassword: 'wrong-password' },
+        {},
+        NO_CLIENT_META,
+      ),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+    expect((await readUser(accountUser.id))?.withdrawalPinHash).toBeNull();
+    expect(events.emit).not.toHaveBeenCalledWith(
+      'identity.security.withdrawal_pin.set',
+      expect.anything(),
+    );
+  });
+
+  it('requires a fresh authenticator code once 2FA is enabled', async () => {
+    const accountUser = await seedAuthenticatedUser({ twoFactorEnabled: true });
+    const { svc } = build();
+
+    await expect(
+      svc.set(
+        accountUser.id,
+        { pin: PIN, confirmPin: PIN, currentPassword: PASSWORD },
+        {},
+        NO_CLIENT_META,
+      ),
+    ).rejects.toMatchObject({ code: 'UNPROCESSABLE_CONTENT' });
+  });
+
+  it('removes an existing PIN with no reauthentication and audits by event', async () => {
+    const accountUser = await seedAuthenticatedUser();
+    const { svc, events } = build();
+    await svc.set(
+      accountUser.id,
+      { pin: PIN, confirmPin: PIN, currentPassword: PASSWORD },
+      {},
+      NO_CLIENT_META,
+    );
+
+    const controls = await svc.remove(accountUser.id, NO_CLIENT_META);
+
+    expect(controls.withdrawalPinSet).toBe(false);
+    const row = await readUser(accountUser.id);
+    expect(row?.withdrawalPinHash).toBeNull();
+    expect(row?.withdrawalPinSetAt).toBeNull();
+    expect(events.emit).toHaveBeenCalledWith(
+      'identity.security.withdrawal_pin.removed',
+      expect.objectContaining({ userId: accountUser.id }),
+    );
+  });
+
+  it('no-ops removing an already-unset PIN, without emitting an event', async () => {
+    const accountUser = await seedAuthenticatedUser();
+    const { svc, events } = build();
+
+    const controls = await svc.remove(accountUser.id, NO_CLIENT_META);
+
+    expect(controls.withdrawalPinSet).toBe(false);
+    expect(events.emit).not.toHaveBeenCalledWith(
+      'identity.security.withdrawal_pin.removed',
+      expect.anything(),
+    );
+  });
+});
+
+describe('WithdrawalPinService - input validation (unit)', () => {
+  it('rejects a mismatched pin/confirmPin', () => {
+    const result = SetWithdrawalPinInputSchema.safeParse({
+      pin: '1234',
+      confirmPin: '4321',
+      currentPassword: 'password123',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('WithdrawalPinService - rate limiting (real Redis + real PG)', () => {
+  let redis: TestRedis;
+
+  beforeAll(async () => {
+    redis = await createTestRedis();
+  });
+
+  afterAll(async () => {
+    await redis.quit();
+  });
+
+  beforeEach(async () => {
+    await redis.flush();
+  });
+
+  it('rejects the 6th set() within the window with a 429', async () => {
+    const accountUser = await seedAuthenticatedUser();
+    const { svc } = build({ limiter: new RedisRateLimiter(redis.client) });
+
+    for (let i = 0; i < 5; i++) {
+      await svc.set(
+        accountUser.id,
+        { pin: PIN, confirmPin: PIN, currentPassword: PASSWORD },
+        {},
+        NO_CLIENT_META,
+      );
+    }
+
+    await expect(
+      svc.set(
+        accountUser.id,
+        { pin: PIN, confirmPin: PIN, currentPassword: PASSWORD },
+        {},
+        NO_CLIENT_META,
+      ),
+    ).rejects.toMatchObject({ code: 'TOO_MANY_REQUESTS' });
+  });
+
+  it('rejects the 6th remove() within the same per-user budget', async () => {
+    const accountUser = await seedAuthenticatedUser();
+    const { svc } = build({ limiter: new RedisRateLimiter(redis.client) });
+
+    for (let i = 0; i < 5; i++) {
+      await svc.remove(accountUser.id, NO_CLIENT_META);
+    }
+
+    await expect(svc.remove(accountUser.id, NO_CLIENT_META)).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+  });
+});

--- a/packages/core/src/pam/identity/contract/index.ts
+++ b/packages/core/src/pam/identity/contract/index.ts
@@ -30,6 +30,7 @@ import {
   LoginSecurityStateSchema,
   SecurityControlsSchema,
   SetLoginWithdrawalAlertsInputSchema,
+  SetWithdrawalPinInputSchema,
   PhoneVerificationRequestInputSchema,
   PhoneVerificationRequestOutputSchema,
   PhoneVerificationConfirmInputSchema,
@@ -147,6 +148,17 @@ export const identityContract = {
     loginWithdrawalAlerts: oc
       .route({ method: 'POST', path: '/identity/security/login-withdrawal-alerts' })
       .input(SetLoginWithdrawalAlertsInputSchema)
+      .output(SecurityControlsSchema),
+
+    // Set and Change share this one upsert route (identical New PIN/Confirm PIN/Save
+    // flow); Remove is a separate route with no confirmation step, per AC.
+    setWithdrawalPin: oc
+      .route({ method: 'POST', path: '/identity/security/withdrawal-pin' })
+      .input(SetWithdrawalPinInputSchema)
+      .output(SecurityControlsSchema),
+
+    removeWithdrawalPin: oc
+      .route({ method: 'DELETE', path: '/identity/security/withdrawal-pin' })
       .output(SecurityControlsSchema),
   },
 

--- a/packages/core/src/pam/identity/drizzle/migrations/0011_useful_the_executioner.sql
+++ b/packages/core/src/pam/identity/drizzle/migrations/0011_useful_the_executioner.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user" ADD COLUMN "withdrawal_pin_hash" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "withdrawal_pin_set_at" timestamp with time zone;

--- a/packages/core/src/pam/identity/drizzle/migrations/meta/0011_snapshot.json
+++ b/packages/core/src/pam/identity/drizzle/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1078 @@
+{
+  "id": "c54c97b7-443f-4926-a6f3-7ea64065abc9",
+  "prevId": "a0b9529c-1962-41a7-90fd-07fb3620665e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_trusted_device": {
+      "name": "admin_trusted_device",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_hash": {
+          "name": "device_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_trusted_device_user_hash_idx": {
+          "name": "admin_trusted_device_user_hash_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_trusted_device_user_id_idx": {
+          "name": "admin_trusted_device_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_trusted_device_expires_at_idx": {
+          "name": "admin_trusted_device_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_trusted_device_user_id_user_id_fk": {
+          "name": "admin_trusted_device_user_id_user_id_fk",
+          "tableFrom": "admin_trusted_device",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phone_verification_session": {
+      "name": "phone_verification_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reauthenticated_at": {
+          "name": "reauthenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phone_verification_session_phone_idx": {
+          "name": "phone_verification_session_phone_idx",
+          "columns": [
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phone_verification_session_session_id_idx": {
+          "name": "phone_verification_session_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phone_verification_session_user_id_user_id_fk": {
+          "name": "phone_verification_session_user_id_user_id_fk",
+          "tableFrom": "phone_verification_session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phone_verification_session_session_id_session_id_fk": {
+          "name": "phone_verification_session_session_id_session_id_fk",
+          "tableFrom": "phone_verification_session",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phone_verification_session_userId_unique": {
+          "name": "phone_verification_session_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_otp_session": {
+      "name": "sms_otp_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_otp_session_phone_idx": {
+          "name": "sms_otp_session_phone_idx",
+          "columns": [
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_otp_session_user_id_user_id_fk": {
+          "name": "sms_otp_session_user_id_user_id_fk",
+          "tableFrom": "sms_otp_session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sms_otp_session_userId_unique": {
+          "name": "sms_otp_session_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "two_factor_user_id_idx": {
+          "name": "two_factor_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "two_factor_secret_idx": {
+          "name": "two_factor_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "user_theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'player'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_verified": {
+          "name": "phone_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone_verified_at": {
+          "name": "phone_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_meets_policy": {
+          "name": "password_meets_policy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "login_withdrawal_alerts_enabled": {
+          "name": "login_withdrawal_alerts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "withdrawal_pin_hash": {
+          "name": "withdrawal_pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_pin_set_at": {
+          "name": "withdrawal_pin_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lockout_until": {
+          "name": "lockout_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_two_factor_attempts": {
+          "name": "failed_two_factor_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "two_factor_lockout_until": {
+          "name": "two_factor_lockout_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_lockout_count": {
+          "name": "two_factor_lockout_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_two_factor_at": {
+          "name": "last_failed_two_factor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lockout_count": {
+          "name": "lockout_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_lockout_at": {
+          "name": "last_lockout_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_login_at": {
+          "name": "last_failed_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rg_blocked": {
+          "name": "rg_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rg_blocked_until": {
+          "name": "rg_blocked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_email_trgm_idx": {
+          "name": "user_email_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_username_trgm_idx": {
+          "name": "user_username_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"username\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_created_at_idx": {
+          "name": "user_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_phoneNumber_unique": {
+          "name": "user_phoneNumber_unique",
+          "nullsNotDistinct": false,
+          "columns": ["phone_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_theme": {
+      "name": "user_theme",
+      "schema": "public",
+      "values": ["light", "dark", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/pam/identity/drizzle/migrations/meta/_journal.json
+++ b/packages/core/src/pam/identity/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1788452428161,
       "tag": "0010_lying_young_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1788785555967,
+      "tag": "0011_useful_the_executioner",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/pam/identity/plugin.ts
+++ b/packages/core/src/pam/identity/plugin.ts
@@ -25,6 +25,8 @@ import { MockKycAdapter } from './adapters/mock/mock-kyc-adapter.js';
 import { MockSmsAdapter } from './adapters/mock/mock-sms-adapter.js';
 import { PhoneLoginService } from './service/phone-login.service.js';
 import { PhoneVerificationService } from './service/phone-verification.service.js';
+import { WithdrawalPinService } from './service/withdrawal-pin.service.js';
+import { MIN_WITHDRAWAL_PIN_SECRET_LENGTH } from './service/withdrawal-pin-hash.service.js';
 import { DrizzleAdminUserDirectory } from './admin-user-directory.js';
 import { IdentityReaderService } from './adapters/identity-reader.service.js';
 import { createIdentityRouter } from './router/index.js';
@@ -88,6 +90,13 @@ export default {
     // calling the original.
     let adminSecurity: AdminSecurityService | undefined;
     const resolveAdminSecurity = (c: IdentityContainer) => (adminSecurity ??= makeAdminSecurity(c));
+
+    const withdrawalPinHmacSecret = process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ?? '';
+    if (withdrawalPinHmacSecret.length < MIN_WITHDRAWAL_PIN_SECRET_LENGTH) {
+      throw new Error(
+        `identity: WITHDRAWAL_PIN_HMAC_SECRET must be at least ${MIN_WITHDRAWAL_PIN_SECRET_LENGTH} characters - the withdrawal PIN is hashed with it`,
+      );
+    }
 
     ctx.provide(KYC_ADAPTER, () => new MockKycAdapter());
     // Platform default SMS transport: logs the OTP to stdout. A consumer overlay
@@ -174,6 +183,15 @@ export default {
         c.get(ADMIN_GUARD),
         c.get(EVENT_BUS),
         resolveAdminSecurity(c),
+        new WithdrawalPinService({
+          drizzle: c.get(DRIZZLE),
+          events: c.get(EVENT_BUS),
+          limiter: c.get(RATE_LIMITER),
+          auth: c.get(AUTH_SESSION).auth,
+          identityReader: c.get(IDENTITY_READER),
+          twoFactorLockout: makeTwoFactorLockout(c),
+          hmacSecret: withdrawalPinHmacSecret,
+        }),
       );
     });
   },

--- a/packages/core/src/pam/identity/react/account.ts
+++ b/packages/core/src/pam/identity/react/account.ts
@@ -16,6 +16,7 @@ import type {
   PhoneVerificationRequestOutput,
   SecurityControls,
   SetLoginWithdrawalAlertsInput,
+  SetWithdrawalPinInput,
 } from '@openora/core/contracts';
 import type { Paginated } from '@openora/core/contracts/kit';
 import { useOrpcQueryUtils } from '@openora/core/react';
@@ -28,6 +29,11 @@ export type UseSetLoginWithdrawalAlertsResult = UseMutationResult<
   SecurityControls,
   Error,
   SetLoginWithdrawalAlertsInput
+>;
+export type UseSetWithdrawalPinResult = UseMutationResult<
+  SecurityControls,
+  Error,
+  SetWithdrawalPinInput
 >;
 export type UseRequestPhoneVerificationResult = UseMutationResult<
   PhoneVerificationRequestOutput,
@@ -117,6 +123,24 @@ export function useSetLoginWithdrawalAlerts(): UseSetLoginWithdrawalAlertsResult
   const queryClient = useQueryClient();
   return useMutation({
     ...utils.security.loginWithdrawalAlerts.mutationOptions(),
+    onSuccess: invalidateSecurityControls(utils, queryClient),
+  });
+}
+
+export function useSetWithdrawalPin(): UseSetWithdrawalPinResult {
+  const utils = useOrpcQueryUtils(identityContract);
+  const queryClient = useQueryClient();
+  return useMutation({
+    ...utils.security.setWithdrawalPin.mutationOptions(),
+    onSuccess: invalidateSecurityControls(utils, queryClient),
+  });
+}
+
+export function useRemoveWithdrawalPin() {
+  const utils = useOrpcQueryUtils(identityContract);
+  const queryClient = useQueryClient();
+  return useMutation({
+    ...utils.security.removeWithdrawalPin.mutationOptions(),
     onSuccess: invalidateSecurityControls(utils, queryClient),
   });
 }

--- a/packages/core/src/pam/identity/router/index.ts
+++ b/packages/core/src/pam/identity/router/index.ts
@@ -11,6 +11,7 @@ import {
 import { identityContract } from '../contract/index.js';
 import { PhoneLoginService } from '../service/phone-login.service.js';
 import { PhoneVerificationService } from '../service/phone-verification.service.js';
+import type { WithdrawalPinService } from '../service/withdrawal-pin.service.js';
 import {
   IdentityService,
   UsernameConflictError,
@@ -44,6 +45,7 @@ export function createIdentityRouter(
   adminGuard: AdminGuard,
   eventBus: EventBus,
   adminSecurity: AdminSecurityService,
+  withdrawalPin: WithdrawalPinService,
 ) {
   const os = implement(identityContract).$context<OssContext>();
 
@@ -96,6 +98,14 @@ export function createIdentityRouter(
 
       loginWithdrawalAlerts: os.security.loginWithdrawalAlerts.handler(({ input, context }) =>
         identity.setLoginWithdrawalAlerts(input, context.request.headers),
+      ),
+
+      setWithdrawalPin: os.security.setWithdrawalPin.handler(({ input, context }) =>
+        withdrawalPin.set(getUserId(context), input, context.request.headers, context.clientMeta),
+      ),
+
+      removeWithdrawalPin: os.security.removeWithdrawalPin.handler(({ context }) =>
+        withdrawalPin.remove(getUserId(context), context.clientMeta),
       ),
     },
 

--- a/packages/core/src/pam/identity/schema/index.ts
+++ b/packages/core/src/pam/identity/schema/index.ts
@@ -43,6 +43,11 @@ export const user = pgTable(
     // and each qualifying password write records the policy state explicitly.
     passwordMeetsPolicy: boolean().notNull().default(false),
     loginWithdrawalAlertsEnabled: boolean().notNull().default(false),
+    // A 4-digit withdrawal PIN, independent of the login credential. HMAC-SHA256'd with
+    // a dedicated secret (never the plaintext) - "is a PIN set" is derived as
+    // `withdrawalPinHash !== null`, no separate boolean column.
+    withdrawalPinHash: text(),
+    withdrawalPinSetAt: timestamp({ withTimezone: true }),
     failedLoginAttempts: integer().notNull().default(0),
     lockoutUntil: timestamp({ withTimezone: true }),
     // Second-factor lockout, counted separately from the password-login columns above:

--- a/packages/core/src/pam/identity/service/fresh-reauthentication.service.ts
+++ b/packages/core/src/pam/identity/service/fresh-reauthentication.service.ts
@@ -1,0 +1,84 @@
+import { ORPCError } from '@orpc/server';
+import { and, eq, isNotNull } from 'drizzle-orm';
+import type { Auth, DrizzleService } from '@openora/core/server';
+import type { ClientMeta, User } from '@openora/core/contracts';
+import { account } from '../schema/index.js';
+import type { TwoFactorLockoutService } from './two-factor-lockout.service.js';
+
+type VerifyTotpApi = {
+  verifyTOTP(opts: {
+    body: { code: string; trustDevice: false };
+    headers: Headers;
+    asResponse: true;
+  }): Promise<Response>;
+};
+
+/**
+ * Requires the account's standing password plus (when 2FA is enrolled) a fresh
+ * authenticator code before a security-sensitive self-service action proceeds. Shared by
+ * every route that gates a mutation on "prove you're still you right now" - phone
+ * verification and the withdrawal PIN both call this instead of re-deriving it.
+ */
+export async function assertFreshReauthentication({
+  drizzle,
+  auth,
+  twoFactorLockout,
+  userId,
+  headers,
+  currentPassword,
+  totpCode,
+  twoFactorEnabled,
+  meta,
+}: {
+  drizzle: DrizzleService;
+  auth: Auth;
+  twoFactorLockout?: TwoFactorLockoutService;
+  userId: User['id'];
+  headers: Headers;
+  currentPassword: string;
+  totpCode: string | undefined;
+  twoFactorEnabled: boolean;
+  meta: ClientMeta;
+}): Promise<void> {
+  const [credential] = await drizzle.db
+    .select({ password: account.password })
+    .from(account)
+    .where(and(eq(account.userId, userId), isNotNull(account.password)))
+    .limit(1);
+  if (!credential?.password) {
+    throw new ORPCError('UNAUTHORIZED', { message: 'Current password is invalid.' });
+  }
+
+  const authContext = await auth.$context;
+  const passwordMatches = await authContext.password.verify({
+    password: currentPassword,
+    hash: credential.password,
+  });
+  if (!passwordMatches) {
+    throw new ORPCError('UNAUTHORIZED', { message: 'Current password is invalid.' });
+  }
+
+  if (!twoFactorEnabled) {
+    return;
+  }
+  if (!totpCode) {
+    throw new ORPCError('UNPROCESSABLE_CONTENT', {
+      message: 'An authenticator code is required.',
+    });
+  }
+
+  await twoFactorLockout?.assertNotLocked(userId);
+  // Library boundary: the base Auth API type omits endpoints contributed by the
+  // twoFactor plugin, but createAuth always installs that plugin for identity.
+  const api = auth.api as unknown as VerifyTotpApi;
+  const verification = await api.verifyTOTP({
+    body: { code: totpCode, trustDevice: false },
+    headers,
+    asResponse: true,
+  });
+  if (!verification.ok) {
+    await twoFactorLockout?.recordFailure(userId, meta);
+    throw new ORPCError('UNAUTHORIZED', { message: 'Invalid authenticator code.' });
+  }
+  await twoFactorLockout?.reset(userId);
+}

--- a/packages/core/src/pam/identity/service/phone-verification.service.ts
+++ b/packages/core/src/pam/identity/service/phone-verification.service.ts
@@ -1,6 +1,6 @@
 import { ORPCError } from '@orpc/server';
 import { DatabaseError } from 'pg';
-import { and, eq, gt, isNotNull, sql } from 'drizzle-orm';
+import { and, eq, gt, sql } from 'drizzle-orm';
 import {
   type Auth,
   type EventBus,
@@ -19,8 +19,9 @@ import type {
   SmsAdapter,
   User,
 } from '@openora/core/contracts';
-import { account, phoneVerificationSession, user, type Session } from '../schema/index.js';
+import { phoneVerificationSession, user, type Session } from '../schema/index.js';
 import { getSecurityControls } from './security-controls.service.js';
+import { assertFreshReauthentication } from './fresh-reauthentication.service.js';
 import type { TwoFactorLockoutService } from './two-factor-lockout.service.js';
 import { nodeHeadersToHeaders } from '../../shared/headers-mapper.js';
 import { hashCode, generateCode } from '../../shared/otp.js';
@@ -53,14 +54,6 @@ function isPhoneNumberCollision(error: unknown): boolean {
     cause.constraint === 'user_phoneNumber_unique'
   );
 }
-
-type VerifyTotpApi = {
-  verifyTOTP(opts: {
-    body: { code: string; trustDevice: false };
-    headers: Headers;
-    asResponse: true;
-  }): Promise<Response>;
-};
 
 export type PhoneVerificationServiceDeps = {
   drizzle: DrizzleService;
@@ -99,64 +92,6 @@ export class PhoneVerificationService {
     this.twoFactorLockout = twoFactorLockout;
   }
 
-  private async assertFreshReauthentication({
-    userId,
-    headers,
-    currentPassword,
-    totpCode,
-    twoFactorEnabled,
-    meta,
-  }: {
-    userId: User['id'];
-    headers: Headers;
-    currentPassword: PhoneVerificationRequestInput['currentPassword'];
-    totpCode: PhoneVerificationRequestInput['totpCode'];
-    twoFactorEnabled: boolean;
-    meta: ClientMeta;
-  }) {
-    const [credential] = await this.drizzle.db
-      .select({ password: account.password })
-      .from(account)
-      .where(and(eq(account.userId, userId), isNotNull(account.password)))
-      .limit(1);
-    if (!credential?.password) {
-      throw new ORPCError('UNAUTHORIZED', { message: 'Current password is invalid.' });
-    }
-
-    const authContext = await this.auth.$context;
-    const passwordMatches = await authContext.password.verify({
-      password: currentPassword,
-      hash: credential.password,
-    });
-    if (!passwordMatches) {
-      throw new ORPCError('UNAUTHORIZED', { message: 'Current password is invalid.' });
-    }
-
-    if (!twoFactorEnabled) {
-      return;
-    }
-    if (!totpCode) {
-      throw new ORPCError('UNPROCESSABLE_CONTENT', {
-        message: 'An authenticator code is required.',
-      });
-    }
-
-    await this.twoFactorLockout?.assertNotLocked(userId);
-    // Library boundary: the base Auth API type omits endpoints contributed by the
-    // twoFactor plugin, but createAuth always installs that plugin for identity.
-    const api = this.auth.api as unknown as VerifyTotpApi;
-    const verification = await api.verifyTOTP({
-      body: { code: totpCode, trustDevice: false },
-      headers,
-      asResponse: true,
-    });
-    if (!verification.ok) {
-      await this.twoFactorLockout?.recordFailure(userId, meta);
-      throw new ORPCError('UNAUTHORIZED', { message: 'Invalid authenticator code.' });
-    }
-    await this.twoFactorLockout?.reset(userId);
-  }
-
   async request({
     userId,
     sessionId,
@@ -187,7 +122,10 @@ export class PhoneVerificationService {
         message: 'Only players can verify a phone number.',
       });
     }
-    await this.assertFreshReauthentication({
+    await assertFreshReauthentication({
+      drizzle: this.drizzle,
+      auth: this.auth,
+      twoFactorLockout: this.twoFactorLockout,
       userId,
       headers: nodeHeadersToHeaders(reqHeaders),
       currentPassword: input.currentPassword,

--- a/packages/core/src/pam/identity/service/security-controls.service.ts
+++ b/packages/core/src/pam/identity/service/security-controls.service.ts
@@ -15,6 +15,7 @@ export async function getSecurityControls(
       phoneVerified: user.phoneVerified,
       twoFactorEnabled: user.twoFactorEnabled,
       loginWithdrawalAlertsEnabled: user.loginWithdrawalAlertsEnabled,
+      withdrawalPinHash: user.withdrawalPinHash,
     })
     .from(user)
     .where(eq(user.id, userId))
@@ -23,10 +24,12 @@ export async function getSecurityControls(
     return null;
   }
   const phone = E164PhoneSchema.safeParse(row.phoneNumber);
+  const { withdrawalPinHash, ...rest } = row;
   return {
-    ...row,
+    ...rest,
     phoneNumber: phone.success ? phone.data : null,
     phoneVerified: phone.success && row.phoneVerified,
     twoFactorEnabled: row.twoFactorEnabled ?? false,
+    withdrawalPinSet: withdrawalPinHash !== null,
   };
 }

--- a/packages/core/src/pam/identity/service/withdrawal-pin-hash.service.ts
+++ b/packages/core/src/pam/identity/service/withdrawal-pin-hash.service.ts
@@ -1,0 +1,11 @@
+import { createHmac } from 'node:crypto';
+
+// A 4-digit PIN is long-lived and low-entropy (10,000 possibilities); the plain-sha256
+// pattern in pam/shared/otp.ts is only safe there because those OTPs expire in minutes.
+// HMAC-SHA256 with a dedicated, never-reused secret closes that gap without inventing a
+// new primitive family (same shape as server/auth/sign-session-cookie.ts).
+export const MIN_WITHDRAWAL_PIN_SECRET_LENGTH = 32;
+
+export function hashWithdrawalPin(pin: string, secret: string): string {
+  return createHmac('sha256', secret).update(pin).digest('hex');
+}

--- a/packages/core/src/pam/identity/service/withdrawal-pin.service.ts
+++ b/packages/core/src/pam/identity/service/withdrawal-pin.service.ts
@@ -1,0 +1,191 @@
+import { ORPCError } from '@orpc/server';
+import { eq } from 'drizzle-orm';
+import {
+  type Auth,
+  type EventBus,
+  type DrizzleService,
+  type NodeHeaders,
+  assertRateLimit,
+} from '@openora/core/server';
+import {
+  RATE_LIMIT_KEYS,
+  makeRateLimitKey,
+  type ClientMeta,
+  type IdentityReader,
+  type RateLimiterAdapter,
+  type SecurityControls,
+  type SetWithdrawalPinInput,
+  type User,
+} from '@openora/core/contracts';
+import { user } from '../schema/index.js';
+import { getSecurityControls } from './security-controls.service.js';
+import { assertFreshReauthentication } from './fresh-reauthentication.service.js';
+import { hashWithdrawalPin } from './withdrawal-pin-hash.service.js';
+import type { TwoFactorLockoutService } from './two-factor-lockout.service.js';
+import { nodeHeadersToHeaders } from '../../shared/headers-mapper.js';
+
+const MINUTE_MS = 60 * 1000;
+const WITHDRAWAL_PIN_RATE_LIMIT = {
+  limit: 5,
+  windowMs: 5 * MINUTE_MS,
+  onUnavailable: 'deny',
+} as const;
+
+export type WithdrawalPinServiceDeps = {
+  drizzle: DrizzleService;
+  events: EventBus;
+  limiter: RateLimiterAdapter;
+  auth: Auth;
+  identityReader: IdentityReader;
+  twoFactorLockout?: TwoFactorLockoutService;
+  hmacSecret: string;
+};
+
+/**
+ * Withdrawal PIN as a security control, independent of the login credential and of
+ * wallet withdrawal itself (verifying the PIN at withdrawal time is a separate,
+ * not-yet-built seam). Set and Change share the one upsert route below; Remove is
+ * immediate and un-gated by design (AC), so it deliberately skips fresh reauth.
+ */
+export class WithdrawalPinService {
+  private readonly drizzle: DrizzleService;
+  private readonly events: EventBus;
+  private readonly limiter: RateLimiterAdapter;
+  private readonly auth: Auth;
+  private readonly identityReader: IdentityReader;
+  private readonly twoFactorLockout?: TwoFactorLockoutService;
+  private readonly hmacSecret: string;
+
+  constructor({
+    drizzle,
+    events,
+    limiter,
+    auth,
+    identityReader,
+    twoFactorLockout,
+    hmacSecret,
+  }: WithdrawalPinServiceDeps) {
+    this.drizzle = drizzle;
+    this.events = events;
+    this.limiter = limiter;
+    this.auth = auth;
+    this.identityReader = identityReader;
+    this.twoFactorLockout = twoFactorLockout;
+    this.hmacSecret = hmacSecret;
+  }
+
+  private async securityControlsFor(userId: User['id']): Promise<SecurityControls> {
+    const controls = await getSecurityControls(this.drizzle, userId);
+    if (!controls) {
+      throw new ORPCError('UNAUTHORIZED', { message: 'Not signed in.' });
+    }
+    return controls;
+  }
+
+  private async loadCaller(userId: User['id']) {
+    const [caller] = await this.drizzle.db
+      .select({
+        role: user.role,
+        twoFactorEnabled: user.twoFactorEnabled,
+        withdrawalPinHash: user.withdrawalPinHash,
+      })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    if (!caller) {
+      throw new ORPCError('UNAUTHORIZED', { message: 'Not signed in.' });
+    }
+    return caller;
+  }
+
+  private async assertPlayer(
+    userId: User['id'],
+    role: string,
+    action: 'set' | 'remove',
+    meta: ClientMeta,
+  ) {
+    if (role === 'player') {
+      return;
+    }
+    // A service-level denial still owes the audit log the same signal AdminGuard emits,
+    // since this check rejects before any shared guard runs (docs/standards/audit.md).
+    this.events.emit('identity.user.unauthorized_access', {
+      userId,
+      playerId: null,
+      resource: 'identity.security.withdrawal_pin',
+      action,
+      role,
+      ip: meta.ip,
+      userAgent: meta.userAgent,
+    });
+    throw new ORPCError('FORBIDDEN', { message: 'Only players can manage a withdrawal PIN.' });
+  }
+
+  async set(
+    userId: User['id'],
+    input: SetWithdrawalPinInput,
+    reqHeaders: NodeHeaders,
+    meta: ClientMeta,
+  ): Promise<SecurityControls> {
+    await assertRateLimit(
+      this.limiter,
+      makeRateLimitKey(RATE_LIMIT_KEYS.WITHDRAWAL_PIN_MUTATION, userId),
+      WITHDRAWAL_PIN_RATE_LIMIT,
+    );
+    const caller = await this.loadCaller(userId);
+    await this.assertPlayer(userId, caller.role, 'set', meta);
+    await assertFreshReauthentication({
+      drizzle: this.drizzle,
+      auth: this.auth,
+      twoFactorLockout: this.twoFactorLockout,
+      userId,
+      headers: nodeHeadersToHeaders(reqHeaders),
+      currentPassword: input.currentPassword,
+      totpCode: input.totpCode,
+      twoFactorEnabled: caller.twoFactorEnabled ?? false,
+      meta,
+    });
+
+    const wasAlreadySet = caller.withdrawalPinHash !== null;
+    await this.drizzle.db
+      .update(user)
+      .set({
+        withdrawalPinHash: hashWithdrawalPin(input.pin, this.hmacSecret),
+        withdrawalPinSetAt: new Date(),
+      })
+      .where(eq(user.id, userId));
+    this.events.emit('identity.security.withdrawal_pin.set', {
+      userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
+      wasAlreadySet,
+      ip: meta.ip,
+      userAgent: meta.userAgent,
+    });
+    return this.securityControlsFor(userId);
+  }
+
+  async remove(userId: User['id'], meta: ClientMeta): Promise<SecurityControls> {
+    await assertRateLimit(
+      this.limiter,
+      makeRateLimitKey(RATE_LIMIT_KEYS.WITHDRAWAL_PIN_MUTATION, userId),
+      WITHDRAWAL_PIN_RATE_LIMIT,
+    );
+    const caller = await this.loadCaller(userId);
+    await this.assertPlayer(userId, caller.role, 'remove', meta);
+
+    if (caller.withdrawalPinHash === null) {
+      return this.securityControlsFor(userId);
+    }
+    await this.drizzle.db
+      .update(user)
+      .set({ withdrawalPinHash: null, withdrawalPinSetAt: null })
+      .where(eq(user.id, userId));
+    this.events.emit('identity.security.withdrawal_pin.removed', {
+      userId,
+      playerId: await this.identityReader.getPlayerIdByUserIdSafe(userId),
+      ip: meta.ip,
+      userAgent: meta.userAgent,
+    });
+    return this.securityControlsFor(userId);
+  }
+}

--- a/packages/core/src/pam/react.ts
+++ b/packages/core/src/pam/react.ts
@@ -17,6 +17,8 @@ export {
   useSendEmailVerification,
   useMySecurityControls,
   useSetLoginWithdrawalAlerts,
+  useSetWithdrawalPin,
+  useRemoveWithdrawalPin,
   useRequestPhoneVerification,
   useConfirmPhoneVerification,
   useMySessions,
@@ -24,6 +26,7 @@ export {
   type Enable2faResult,
   type UseMySecurityControlsResult,
   type UseSetLoginWithdrawalAlertsResult,
+  type UseSetWithdrawalPinResult,
   type UseRequestPhoneVerificationResult,
   type UseConfirmPhoneVerificationResult,
 } from './identity/react/account.js';

--- a/packages/testing/src/__tests__/analytics.e2e.test.ts
+++ b/packages/testing/src/__tests__/analytics.e2e.test.ts
@@ -71,6 +71,7 @@ async function insertTransaction(
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/chat-mention-search.e2e.test.ts
+++ b/packages/testing/src/__tests__/chat-mention-search.e2e.test.ts
@@ -37,6 +37,7 @@ async function readMentionResults(res: Response) {
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/display-currency.e2e.test.ts
+++ b/packages/testing/src/__tests__/display-currency.e2e.test.ts
@@ -21,6 +21,7 @@ let playerId: string;
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/exchange-rate.e2e.test.ts
+++ b/packages/testing/src/__tests__/exchange-rate.e2e.test.ts
@@ -18,6 +18,7 @@ let player: TestClient;
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/gaming-stake-debit.e2e.test.ts
+++ b/packages/testing/src/__tests__/gaming-stake-debit.e2e.test.ts
@@ -51,6 +51,7 @@ async function balanceOf(container: Container<CoreTokenCatalog>, userId: string)
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/http-cache.e2e.test.ts
+++ b/packages/testing/src/__tests__/http-cache.e2e.test.ts
@@ -34,6 +34,7 @@ const isCmsPage = (value: unknown): value is CmsPage =>
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/jsonb-contract-drift.e2e.test.ts
+++ b/packages/testing/src/__tests__/jsonb-contract-drift.e2e.test.ts
@@ -18,6 +18,7 @@ let app: TestApp;
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/kyc.e2e.test.ts
+++ b/packages/testing/src/__tests__/kyc.e2e.test.ts
@@ -69,6 +69,7 @@ beforeAll(async () => {
   process.env['KYC_WEBHOOK_SECRET'] = KYC_WEBHOOK_SECRET;
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/player-timezone.e2e.test.ts
+++ b/packages/testing/src/__tests__/player-timezone.e2e.test.ts
@@ -55,6 +55,7 @@ async function newPlayer(): Promise<{ client: TestClient; email: string }> {
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/qa-bonus-rollover.e2e.test.ts
+++ b/packages/testing/src/__tests__/qa-bonus-rollover.e2e.test.ts
@@ -107,6 +107,7 @@ async function rolloverStatus(client: TestClient, status?: 'active' | 'completed
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/qa-wallet-auto-withdrawal-config.e2e.test.ts
+++ b/packages/testing/src/__tests__/qa-wallet-auto-withdrawal-config.e2e.test.ts
@@ -129,6 +129,7 @@ async function createIsolatedTestDatabase(): Promise<string> {
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/qa-wallet-auto-withdrawal-exclude-risk-flags.e2e.test.ts
+++ b/packages/testing/src/__tests__/qa-wallet-auto-withdrawal-exclude-risk-flags.e2e.test.ts
@@ -106,6 +106,7 @@ async function setConfig(input: {
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/registration.e2e.test.ts
+++ b/packages/testing/src/__tests__/registration.e2e.test.ts
@@ -41,6 +41,7 @@ const userIdFor = async (email: string) => {
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/rg.e2e.test.ts
+++ b/packages/testing/src/__tests__/rg.e2e.test.ts
@@ -84,6 +84,7 @@ async function triggerRgMonitorSweep(container: Container<CoreTokenCatalog>) {
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/social-friend-requests.e2e.test.ts
+++ b/packages/testing/src/__tests__/social-friend-requests.e2e.test.ts
@@ -94,6 +94,7 @@ async function friendshipRowCount(
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/tag-lifecycle.e2e.test.ts
+++ b/packages/testing/src/__tests__/tag-lifecycle.e2e.test.ts
@@ -101,6 +101,7 @@ async function auditHasEntry(admin: TestClient, resourceId: string, action: stri
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/tag.e2e.test.ts
+++ b/packages/testing/src/__tests__/tag.e2e.test.ts
@@ -107,6 +107,7 @@ async function auditHasEntry(admin: TestClient, playerId: string, action: string
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/wallet-ledger-auto-withdrawal.e2e.test.ts
+++ b/packages/testing/src/__tests__/wallet-ledger-auto-withdrawal.e2e.test.ts
@@ -75,6 +75,7 @@ async function pendingWithdrawalIds(admin: TestClient, currency = 'USD') {
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
 
   db = await setupTestDb();

--- a/packages/testing/src/__tests__/wallet-manual-adjustment.e2e.test.ts
+++ b/packages/testing/src/__tests__/wallet-manual-adjustment.e2e.test.ts
@@ -38,6 +38,7 @@ async function registerPlayer() {
 beforeAll(async () => {
   process.env['BETTER_AUTH_SECRET'] ??= 'e2e-test-better-auth-secret-please-change-000000';
   process.env['AUTH_SECRET'] ??= process.env['BETTER_AUTH_SECRET'];
+  process.env['WITHDRAWAL_PIN_HMAC_SECRET'] ??= 'e2e-test-withdrawal-pin-hmac-secret-000000';
   process.env['NODE_ENV'] ??= 'test';
   db = await setupTestDb();
   testApp = await bootTestApp({ plugins: await loadExtensions(), databaseUrl: db.url });


### PR DESCRIPTION
## Summary

BF-519. Adds the backend for a hashed withdrawal-PIN security control (set/change/remove) to the identity module, exposed as `SecurityControlsSchema.withdrawalPinSet` plus two new routes and matching react hooks.

## Why

Players want an extra 4-digit checkpoint before funds leave their account, configured independently of login. The identity module's earlier security-controls work explicitly deferred this PIN (and security-score computation) to a later ticket; this closes the PIN half of that gap. Score computation and PIN verification at actual withdrawal time stay out of scope, owned by the consumer app and a future ticket respectively.

## Alternatives considered

- Gating Remove behind the same fresh-reauthentication check as Set/Change: rejected, the acceptance criteria explicitly call for immediate removal with no confirmation step.
- Hashing the PIN with the existing OTP module's plain SHA-256: rejected, that pattern is only safe for short-lived single-use codes. A 4-digit PIN is long-lived and low-entropy, so it's HMAC-SHA256 with a dedicated server secret instead.

## Risks

- New required env var (`WITHDRAWAL_PIN_HMAC_SECRET`, >=32 chars) — the identity plugin now fails fast at boot without it. Added to `.env.example` and defaulted in every `packages/testing` e2e bootstrap so existing suites keep booting.
- Withdrawal-time PIN verification and the security-score wiring are deferred, not implemented here.