### PR TITLE
feat(iam): add a swap-config admin permission resource

### DIFF
--- a/.changeset/swap-config-permission.md
+++ b/.changeset/swap-config-permission.md
@@ -1,0 +1,5 @@
+---
+'@openora/core': minor
+---
+
+New admin permission resource `swap-config` (`view`, `update`) for the screen that sets a swap desk's pricing. Until now an overlay that owned swap pricing had to gate it on `wallet-asset`, so anyone allowed to edit the asset catalog could also change what players pay to swap. The built-in `admin` role and the seeded Finance / Accounting role are granted it; every other seeded role starts with no access.

--- a/.changeset/swap-config-permission.md
+++ b/.changeset/swap-config-permission.md
@@ -3,3 +3,10 @@
 ---
 
 New admin permission resource `swap-config` (`view`, `update`) for the screen that sets a swap desk's pricing. Until now an overlay that owned swap pricing had to gate it on `wallet-asset`, so anyone allowed to edit the asset catalog could also change what players pay to swap. The built-in `admin` role and the seeded Finance / Accounting role are granted it; every other seeded role starts with no access.
+
+An existing database does not get the Finance / Accounting grant on upgrade. Role grants are reference data written by `seedRoles`, and no migration carries them, so moving a swap pricing screen onto `swap-config` before granting it locks that team out. Grant it first, one of two ways:
+
+- A Super Admin calls `iam.setRolePermissions` (`PUT /iam/roles/{roleId}/permissions`) for the role. It replaces the role's whole grant set, so send the current grants plus `swap-config`.
+- Re-run `seedRoles`. It re-asserts the shipped matrix on every seeded role: a shipped grant whose level was changed goes back to the shipped level, and a shipped grant that was removed comes back. Grants on resources the shipped matrix leaves at no access are kept.
+
+Custom roles get no grant either way; grant them `swap-config` before switching the screen over.

--- a/packages/core/src/contracts/schemas/iam.ts
+++ b/packages/core/src/contracts/schemas/iam.ts
@@ -44,6 +44,7 @@ export const adminStatement = {
   'wallet-asset': ['view', 'create', 'update', 'delete'] as const,
   'wallet-custody': ['view', 'run'] as const,
   'wallet-reconciliation': ['view', 'resolve', 'run'] as const,
+  'swap-config': ['view', 'update'] as const,
   'chat-command': ['view', 'update'] as const,
   'chat-moderation': ['view', 'moderate'] as const,
 } as const;

--- a/packages/core/src/iam/seed/data/default-admin-roles.ts
+++ b/packages/core/src/iam/seed/data/default-admin-roles.ts
@@ -198,6 +198,7 @@ export const DEFAULT_ADMIN_ROLES: readonly DefaultAdminRole[] = [
       audit: R,
       analytics: R,
       'wallet-asset': RW,
+      'swap-config': RW,
     },
   },
   {

--- a/packages/core/src/server/auth/permissions.ts
+++ b/packages/core/src/server/auth/permissions.ts
@@ -32,6 +32,7 @@ export const adminRole = ac.newRole({
   'wallet-asset': ['view', 'create', 'update', 'delete'],
   'wallet-custody': ['view', 'run'],
   'wallet-reconciliation': ['view', 'resolve', 'run'],
+  'swap-config': ['view', 'update'],
   'chat-command': ['view', 'update'],
   'chat-moderation': ['view', 'moderate'],
 });


### PR DESCRIPTION
## Summary

Adds a `swap-config` admin permission resource (`view`, `update`), granted to the built-in admin role and the seeded Finance / Accounting role.

## Why

A screen that sets swap pricing had to gate on `wallet-asset`, so anyone allowed to edit the asset catalog could also change what players pay to swap. Pricing is a finance decision, the asset catalog is an ops one.

## Alternatives considered

- Keep gating swap pricing on `wallet-asset`. It couples two unrelated duties in one grant.

## Risks

- Custom roles do not get the resource automatically. A consumer that moves its swap settings screen onto `swap-config` has to grant it to those roles first.
