### PR TITLE
fix(wallet): read auto-withdrawal thresholds and caps in the fx pivot

### DIFF
--- a/.changeset/currency-aware-auto-withdrawal.md
+++ b/.changeset/currency-aware-auto-withdrawal.md
@@ -4,8 +4,14 @@
 
 Auto-withdrawal thresholds, the daily amount cap and the large-amount heuristic are now read in the fx pivot currency (`exchangeRate.pivot`, `USD` by default) instead of compared raw against whatever currency the withdrawal is in.
 
-One `cryptoThreshold` serves every crypto asset, so a raw comparison made its meaning depend on the coin: a threshold of `1` written with a stablecoin in mind let `0.4 BTC` auto-approve. The daily amount cap summed trailing payouts across currencies as if they were one unit. Both now convert through `EXCHANGE_RATE_READER`, and every comparison is exact decimal instead of `Number()`.
+One `cryptoThreshold` serves every crypto asset, so a raw comparison made its meaning depend on the coin: a threshold of `1` written with a stablecoin in mind let `0.4 BTC` auto-approve. The daily amount cap summed trailing payouts across currencies as if they were one unit. The withdrawal is now converted once through `EXCHANGE_RATE_READER`, outside the advisory lock, and every comparison is exact decimal instead of `Number()`.
 
-**Behaviour change:** `fiatThreshold`, `cryptoThreshold`, per-player `auto_withdrawal_rule.threshold` and `autoWithdrawal.dailyCapAmount` are pivot amounts. A threshold configured in coin units reads as a tiny pivot amount after upgrade, so withdrawals route to manual review until an operator re-enters it - the safe direction. When no rate is available for the withdrawal's currency, or the fx module is not loaded, the withdrawal is not auto-approved.
+Each auto-approved payout stores its pivot value in the new `wallet_transaction.auto_approval_pivot_amount` column, and the daily amount cap sums those stored values. A rate move after approval cannot shrink what a player already withdrew, and no rate is read while the per-user lock is held.
+
+The `wallet.withdrawal.auto_approved` audit row now carries `pivotAmount` and `pivotCurrency`. `threshold`, `dailyCapAmount` and `cumulativeAmountUsed` are in that pivot currency; `amount` and `currency` stay the raw request.
+
+**Behaviour change:** `fiatThreshold`, `cryptoThreshold`, per-player `auto_withdrawal_rule.threshold` and `autoWithdrawal.dailyCapAmount` are pivot amounts. A threshold configured in coin units reads as a tiny pivot amount after upgrade, so withdrawals route to manual review until an operator re-enters it - the safe direction. When no rate is available for the withdrawal's currency, or the fx module is not loaded, a withdrawal in any currency other than the pivot is not auto-approved; one already in the pivot needs no rate and is still evaluated.
+
+Auto-approvals written before the upgrade have no stored pivot value. While a daily amount cap is configured, a wallet with one in its trailing 24 hours routes to manual review until it ages out, and `cumulativeAmountUsed` is recorded as `null` rather than a partial total.
 
 The review-queue `large_amount` tag still compares the raw amount; it is a display hint, not a decision.

--- a/.changeset/currency-aware-auto-withdrawal.md
+++ b/.changeset/currency-aware-auto-withdrawal.md
@@ -1,0 +1,11 @@
+---
+'@openora/core': minor
+---
+
+Auto-withdrawal thresholds, the daily amount cap and the large-amount heuristic are now read in the fx pivot currency (`exchangeRate.pivot`, `USD` by default) instead of compared raw against whatever currency the withdrawal is in.
+
+One `cryptoThreshold` serves every crypto asset, so a raw comparison made its meaning depend on the coin: a threshold of `1` written with a stablecoin in mind let `0.4 BTC` auto-approve. The daily amount cap summed trailing payouts across currencies as if they were one unit. Both now convert through `EXCHANGE_RATE_READER`, and every comparison is exact decimal instead of `Number()`.
+
+**Behaviour change:** `fiatThreshold`, `cryptoThreshold`, per-player `auto_withdrawal_rule.threshold` and `autoWithdrawal.dailyCapAmount` are pivot amounts. A threshold configured in coin units reads as a tiny pivot amount after upgrade, so withdrawals route to manual review until an operator re-enters it - the safe direction. When no rate is available for the withdrawal's currency, or the fx module is not loaded, the withdrawal is not auto-approved.
+
+The review-queue `large_amount` tag still compares the raw amount; it is a display hint, not a decision.

--- a/packages/core/src/contracts/schemas/platform-config.ts
+++ b/packages/core/src/contracts/schemas/platform-config.ts
@@ -134,10 +134,12 @@ export const WalletConfigSchema = z
 
 export type WalletConfig = z.infer<typeof WalletConfigSchema>;
 
