### PR TITLE
feat(core): send an email on wallet.deposit.completed

### DIFF
--- a/packages/core/src/contracts/schemas/mail.ts
+++ b/packages/core/src/contracts/schemas/mail.ts
@@ -12,6 +12,7 @@ export const MAIL_TEMPLATE_KEYS = [
   'rgCoolingOffLifted',
   'rgSelfExclusionActivated',
   'rgSelfExclusionLifted',
+  'depositCompleted',
   'withdrawalApproved',
   'withdrawalRejected',
   'kycResubmissionRequested',
@@ -48,6 +49,7 @@ export const EmailTemplateDataSchemas = {
     isPermanent: z.boolean(),
   }),
   rgSelfExclusionLifted: z.object({}),
+  depositCompleted: z.object({ ...WithdrawalDetailsShape }),
   withdrawalApproved: z.object({ ...WithdrawalDetailsShape }),
   withdrawalRejected: z.object({
     ...WithdrawalDetailsShape,
@@ -76,6 +78,7 @@ export const MailTemplateSchema = z.discriminatedUnion('key', [
   templateVariant('rgCoolingOffLifted'),
   templateVariant('rgSelfExclusionActivated'),
   templateVariant('rgSelfExclusionLifted'),
+  templateVariant('depositCompleted'),
   templateVariant('withdrawalApproved'),
   templateVariant('withdrawalRejected'),
   templateVariant('kycResubmissionRequested'),

--- a/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
+++ b/packages/core/src/engagement/notifications/__tests__/notification-event-map.test.ts
@@ -179,7 +179,6 @@ describe('notificationEventMap', () => {
 
   it('keeps every newly-mapped trigger type in-app only (no email), per the email scope decision', () => {
     const inAppOnlyEvents = [
-      'wallet.deposit.completed',
       'wallet.manual_adjustment.created',
       'wallet.withdrawal.completed',
       'wallet.withdrawal.failed',
@@ -207,6 +206,22 @@ describe('notificationEventMap', () => {
     expect(entry.securityAlert).toBe(true);
     expect(entry.buildEmail(payload, OCCURRED_AT)).toEqual({
       key: 'securityWithdrawalRequested',
+      data: {
+        amount: '10.00',
+        currency: 'USD',
+        transactionId,
+        occurredAt: OCCURRED_AT,
+      },
+    });
+  });
+
+  it('builds a deposit-completed mail dated from the envelope, not the worker clock', () => {
+    const userId = randomUUID();
+    const transactionId = randomUUID();
+    const payload = { userId, amount: '10.00', currency: 'USD', transactionId, playerId: null };
+
+    expect(entryFor('wallet.deposit.completed').buildEmail(payload, OCCURRED_AT)).toEqual({
+      key: 'depositCompleted',
       data: {
         amount: '10.00',
         currency: 'USD',

--- a/packages/core/src/engagement/notifications/plugin.ts
+++ b/packages/core/src/engagement/notifications/plugin.ts
@@ -189,13 +189,27 @@ export const notificationEventMap: NotificationMapEntry[] = [
     data: { transactionId: p.transactionId },
   })),
 
-  mapEvent('wallet.deposit.completed', (p) => ({
-    userId: p.userId,
-    type: 'deposit.completed',
-    title: 'Deposit completed',
-    body: `Your deposit of ${formatMoneyAmount(p.amount)} ${p.currency} has been completed.`,
-    data: { transactionId: p.transactionId },
-  })),
+  mapEvent(
+    'wallet.deposit.completed',
+    (p) => ({
+      userId: p.userId,
+      type: 'deposit.completed',
+      title: 'Deposit completed',
+      body: `Your deposit of ${formatMoneyAmount(p.amount)} ${p.currency} has been completed.`,
+      data: { transactionId: p.transactionId },
+    }),
+    {
+      email: (p, occurredAt) => ({
+        key: 'depositCompleted',
+        data: {
+          amount: p.amount,
+          currency: p.currency,
+          transactionId: p.transactionId,
+          occurredAt,
+        },
+      }),
+    },
+  ),
 
   mapEvent('wallet.manual_adjustment.created', (p) => ({
     userId: p.userId,

--- a/packages/core/src/mail/adapters/default-email-template-renderer.ts
+++ b/packages/core/src/mail/adapters/default-email-template-renderer.ts
@@ -93,6 +93,12 @@ const PLAIN_EMAIL_TEMPLATES: { [K in EmailTemplateKey]: PlainTemplate<K> } = {
     subject: 'Your self-exclusion has been lifted',
     text: 'Your self-exclusion has been lifted and you can log in again.',
   }),
+  depositCompleted: (data, locale) => ({
+    subject: 'Your deposit has arrived',
+    text:
+      `Your deposit of ${formatMoney(data.amount, data.currency)} has been completed and is now available in your balance.\n\n` +
+      `Transaction: ${data.transactionId}\nDate: ${formatEmailDate(data.occurredAt, locale)}`,
+  }),
   withdrawalApproved: (data, locale) => ({
     subject: 'Your withdrawal was approved',
     text:


### PR DESCRIPTION
## What

Adds a `depositCompleted` mail template key and wires the `email` option onto the existing `wallet.deposit.completed` entry in `notificationEventMap`. The in-app leg is unchanged.

## Why

`MailTemplateSchema` is a closed discriminated union, so a consumer cannot add a template key without a core release. Combined with `wallet.deposit.completed` carrying no `email` option, an operator whose spec requires an email on a successful deposit has no supported path: the only workaround is a parallel mail pipeline that bypasses `MAIL_DISPATCH` and every branded template the operator already ships. That workaround was built downstream and is deleted by this change.

Withdrawal approvals and rejections already send email through this exact mechanism, so this closes an asymmetry rather than introducing a pattern.

## Scope decision this reverses

`notification-event-map.test.ts` asserted that a set of newly-mapped triggers stays in-app only, "per the email scope decision", and `wallet.deposit.completed` was on that list. This removes it from that list and leaves the other events untouched. That is a deliberate reversal for deposits specifically and wants a maintainer's sign-off rather than a silent pass.

## Acceptance criteria

- `wallet.deposit.completed` builds a `depositCompleted` mail dated from the event envelope, not the worker clock.
- The in-app notification for the same event is byte-identical to before.
- No existing template key or its data schema changes.
- `depositCompleted` reuses the withdrawal details shape rather than declaring a parallel one.

## Notes for review

Two files beyond the schema and the map needed a mechanical one-entry addition, because the union is exhaustive at both sites and core will not typecheck without them: `default-email-template-renderer.ts`'s `PLAIN_EMAIL_TEMPLATES` map, and the event-map test above.