+const DEFAULT_EXCHANGE_RATE_PIVOT = 'USD';
+
 export const ExchangeRateConfigSchema = z
   .object({
     /** Comparison currency the fx module derives a cross rate against. Absent = 'USD'. */
-    pivot: CurrencyCodeSchema.default('USD'),
+    pivot: CurrencyCodeSchema.default(DEFAULT_EXCHANGE_RATE_PIVOT),
     freshTtlMs: z.number().int().positive().default(60_000),
     hardMaxAgeMs: z
       .number()
@@ -149,6 +151,11 @@ export const ExchangeRateConfigSchema = z
   .strict();
 
 export type ExchangeRateConfig = z.infer<typeof ExchangeRateConfigSchema>;
+
+/** The pivot every fx conversion targets. One resolver, so no module converts against another. */
+export function resolveExchangeRatePivot(config: ExchangeRateConfig | undefined): string {
+  return (config?.pivot ?? DEFAULT_EXCHANGE_RATE_PIVOT).toUpperCase();
+}
 
 export const NotificationsConfigSchema = z
   .object({

--- a/packages/core/src/fx/exchange-rate/plugin.ts
+++ b/packages/core/src/fx/exchange-rate/plugin.ts
@@ -6,20 +6,15 @@ import {
   EXCHANGE_RATE_READER,
   PLATFORM_CONFIG,
   resolveDisplayCurrencies,
-  type PlatformConfig,
+  resolveExchangeRatePivot,
 } from '@openora/core/contracts';
 import { ExchangeRateService } from './service/exchange-rate.service.js';
 import { createExchangeRateRouter } from './router/index.js';
 import { ExchangeRateReaderService } from './adapters/exchange-rate-reader.service.js';
 
-const DEFAULT_PIVOT = 'USD';
 const DEFAULT_FRESH_TTL_MS = 60_000;
 const DEFAULT_HARD_MAX_AGE_MS = 15 * 60_000;
 const DEFAULT_PROVIDER_TIMEOUT_MS = 2_000;
-
-function resolvePivot(platformConfig: PlatformConfig): string {
-  return (platformConfig.exchangeRate?.pivot ?? DEFAULT_PIVOT).toUpperCase();
-}
 
 export default {
   id: 'exchange-rate',
@@ -29,7 +24,7 @@ export default {
       const exchangeRateConfig = platformConfig.exchangeRate;
       return new ExchangeRateReaderService({
         drizzle: c.get(DRIZZLE),
-        pivot: resolvePivot(platformConfig),
+        pivot: resolveExchangeRatePivot(exchangeRateConfig),
         cryptoProvider: c.has(CRYPTO_EXCHANGE_RATE_PROVIDER)
           ? c.get(CRYPTO_EXCHANGE_RATE_PROVIDER)
           : undefined,
@@ -49,7 +44,7 @@ export default {
       // every cross rate is computed through it, so a quote against it is always legitimate.
       const supported = [
         ...resolveDisplayCurrencies(platformConfig.displayCurrencies),
-        resolvePivot(platformConfig),
+        resolveExchangeRatePivot(platformConfig.exchangeRate),
       ];
       return createExchangeRateRouter(
         new ExchangeRateService(c.get(EXCHANGE_RATE_READER), supported),

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
@@ -210,6 +210,7 @@ describe('WalletService.withdraw auto-approval (real PG)', () => {
       reviewedBy: null,
       reviewReason: 'auto-approved',
       providerName: DEFAULT_PAYMENT_PROVIDER,
+      autoApprovalPivotAmount: '40.000000000000000000',
     });
     expect(events.emit.mock.calls.map(([topic]) => topic)).toEqual([
       'wallet.withdrawal.requested',
@@ -225,6 +226,8 @@ describe('WalletService.withdraw auto-approval (real PG)', () => {
           threshold: '1000.000000000000000000',
           thresholdSource: 'global',
           kycStatus: 'verified',
+          pivotAmount: '40',
+          pivotCurrency: 'USD',
           cumulativeCountUsed: 0,
         }),
       }),
@@ -625,6 +628,24 @@ describe('WalletService.withdraw auto-approval (real PG)', () => {
     expect(result.status).toBe('completed');
   });
 
+  it('auto-approves a withdrawal already in the pivot without the fx module', async () => {
+    const { svc } = await makeService({
+      autoWithdrawal: {},
+      fiatThreshold: '1000',
+      rates: 'unbound',
+    });
+    const w = await seedWallet();
+
+    const result = await svc.withdraw({
+      userId: w.userId,
+      amount: '40',
+      currency: 'USD',
+      ...NO_CLIENT_META,
+    });
+
+    expect(result.status).toBe('completed');
+  });
+
   it('stays pending when a configured daily count cap would be exceeded', async () => {
     const { svc } = await makeService({
       autoWithdrawal: { dailyCapCount: 1 },
@@ -660,6 +681,32 @@ describe('WalletService.withdraw auto-approval (real PG)', () => {
       walletId: w.id,
       type: 'withdrawal',
       amount: '20',
+      currency: 'USD',
+      status: 'completed',
+      reviewReason: 'auto-approved',
+      autoApprovalPivotAmount: '20',
+    });
+
+    const result = await svc.withdraw({
+      userId: w.userId,
+      amount: '40',
+      currency: 'USD',
+      ...NO_CLIENT_META,
+    });
+
+    expect(result.status).toBe('pending');
+  });
+
+  it('stays pending when a trailing auto-approval has no stored pivot value to sum', async () => {
+    const { svc } = await makeService({
+      autoWithdrawal: { dailyCapAmount: '1000' },
+      fiatThreshold: '1000',
+    });
+    const w = await seedWallet();
+    await db.drizzle.db.insert(walletTransaction).values({
+      walletId: w.id,
+      type: 'withdrawal',
+      amount: '1',
       currency: 'USD',
       status: 'completed',
       reviewReason: 'auto-approved',
@@ -802,12 +849,32 @@ describe('WalletService.withdraw auto-approval - crypto rail (real PG)', () => {
     expect(result.status).toBe('pending');
   });
 
-  it('sums the daily amount cap in the pivot, not raw across currencies', async () => {
+  it('stays pending when the bound reader has no rate for the currency', async () => {
+    const { svc } = await makeService({
+      autoWithdrawal: {},
+      fiatThreshold: '100000',
+      cryptoThreshold: '100000',
+    });
+    const w = await seedWallet({ currency: 'ETH', balance: '10' });
+
+    const result = await svc.withdraw({
+      userId: w.userId,
+      amount: '1',
+      currency: 'ETH',
+      destinationAddress: '0xexample',
+      ...NO_CLIENT_META,
+    });
+
+    expect(result.status).toBe('pending');
+  });
+
+  it('caps on the pivot value a past payout was approved at, not its value at the current rate', async () => {
     const { svc } = await makeService({
       autoWithdrawal: { dailyCapAmount: '1500' },
       cryptoThreshold: '2000',
     });
     const w = await seedWallet({ currency: 'BTC', balance: '10' });
+    // Approved when BTC was 1400; at today's 1000 the same payout would leave room for 0.2 BTC.
     await db.drizzle.db.insert(walletTransaction).values({
       walletId: w.id,
       type: 'withdrawal',
@@ -815,11 +882,12 @@ describe('WalletService.withdraw auto-approval - crypto rail (real PG)', () => {
       currency: 'BTC',
       status: 'completed',
       reviewReason: 'auto-approved',
+      autoApprovalPivotAmount: '1400',
     });
 
     const result = await svc.withdraw({
       userId: w.userId,
-      amount: '1',
+      amount: '0.2',
       currency: 'BTC',
       destinationAddress: 'bc1qexample',
       ...NO_CLIENT_META,

--- a/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
+++ b/packages/core/src/wallet/__tests__/wallet-auto-withdrawal.int.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
-import { findOneOrThrow } from '@openora/core/server';
+import { findOneOrThrow, moneyScaleBy } from '@openora/core/server';
 import { randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
 import {
@@ -7,6 +7,7 @@ import {
   type AdminUserDirectory,
   type AuditWritePort,
   type AutoWithdrawalConfig,
+  type ExchangeRateReader,
   type KycStatus,
   type PaymentAdapter,
   type PlatformConfig,
@@ -48,8 +49,25 @@ const MIGRATION_DEFAULT_EXCLUDE_RISK_FLAGS: readonly TagKey[] = [
   'multi_account',
 ];
 
+// USD per unit. One BTC at 1000 keeps a one-coin withdrawal under the 5000 large-amount
+// heuristic, so the crypto cases below exercise the threshold rather than the heuristic.
+const USD_PER_UNIT: Partial<Record<string, string>> = { BTC: '1000', USDT: '1' };
+
+function fixedRates(): ExchangeRateReader {
+  return mock<ExchangeRateReader>({
+    convert: vi.fn(async (amount: string, from: string, to: string) => {
+      const perUnit = USD_PER_UNIT[from];
+      if (from === to) {
+        return amount;
+      }
+      return perUnit && to === 'USD' ? moneyScaleBy(amount, perUnit) : null;
+    }),
+  });
+}
+
 type ServiceOptions = {
   autoWithdrawal?: Partial<AutoWithdrawalConfig>;
+  rates?: ExchangeRateReader | 'unbound';
   // The global fiat/crypto thresholds are DB-backed, not part of
   // PlatformConfig any more - seeded into wallet_auto_withdrawal_config here
   // whenever `autoWithdrawal` is passed, mirroring the production seed
@@ -70,6 +88,7 @@ type ServiceOptions = {
 
 async function makeService({
   autoWithdrawal,
+  rates = fixedRates(),
   fiatThreshold,
   cryptoThreshold,
   excludeRiskFlags,
@@ -116,6 +135,7 @@ async function makeService({
     identityReader: makeIdentityReader(),
     directory,
     platformConfig,
+    ...(rates === 'unbound' ? {} : { rates }),
     ...(riskTags === 'unbound'
       ? {}
       : {
@@ -714,7 +734,7 @@ describe('WalletService.withdraw auto-approval - crypto rail (real PG)', () => {
   });
 
   it('auto-approves once an operator configures a positive cryptoThreshold', async () => {
-    const { svc } = await makeService({ autoWithdrawal: {}, cryptoThreshold: '2' });
+    const { svc } = await makeService({ autoWithdrawal: {}, cryptoThreshold: '2000' });
     const w = await seedWallet({ currency: 'BTC', balance: '10' });
 
     const result = await svc.withdraw({
@@ -734,8 +754,68 @@ describe('WalletService.withdraw auto-approval - crypto rail (real PG)', () => {
   });
 
   it('stays pending when the crypto amount exceeds cryptoThreshold', async () => {
-    const { svc } = await makeService({ autoWithdrawal: {}, cryptoThreshold: '0.5' });
+    const { svc } = await makeService({ autoWithdrawal: {}, cryptoThreshold: '500' });
     const w = await seedWallet({ currency: 'BTC', balance: '10' });
+
+    const result = await svc.withdraw({
+      userId: w.userId,
+      amount: '1',
+      currency: 'BTC',
+      destinationAddress: 'bc1qexample',
+      ...NO_CLIENT_META,
+    });
+
+    expect(result.status).toBe('pending');
+  });
+
+  it('judges a crypto withdrawal by its pivot value, not its raw amount', async () => {
+    const { svc } = await makeService({ autoWithdrawal: {}, cryptoThreshold: '1000' });
+    const w = await seedWallet({ currency: 'BTC', balance: '10' });
+
+    const result = await svc.withdraw({
+      userId: w.userId,
+      amount: '2',
+      currency: 'BTC',
+      destinationAddress: 'bc1qexample',
+      ...NO_CLIENT_META,
+    });
+
+    expect(result.status).toBe('pending');
+  });
+
+  it('stays pending when there is no rate to value the withdrawal in the pivot', async () => {
+    const { svc } = await makeService({
+      autoWithdrawal: {},
+      cryptoThreshold: '100000',
+      rates: 'unbound',
+    });
+    const w = await seedWallet({ currency: 'BTC', balance: '10' });
+
+    const result = await svc.withdraw({
+      userId: w.userId,
+      amount: '1',
+      currency: 'BTC',
+      destinationAddress: 'bc1qexample',
+      ...NO_CLIENT_META,
+    });
+
+    expect(result.status).toBe('pending');
+  });
+
+  it('sums the daily amount cap in the pivot, not raw across currencies', async () => {
+    const { svc } = await makeService({
+      autoWithdrawal: { dailyCapAmount: '1500' },
+      cryptoThreshold: '2000',
+    });
+    const w = await seedWallet({ currency: 'BTC', balance: '10' });
+    await db.drizzle.db.insert(walletTransaction).values({
+      walletId: w.id,
+      type: 'withdrawal',
+      amount: '1',
+      currency: 'BTC',
+      status: 'completed',
+      reviewReason: 'auto-approved',
+    });
 
     const result = await svc.withdraw({
       userId: w.userId,
@@ -751,7 +831,7 @@ describe('WalletService.withdraw auto-approval - crypto rail (real PG)', () => {
   it('applies the same KYC guard as the fiat rail', async () => {
     const { svc } = await makeService({
       autoWithdrawal: {},
-      cryptoThreshold: '2',
+      cryptoThreshold: '2000',
       kycStatus: 'rejected',
     });
     const w = await seedWallet({ currency: 'BTC', balance: '10' });
@@ -839,11 +919,11 @@ describe('WalletService auto-approval threshold resolution (real PG)', () => {
   });
 
   it('a per-player rule overrides the crypto threshold too', async () => {
-    const { svc } = await makeService({ autoWithdrawal: {}, cryptoThreshold: '0.5' });
+    const { svc } = await makeService({ autoWithdrawal: {}, cryptoThreshold: '500' });
     const w = await seedWallet({ currency: 'BTC', balance: '10' });
     await svc.setAutoWithdrawalRule({
       userId: w.userId,
-      threshold: '5',
+      threshold: '2000',
       reason: 'trusted',
       createdBy: randomUUID(),
     });

--- a/packages/core/src/wallet/drizzle/migrations/0020_salty_infant_terrible.sql
+++ b/packages/core/src/wallet/drizzle/migrations/0020_salty_infant_terrible.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wallet_transaction" ADD COLUMN "auto_approval_pivot_amount" numeric(38, 18);

--- a/packages/core/src/wallet/drizzle/migrations/meta/0020_snapshot.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/0020_snapshot.json
@@ -1,0 +1,1979 @@
+{
+  "id": "fd56d338-6246-4671-be45-e6bab4c16d07",
+  "prevId": "90a95b14-83e4-4eba-8277-650ba777c078",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auto_withdrawal_rule": {
+      "name": "auto_withdrawal_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auto_withdrawal_rule_user_id_unique": {
+          "name": "auto_withdrawal_rule_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_user_id_unique": {
+          "name": "wallet_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_asset": {
+      "name": "wallet_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_asset_id": {
+          "name": "provider_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_deposit": {
+          "name": "min_deposit",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_withdrawal": {
+          "name": "min_withdrawal",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawal_fee": {
+          "name": "withdrawal_fee",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deposit_enabled": {
+          "name": "deposit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "withdrawal_enabled": {
+          "name": "withdrawal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sweep_dust_threshold": {
+          "name": "sweep_dust_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sweep_fee_ceiling": {
+          "name": "sweep_fee_ceiling",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool_liquidity_floor": {
+          "name": "pool_liquidity_floor",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_asset_currency_network_idx": {
+          "name": "wallet_asset_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_auto_withdrawal_config": {
+      "name": "wallet_auto_withdrawal_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "fiat_threshold": {
+          "name": "fiat_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crypto_threshold": {
+          "name": "crypto_threshold",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_risk_flags": {
+          "name": "exclude_risk_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['high_risk','bonus_abuser','kyc_rejected','withdrawal_review','multi_account']::text[]"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_auto_withdrawal_config_singletonKey_unique": {
+          "name": "wallet_auto_withdrawal_config_singletonKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_balance": {
+      "name": "wallet_balance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_balance_wallet_id_currency_idx": {
+          "name": "wallet_balance_wallet_id_currency_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_balance_wallet_id_wallet_id_fk": {
+          "name": "wallet_balance_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_balance",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_bonus_credit": {
+      "name": "wallet_bonus_credit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "wallet_bonus_credit_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credited_amount": {
+          "name": "credited_amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_multiplier": {
+          "name": "rollover_multiplier",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_required": {
+          "name": "rollover_required",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_progress": {
+          "name": "rollover_progress",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_bonus_credit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wallet_bonus_credit_user_id_currency_status_idx": {
+          "name": "wallet_bonus_credit_user_id_currency_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_bonus_credit_wallet_id_idx": {
+          "name": "wallet_bonus_credit_wallet_id_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_bonus_credit_wallet_id_wallet_id_fk": {
+          "name": "wallet_bonus_credit_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_bonus_credit",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_bonus_rollover_config": {
+      "name": "wallet_bonus_rollover_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_bonus_rollover_config_singletonKey_unique": {
+          "name": "wallet_bonus_rollover_config_singletonKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["singleton_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_custody_sweep": {
+      "name": "wallet_custody_sweep",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_fee": {
+          "name": "estimated_fee",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool_ref": {
+          "name": "pool_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_custody_sweep_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_custody_sweep_user_id_currency_network_idx": {
+          "name": "wallet_custody_sweep_user_id_currency_network_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending','processing','unknown')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_external_id_idx": {
+          "name": "wallet_custody_sweep_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_custody_sweep\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_status_created_at_idx": {
+          "name": "wallet_custody_sweep_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_custody_sweep_provider_name_created_at_idx": {
+          "name": "wallet_custody_sweep_provider_name_created_at_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_deposit_address": {
+      "name": "wallet_deposit_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_deposit_address_user_id_currency_network_idx": {
+          "name": "wallet_deposit_address_user_id_currency_network_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_user_id_currency_idx": {
+          "name": "wallet_deposit_address_user_id_currency_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"network\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_tag_idx": {
+          "name": "wallet_deposit_address_address_tag_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_network_currency_idx": {
+          "name": "wallet_deposit_address_address_network_currency_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_deposit_address\".\"tag\" IS NULL AND \"wallet_deposit_address\".\"network\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_deposit_address_address_idx": {
+          "name": "wallet_deposit_address_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_job_run": {
+      "name": "wallet_job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_job_run_job_name_idx": {
+          "name": "wallet_job_run_job_name_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_job_run\".\"finished_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_job_run_job_name_started_at_idx": {
+          "name": "wallet_job_run_job_name_started_at_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_provider_vault": {
+      "name": "wallet_provider_vault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_account_id": {
+          "name": "vault_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_provider_vault_user_id_provider_name_idx": {
+          "name": "wallet_provider_vault_user_id_provider_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_provider_vault_provider_name_vault_account_id_idx": {
+          "name": "wallet_provider_vault_provider_name_vault_account_id_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vault_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_reconciliation_finding": {
+      "name": "wallet_reconciliation_finding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "wallet_reconciliation_finding_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_reconciliation_finding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_reconciliation_finding_kind_external_id_idx": {
+          "name": "wallet_reconciliation_finding_kind_external_id_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_reconciliation_finding\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_reconciliation_finding_status_created_at_idx": {
+          "name": "wallet_reconciliation_finding_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_reconciliation_finding_run_id_idx": {
+          "name": "wallet_reconciliation_finding_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transaction": {
+      "name": "wallet_transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "wallet_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rail": {
+          "name": "rail",
+          "type": "wallet_rail",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "wallet_transaction_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_approval_pivot_amount": {
+          "name": "auto_approval_pivot_amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_ref_id": {
+          "name": "provider_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_round_id": {
+          "name": "external_round_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_address": {
+          "name": "destination_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_tag": {
+          "name": "destination_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_wallet_id": {
+          "name": "destination_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transaction_wallet_id_idx": {
+          "name": "wallet_transaction_wallet_id_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_created_at_idx": {
+          "name": "wallet_transaction_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_type_idx": {
+          "name": "wallet_transaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_idx": {
+          "name": "wallet_transaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_rail_idx": {
+          "name": "wallet_transaction_rail_idx",
+          "columns": [
+            {
+              "expression": "rail",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_idx": {
+          "name": "wallet_transaction_currency_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_currency_network_idx": {
+          "name": "wallet_transaction_currency_network_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_tx_hash_idx": {
+          "name": "wallet_transaction_tx_hash_idx",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_status_type_created_at_idx": {
+          "name": "wallet_transaction_status_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_type_status_idx": {
+          "name": "wallet_transaction_wallet_id_type_status_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_provider_ref_id_idx": {
+          "name": "wallet_transaction_provider_ref_id_idx",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"provider_ref_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_external_round_id_idx": {
+          "name": "wallet_transaction_external_round_id_idx",
+          "columns": [
+            {
+              "expression": "external_round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_transaction_wallet_id_idempotency_key_idx": {
+          "name": "wallet_transaction_wallet_id_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wallet_transaction\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transaction_wallet_id_wallet_id_fk": {
+          "name": "wallet_transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "wallet_transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_withdrawal_address": {
+      "name": "wallet_withdrawal_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_tag": {
+          "name": "destination_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_wallet_id": {
+          "name": "provider_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_withdrawal_address_user_id_currency_network_address_idx": {
+          "name": "wallet_withdrawal_address_user_id_currency_network_address_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"destination_tag\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wallet_withdrawal_address_user_id_created_at_idx": {
+          "name": "wallet_withdrawal_address_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.wallet_bonus_credit_source_type": {
+      "name": "wallet_bonus_credit_source_type",
+      "schema": "public",
+      "values": ["gift", "rain"]
+    },
+    "public.wallet_bonus_credit_status": {
+      "name": "wallet_bonus_credit_status",
+      "schema": "public",
+      "values": ["active", "completed"]
+    },
+    "public.wallet_custody_sweep_status": {
+      "name": "wallet_custody_sweep_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "unknown"]
+    },
+    "public.wallet_job_run_status": {
+      "name": "wallet_job_run_status",
+      "schema": "public",
+      "values": ["running", "completed", "skipped", "failed", "abandoned"]
+    },
+    "public.wallet_rail": {
+      "name": "wallet_rail",
+      "schema": "public",
+      "values": ["crypto", "fiat"]
+    },
+    "public.wallet_reconciliation_finding_kind": {
+      "name": "wallet_reconciliation_finding_kind",
+      "schema": "public",
+      "values": [
+        "missing_deposit",
+        "unattributed_deposit",
+        "amount_mismatch",
+        "currency_mismatch",
+        "status_mismatch",
+        "unknown_at_provider",
+        "unconfigured_asset",
+        "stuck_sweep"
+      ]
+    },
+    "public.wallet_reconciliation_finding_status": {
+      "name": "wallet_reconciliation_finding_status",
+      "schema": "public",
+      "values": ["open", "resolved"]
+    },
+    "public.wallet_transaction_direction": {
+      "name": "wallet_transaction_direction",
+      "schema": "public",
+      "values": ["credit", "debit"]
+    },
+    "public.wallet_transaction_status": {
+      "name": "wallet_transaction_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "rejected", "on_hold", "cancelled"]
+    },
+    "public.wallet_transaction_type": {
+      "name": "wallet_transaction_type",
+      "schema": "public",
+      "values": [
+        "deposit",
+        "withdrawal",
+        "bet",
+        "win",
+        "loss",
+        "bonus",
+        "tip",
+        "gift",
+        "rain",
+        "manual_credit",
+        "manual_debit",
+        "swap_out",
+        "swap_in",
+        "bet_reversal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
+++ b/packages/core/src/wallet/drizzle/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1788775636543,
       "tag": "0019_awesome_drax",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1789120359101,
+      "tag": "0020_salty_infant_terrible",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/wallet/plugin.ts
+++ b/packages/core/src/wallet/plugin.ts
@@ -19,6 +19,7 @@ import {
   TAG_EVALUATION_COMMANDS,
   PLAY_ELIGIBILITY,
   RG_LIMITS,
+  EXCHANGE_RATE_READER,
   SWAP_ADAPTER,
   SWAP_WEBHOOK_VERIFIER,
   AUDIT_WRITER,
@@ -253,6 +254,7 @@ export default {
           : undefined,
         audit: c.get(AUDIT_WRITER),
         rgLimits: c.has(RG_LIMITS) ? c.get(RG_LIMITS) : undefined,
+        rates: c.has(EXCHANGE_RATE_READER) ? c.get(EXCHANGE_RATE_READER) : undefined,
       });
 
       const reconciliation = new ReconciliationService({

--- a/packages/core/src/wallet/schema/index.ts
+++ b/packages/core/src/wallet/schema/index.ts
@@ -127,6 +127,10 @@ export const walletTransaction = pgTable(
     reviewedBy: uuid(),
     reviewedAt: timestamp({ withTimezone: true }),
     reviewReason: text(),
+    // What an auto-approved payout was worth in the fx pivot at approval. The daily amount cap
+    // sums these, so a rate move after approval cannot shrink what the player already took.
+    // NULL on every other row, and on auto-approvals written before this column existed.
+    autoApprovalPivotAmount: decimal({ precision: MONEY_PRECISION, scale: MONEY_SCALE }),
     // The concrete settlement provider (eg a PSP name) and its reference id (eg the
     // PSP charge id), as first-class typed columns so they are filterable for
     // reconciliation rather than buried in free-form JSON.

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -34,6 +34,7 @@ import {
   railFor as sharedRailFor,
   type PlayerTags,
   type RgLimitsPort,
+  type ExchangeRateReader,
   type AuditWritePort,
   type TagEvaluationCommands,
   type TagKey,
@@ -561,10 +562,13 @@ function namespacedIdempotencyKey(namespace: string, rawKey: string): string {
   ].join('-');
 }
 
-// ponytail: a flat, currency-agnostic threshold - a starter heuristic for the review
-// queue, not a compliance risk engine. Revisit with a real risk service if/when one exists.
-// moneyToNumber is the sanctioned JS conversion point for this heuristic comparison only.
+// ponytail: a flat threshold - a starter heuristic, not a compliance risk engine. Auto-approval
+// reads it in the fx pivot; the review-queue tag still compares the raw amount, so it is only
+// a display hint there. Revisit with a real risk service if/when one exists.
 const LARGE_WITHDRAWAL_THRESHOLD = '5000';
+
+// The fx module's own fallback when `exchangeRate.pivot` is unset.
+const DEFAULT_FX_PIVOT = 'USD';
 
 // ponytail: >=3 withdrawals in a 24h window flags velocity; a flat count, not a per-tier rule.
 const HIGH_FREQUENCY_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -692,6 +696,9 @@ export type WalletServiceDeps = {
   // Required: the auto-approval audit trail is a regulatory invariant, so wallet hard-depends on audit.
   audit: AuditWritePort;
   rgLimits?: RgLimitsPort;
+  // Optional: bound by the fx module. Auto-approval thresholds and caps are denominated in
+  // the fx pivot; without a reader, a withdrawal in any other currency is never auto-approved.
+  rates?: ExchangeRateReader;
 };
 
 /**
@@ -715,6 +722,7 @@ export class WalletService {
   private readonly tagEvaluationCommands?: TagEvaluationCommands;
   private readonly audit: AuditWritePort;
   private readonly rgLimits?: RgLimitsPort;
+  private readonly rates?: ExchangeRateReader;
 
   constructor({
     drizzle,
@@ -729,6 +737,7 @@ export class WalletService {
     tagEvaluationCommands,
     audit,
     rgLimits,
+    rates,
   }: WalletServiceDeps) {
     this.drizzle = drizzle;
     this.events = events;
@@ -742,6 +751,7 @@ export class WalletService {
     this.tagEvaluationCommands = tagEvaluationCommands;
     this.audit = audit;
     this.rgLimits = rgLimits;
+    this.rates = rates;
   }
 
   // Every catalog row for the currency, enabled or not - resolveWithdrawalNetwork needs
@@ -1833,7 +1843,7 @@ export class WalletService {
       const decided = await this.drizzle.db.transaction((txn) =>
         withAdvisoryXactLock(txn, args.userId, async () => {
           const caps = await this.autoApprovalCaps(
-            { walletId: args.walletId, amount: args.amount, cfg },
+            { walletId: args.walletId, amount: args.amount, currency: args.currency, cfg },
             txn,
           );
           if (caps.exceeded) {
@@ -1897,11 +1907,13 @@ export class WalletService {
   private async evaluateAutoApproval({
     userId,
     amount,
+    currency,
     walletId,
     rail,
   }: {
     userId: User['id'];
     amount: string;
+    currency: string;
     walletId: Wallet['id'];
     rail: WalletRail;
   }): Promise<AutoApprovalGates | null> {
@@ -1910,10 +1922,13 @@ export class WalletService {
       return null;
     }
     const threshold = await this.resolveAutoThreshold(userId, rail);
-    if (!threshold || moneyToNumber(threshold.value) <= 0) {
+    if (!threshold || moneyCompare(threshold.value, '0') <= 0) {
       return null;
     }
-    if (moneyToNumber(amount) > moneyToNumber(threshold.value)) {
+    // One threshold serves every currency on the rail, so it is read in the fx pivot. A raw
+    // comparison let 0.4 BTC clear a threshold of 1 that was written with a stablecoin in mind.
+    const pivotAmount = await this.toPivotAmount(amount, currency);
+    if (pivotAmount === null || moneyCompare(pivotAmount, threshold.value) > 0) {
       return null;
     }
 
@@ -1934,7 +1949,7 @@ export class WalletService {
       return null;
     }
 
-    const heuristics = await this.autoApprovalHeuristics({ walletId, amount });
+    const heuristics = await this.autoApprovalHeuristics({ walletId, amount: pivotAmount });
     if (heuristics.largeAmount || heuristics.highFrequency) {
       return null;
     }
@@ -2342,7 +2357,7 @@ export class WalletService {
   }): Promise<{ largeAmount: boolean; highFrequency: boolean }> {
     const frequent = await this.frequentWithdrawalWalletIds(this.drizzle.db, [walletId]);
     return {
-      largeAmount: moneyToNumber(amount) >= moneyToNumber(LARGE_WITHDRAWAL_THRESHOLD),
+      largeAmount: moneyCompare(amount, LARGE_WITHDRAWAL_THRESHOLD) >= 0,
       highFrequency: frequent.has(walletId),
     };
   }
@@ -2379,21 +2394,26 @@ export class WalletService {
 
   // Sum + count of this wallet's auto-approved payouts in the trailing 24h; `exceeded` when this withdrawal
   // would breach a configured amount or count cap (an unconfigured cap never blocks).
+  // The amount cap is in the fx pivot: the trailing payouts are summed per currency and each
+  // converted, never added raw across currencies. A currency with no rate exceeds the cap.
   private async autoApprovalCaps(
     {
       walletId,
       amount,
+      currency,
       cfg,
     }: {
       walletId: Wallet['id'];
       amount: string;
+      currency: string;
       cfg: NonNullable<PlatformConfig['autoWithdrawal']>;
     },
     db: DrizzleTx,
   ): Promise<{ exceeded: boolean; amountUsed: string; countUsed: number }> {
     const since = new Date(Date.now() - DAILY_CAP_WINDOW_MS);
-    const [row] = await db
+    const rows = await db
       .select({
+        currency: walletTransaction.currency,
         total: sql<string>`coalesce(sum(${walletTransaction.amount}), 0)`,
         n: count(),
       })
@@ -2405,16 +2425,32 @@ export class WalletService {
           eq(walletTransaction.reviewReason, AUTO_APPROVED_REASON),
           gte(walletTransaction.createdAt, since),
         ),
-      );
-    const amountUsed = row?.total ?? '0';
-    const countUsed = Number(row?.n ?? 0);
-    // Cap comparison is a review-queue decision, not a ledger write - moneyToNumber is the
-    // documented single conversion point (see the helper's own doc comment).
+      )
+      .groupBy(walletTransaction.currency);
+    const countUsed = rows.reduce((total, row) => total + Number(row.n), 0);
+    const [pivotAttempt, ...pivotUsed] = await Promise.all([
+      this.toPivotAmount(amount, currency),
+      ...rows.map((row) => this.toPivotAmount(row.total, row.currency)),
+    ]);
+    const isUnpriced = pivotAttempt === null || pivotUsed.some((value) => value === null);
+    const amountUsed = pivotUsed.reduce<string>(
+      (total, value) => moneyAdd(total, value ?? '0'),
+      '0',
+    );
     const amountExceeded =
       cfg.dailyCapAmount !== undefined &&
-      moneyToNumber(amountUsed) + moneyToNumber(amount) > moneyToNumber(cfg.dailyCapAmount);
+      (isUnpriced ||
+        moneyCompare(moneyAdd(amountUsed, pivotAttempt ?? '0'), cfg.dailyCapAmount) > 0);
     const countExceeded = cfg.dailyCapCount !== undefined && countUsed + 1 > cfg.dailyCapCount;
     return { exceeded: amountExceeded || countExceeded, amountUsed, countUsed };
+  }
+
+  private async toPivotAmount(amount: string, currency: string): Promise<string | null> {
+    const pivot = this.platformConfig?.exchangeRate?.pivot ?? DEFAULT_FX_PIVOT;
+    if (currency.toUpperCase() === pivot.toUpperCase()) {
+      return amount;
+    }
+    return this.rates ? this.rates.convert(amount, currency, pivot) : null;
   }
 
   async setAutoWithdrawalRule({

--- a/packages/core/src/wallet/service/wallet.service.ts
+++ b/packages/core/src/wallet/service/wallet.service.ts
@@ -32,6 +32,7 @@ import {
   type RateLimitKey,
   type WalletRail,
   railFor as sharedRailFor,
+  resolveExchangeRatePivot,
   type PlayerTags,
   type RgLimitsPort,
   type ExchangeRateReader,
@@ -567,9 +568,6 @@ function namespacedIdempotencyKey(namespace: string, rawKey: string): string {
 // a display hint there. Revisit with a real risk service if/when one exists.
 const LARGE_WITHDRAWAL_THRESHOLD = '5000';
 
-// The fx module's own fallback when `exchangeRate.pivot` is unset.
-const DEFAULT_FX_PIVOT = 'USD';
-
 // ponytail: >=3 withdrawals in a 24h window flags velocity; a flat count, not a per-tier rule.
 const HIGH_FREQUENCY_WINDOW_MS = 24 * 60 * 60 * 1000;
 const HIGH_FREQUENCY_MIN_COUNT = 3;
@@ -585,16 +583,27 @@ type AutoApprovalDecision = {
   kycStatus: KycStatus;
   riskTagsEvaluated: TagKey[];
   effectiveExcludeTags: TagKey[];
+  // The withdrawal's value in `pivotCurrency`, the unit of `threshold`, the daily amount cap
+  // and `cumulativeAmountUsed`. `amount` and `currency` in the audit row stay the raw request.
+  pivotAmount: string;
+  pivotCurrency: string;
   dailyCapAmount: string | null;
   dailyCapCount: number | null;
-  cumulativeAmountUsed: string;
+  // null when a trailing payout has no stored pivot value, so the total is unknown.
+  cumulativeAmountUsed: string | null;
   cumulativeCountUsed: number;
 };
 
 // The pre-lock portion of the decision, resolvable without the advisory-locked cap read.
 type AutoApprovalGates = Pick<
   AutoApprovalDecision,
-  'threshold' | 'thresholdSource' | 'kycStatus' | 'riskTagsEvaluated' | 'effectiveExcludeTags'
+  | 'threshold'
+  | 'thresholdSource'
+  | 'kycStatus'
+  | 'riskTagsEvaluated'
+  | 'effectiveExcludeTags'
+  | 'pivotAmount'
+  | 'pivotCurrency'
 >;
 
 type DepositAddressResult = {
@@ -1612,11 +1621,13 @@ export class WalletService {
     withdrawalId,
     adminId,
     reviewReason,
+    autoApprovalPivotAmount,
   }: {
     txn: DrizzleTx;
     withdrawalId: WalletTransaction['id'];
     adminId: User['id'] | null;
     reviewReason?: string;
+    autoApprovalPivotAmount?: string;
   }): Promise<WalletTransaction> {
     const current = findOneOrThrow(
       await txn
@@ -1638,6 +1649,7 @@ export class WalletService {
           reviewedBy: adminId,
           reviewedAt: new Date(),
           ...(reviewReason !== undefined ? { reviewReason } : {}),
+          ...(autoApprovalPivotAmount !== undefined ? { autoApprovalPivotAmount } : {}),
         })
         .where(eq(walletTransaction.id, withdrawalId))
         .returning(),
@@ -1830,7 +1842,8 @@ export class WalletService {
     try {
       const cfg = this.platformConfig.autoWithdrawal;
 
-      // Threshold/KYC/risk/velocity gates run outside any lock; only the cap check below needs serializing.
+      // Threshold/KYC/risk/velocity gates and the fx conversion run outside any lock; only the cap check
+      // below needs serializing, and it reads stored pivot values, never the rate reader.
       const gates = await this.evaluateAutoApproval(args);
       if (!gates) {
         return undefined;
@@ -1843,7 +1856,7 @@ export class WalletService {
       const decided = await this.drizzle.db.transaction((txn) =>
         withAdvisoryXactLock(txn, args.userId, async () => {
           const caps = await this.autoApprovalCaps(
-            { walletId: args.walletId, amount: args.amount, currency: args.currency, cfg },
+            { walletId: args.walletId, pivotAmount: gates.pivotAmount, cfg },
             txn,
           );
           if (caps.exceeded) {
@@ -1854,6 +1867,7 @@ export class WalletService {
             withdrawalId: args.transactionId,
             adminId: null,
             reviewReason: AUTO_APPROVED_REASON,
+            autoApprovalPivotAmount: gates.pivotAmount,
           });
           return { tx, caps };
         }),
@@ -1889,7 +1903,13 @@ export class WalletService {
         // with no PSP attempt, so revert to `pending` before rethrowing (held funds are unaffected).
         await this.drizzle.db
           .update(walletTransaction)
-          .set({ status: 'pending', reviewedBy: null, reviewedAt: null, reviewReason: null })
+          .set({
+            status: 'pending',
+            reviewedBy: null,
+            reviewedAt: null,
+            reviewReason: null,
+            autoApprovalPivotAmount: null,
+          })
           .where(eq(walletTransaction.id, args.transactionId));
         throw err;
       }
@@ -1927,7 +1947,8 @@ export class WalletService {
     }
     // One threshold serves every currency on the rail, so it is read in the fx pivot. A raw
     // comparison let 0.4 BTC clear a threshold of 1 that was written with a stablecoin in mind.
-    const pivotAmount = await this.toPivotAmount(amount, currency);
+    const pivotCurrency = resolveExchangeRatePivot(this.platformConfig?.exchangeRate);
+    const pivotAmount = await this.toPivotAmount(amount, currency, pivotCurrency);
     if (pivotAmount === null || moneyCompare(pivotAmount, threshold.value) > 0) {
       return null;
     }
@@ -1960,6 +1981,8 @@ export class WalletService {
       kycStatus,
       riskTagsEvaluated: riskTags,
       effectiveExcludeTags,
+      pivotAmount,
+      pivotCurrency,
     };
   }
 
@@ -2394,28 +2417,28 @@ export class WalletService {
 
   // Sum + count of this wallet's auto-approved payouts in the trailing 24h; `exceeded` when this withdrawal
   // would breach a configured amount or count cap (an unconfigured cap never blocks).
-  // The amount cap is in the fx pivot: the trailing payouts are summed per currency and each
-  // converted, never added raw across currencies. A currency with no rate exceeds the cap.
+  // The amount cap is in the fx pivot and sums the value each payout was approved at, so a rate
+  // move since cannot shrink it and no rate is read under the lock. A trailing payout with no
+  // stored value (approved before the column existed) leaves the total unknown: `amountUsed` is
+  // null and a configured amount cap counts as exceeded.
   private async autoApprovalCaps(
     {
       walletId,
-      amount,
-      currency,
+      pivotAmount,
       cfg,
     }: {
       walletId: Wallet['id'];
-      amount: string;
-      currency: string;
+      pivotAmount: string;
       cfg: NonNullable<PlatformConfig['autoWithdrawal']>;
     },
     db: DrizzleTx,
-  ): Promise<{ exceeded: boolean; amountUsed: string; countUsed: number }> {
+  ): Promise<{ exceeded: boolean; amountUsed: string | null; countUsed: number }> {
     const since = new Date(Date.now() - DAILY_CAP_WINDOW_MS);
-    const rows = await db
+    const [row] = await db
       .select({
-        currency: walletTransaction.currency,
-        total: sql<string>`coalesce(sum(${walletTransaction.amount}), 0)`,
+        total: sql<string>`coalesce(sum(${walletTransaction.autoApprovalPivotAmount}), 0)`,
         n: count(),
+        priced: count(walletTransaction.autoApprovalPivotAmount),
       })
       .from(walletTransaction)
       .where(
@@ -2425,32 +2448,27 @@ export class WalletService {
           eq(walletTransaction.reviewReason, AUTO_APPROVED_REASON),
           gte(walletTransaction.createdAt, since),
         ),
-      )
-      .groupBy(walletTransaction.currency);
-    const countUsed = rows.reduce((total, row) => total + Number(row.n), 0);
-    const [pivotAttempt, ...pivotUsed] = await Promise.all([
-      this.toPivotAmount(amount, currency),
-      ...rows.map((row) => this.toPivotAmount(row.total, row.currency)),
-    ]);
-    const isUnpriced = pivotAttempt === null || pivotUsed.some((value) => value === null);
-    const amountUsed = pivotUsed.reduce<string>(
-      (total, value) => moneyAdd(total, value ?? '0'),
-      '0',
-    );
+      );
+    const countUsed = row?.n ?? 0;
+    const amountUsed = (row?.priced ?? 0) < countUsed ? null : (row?.total ?? '0');
     const amountExceeded =
       cfg.dailyCapAmount !== undefined &&
-      (isUnpriced ||
-        moneyCompare(moneyAdd(amountUsed, pivotAttempt ?? '0'), cfg.dailyCapAmount) > 0);
+      (amountUsed === null ||
+        moneyCompare(moneyAdd(amountUsed, pivotAmount), cfg.dailyCapAmount) > 0);
     const countExceeded = cfg.dailyCapCount !== undefined && countUsed + 1 > cfg.dailyCapCount;
     return { exceeded: amountExceeded || countExceeded, amountUsed, countUsed };
   }
 
-  private async toPivotAmount(amount: string, currency: string): Promise<string | null> {
-    const pivot = this.platformConfig?.exchangeRate?.pivot ?? DEFAULT_FX_PIVOT;
-    if (currency.toUpperCase() === pivot.toUpperCase()) {
+  // A withdrawal already in the pivot needs no rate, so it is valued even without the fx module.
+  private async toPivotAmount(
+    amount: string,
+    currency: string,
+    pivotCurrency: string,
+  ): Promise<string | null> {
+    if (currency.toUpperCase() === pivotCurrency) {
       return amount;
     }
-    return this.rates ? this.rates.convert(amount, currency, pivot) : null;
+    return this.rates ? this.rates.convert(amount, currency, pivotCurrency) : null;
   }
 
   async setAutoWithdrawalRule({


### PR DESCRIPTION
## Summary

Auto-withdrawal thresholds, the daily amount cap and the large-amount heuristic are read in the fx pivot currency (`exchangeRate.pivot`, `USD` by default) through `EXCHANGE_RATE_READER`, and compared exactly instead of with `Number()`. With no rate for the withdrawal's currency, or no fx module loaded, the withdrawal is not auto-approved.

## Why

One `cryptoThreshold` serves every crypto asset but was compared raw against the withdrawal amount, so its meaning depended on the coin: a threshold of `1` written with a stablecoin in mind let `0.4 BTC` auto-approve. The daily amount cap summed trailing payouts across currencies as if they were one unit.

## Alternatives considered

- A threshold per asset. More config for every asset added, and the daily cap would still need a common unit to sum in.

## Risks

- **Behaviour change:** `fiatThreshold`, `cryptoThreshold`, per-player `auto_withdrawal_rule.threshold` and `autoWithdrawal.dailyCapAmount` are pivot amounts. A threshold configured in coin units reads as a tiny pivot amount after upgrade, so withdrawals route to manual review until an operator re-enters it. That is the safe direction, but operators need to know before they upgrade.
- A rate outage stops auto-approval for the affected currency; those withdrawals queue for manual review.
- The review-queue `large_amount` tag still compares the raw amount. It is a display hint, not a decision.
